### PR TITLE
Add default text for newsletter submit button

### DIFF
--- a/coresite/templates/coresite/partials/newsletter_block.html
+++ b/coresite/templates/coresite/partials/newsletter_block.html
@@ -21,7 +21,7 @@
                    required autocomplete="email" inputmode="email" spellcheck="false"
                    aria-describedby="newsletter-privacy">
             <input type="text" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" hidden>
-            <button type="submit" aria-label="Subscribe to the newsletter" class="btn btn-cta radius-md">{{ APPROVED_CTA }}</button>
+            <button type="submit" aria-label="Subscribe to the newsletter" class="btn btn-cta radius-md">{{ APPROVED_CTA|default:'Subscribe' }}</button>
             <div role="status" aria-live="polite" class="form-message is-{{ m.tags }}">{{ m }}</div>
           </form>
         {% endif %}
@@ -36,7 +36,7 @@
                required autocomplete="email" inputmode="email" spellcheck="false"
                aria-describedby="newsletter-privacy">
         <input type="text" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" hidden>
-        <button type="submit" aria-label="Subscribe to the newsletter" class="btn btn-cta radius-md">{{ APPROVED_CTA }}</button>
+        <button type="submit" aria-label="Subscribe to the newsletter" class="btn btn-cta radius-md">{{ APPROVED_CTA|default:'Subscribe' }}</button>
         <div role="status" aria-live="polite" class="form-message"></div>
       </form>
     {% endif %}


### PR DESCRIPTION
## Summary
- ensure the newsletter signup submit button displays "Subscribe" by default

## Testing
- `npm test` (fails: Missing script "test")
- `python -m pytest`
- `python manage.py test` (fails: Could not import Django)


------
https://chatgpt.com/codex/tasks/task_e_68a6bc0a0c68832aada3f7e95370ea5b