### PR TITLE
fix: hide newsletter messages comment

### DIFF
--- a/coresite/templates/coresite/partials/newsletter_block.html
+++ b/coresite/templates/coresite/partials/newsletter_block.html
@@ -42,7 +42,7 @@
     {% endif %}
 
     <p id="newsletter-privacy">We respect your inbox. Unsubscribe any time. We never sell your email.</p>
-    {#
+    <!--
       Messages:
         success_no_confirm: Thanks — you’re subscribed and will get the next newsletter.
         error: Something went wrong. Please try again.
@@ -50,6 +50,6 @@
       Errors:
         required_email: Please enter your email address to subscribe.
         invalid_email: Enter a valid email address (example: name@example.com).
-    #}
+    -->
   </div>
 </section>


### PR DESCRIPTION
## Summary
- prevent newsletter status copy from appearing on homepage by converting template comment to HTML comment

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a6c417ea24832aadfb05767cf2eeb7