### PR TITLE
Update CTA button class and hover style

### DIFF
--- a/coresite/static/coresite/scss/components/_buttons.scss
+++ b/coresite/static/coresite/scss/components/_buttons.scss
@@ -11,4 +11,12 @@
 .btn--primary { @extend .btn; @extend .btn-primary; }
 
 /* Our CTA = Bootstrap success themed with Technofatty green */
-.btn--cta     { @extend .btn; @extend .btn-success; }
+.btn--cta {
+  @extend .btn;
+  @extend .btn-success;
+
+  &:hover {
+    background-color: $btn-success-hover-bg;
+    color: $btn-success-hover-color;
+  }
+}

--- a/coresite/templates/coresite/partials/newsletter_block.html
+++ b/coresite/templates/coresite/partials/newsletter_block.html
@@ -21,7 +21,7 @@
                    required autocomplete="email" inputmode="email" spellcheck="false"
                    aria-describedby="newsletter-privacy">
             <input type="text" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" hidden>
-            <button type="submit" aria-label="Subscribe to the newsletter" class="btn btn-cta radius-md">{{ APPROVED_CTA|default:'Subscribe' }}</button>
+            <button type="submit" aria-label="Subscribe to the newsletter" class="btn btn--cta radius-md">{{ APPROVED_CTA|default:'Subscribe' }}</button>
             <div role="status" aria-live="polite" class="form-message is-{{ m.tags }}">{{ m }}</div>
           </form>
         {% endif %}
@@ -36,7 +36,7 @@
                required autocomplete="email" inputmode="email" spellcheck="false"
                aria-describedby="newsletter-privacy">
         <input type="text" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" hidden>
-        <button type="submit" aria-label="Subscribe to the newsletter" class="btn btn-cta radius-md">{{ APPROVED_CTA|default:'Subscribe' }}</button>
+        <button type="submit" aria-label="Subscribe to the newsletter" class="btn btn--cta radius-md">{{ APPROVED_CTA|default:'Subscribe' }}</button>
         <div role="status" aria-live="polite" class="form-message"></div>
       </form>
     {% endif %}


### PR DESCRIPTION
## Summary
- use `btn--cta` class for newsletter signup button
- add explicit hover color change for `.btn--cta`

## Testing
- `python manage.py compilescss` *(fails: No module named 'django')*
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a6c1d31704832abd6bff1a0e3aa723