### PR TITLE
Add CTA button to site menu

### DIFF
--- a/coresite/static/coresite/scss/components/_menu-overlay.scss
+++ b/coresite/static/coresite/scss/components/_menu-overlay.scss
@@ -61,7 +61,7 @@ $overlay-bg: rgba(map-get($colors, blue), 0.9);
       margin-bottom: map-get($space, 4);
     }
 
-    a {
+    a:not(.btn) {
       color: map-get($colors, white);
       text-decoration: none;
       font-size: 1.25rem;

--- a/coresite/templates/coresite/base.html
+++ b/coresite/templates/coresite/base.html
@@ -39,6 +39,7 @@
         <li><a href="/about/">About</a></li>
         <li><a href="/services/">Services</a></li>
         <li><a href="/contact/">Contact</a></li>
+        <li><a class="btn btn--cta" href="#">Join Us</a></li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- add "Join Us" CTA button to site menu overlay
- adjust menu styles to avoid overriding button styling

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a0228730a0832a8f6fb597fd0adfce