### PR TITLE
Add Signals section with content spec and routing

### DIFF
--- a/coresite/content/signals.json
+++ b/coresite/content/signals.json
@@ -1,0 +1,42 @@
+{
+  "heading_level": "h2",
+  "headline": "Signals",
+  "intro": "Three quick looks at reproducible tech wins.",
+  "cards": [
+    {
+      "slug": "model-tuning",
+      "kicker": "Modeling",
+      "title": "Tuning models boosts accuracy 15%",
+      "problem": "Baseline models plateaued at 70% F1 on noisy data.",
+      "approach": "Iterative hyperparameter search with cross-validation avoided overfitting.",
+      "evidence": "Benchmarks on three datasets lifted F1 to 80% ±0.5 in reproducible tests.",
+      "cta_text": "See method"
+    },
+    {
+      "slug": "cache-warm",
+      "kicker": "Caching",
+      "title": "Prewarming slashes load times",
+      "problem": "Cold starts slowed API responses to 900 ms under load.",
+      "approach": "Introduced staged cache warming and connection pooling on deploy.",
+      "evidence": "Synthetic traffic showed median latency drop to 250 ms.",
+      "cta_text": "View lab note"
+    },
+    {
+      "slug": "risk-sim",
+      "kicker": "Risk",
+      "title": "Simulated stress tests flag weak spots",
+      "problem": "Unclear how system handled burst traffic and partial failures.",
+      "approach": "Ran distributed chaos simulations modeling node loss and spikes.",
+      "evidence": "Results mapped threshold where error rate exceeds 2%.",
+      "cta_text": "Explore scenarios"
+    }
+  ],
+  "tokens": {
+    "color": "gold",
+    "spacing": "s(3)",
+    "radius": "r(md)"
+  },
+  "messages": {
+    "no_cards": "No signals available."
+  }
+}

--- a/coresite/signals.py
+++ b/coresite/signals.py
@@ -1,0 +1,9 @@
+import json
+from pathlib import Path
+
+
+def get_signals_content() -> dict:
+    """Load signals content spec from JSON."""
+    path = Path(__file__).resolve().parent / "content" / "signals.json"
+    with path.open() as f:
+        return json.load(f)

--- a/coresite/static/coresite/scss/main.scss
+++ b/coresite/static/coresite/scss/main.scss
@@ -27,6 +27,7 @@
 @import "sections/hero";
 @import "sections/trust";
 @import "sections/featured";
+@import "sections/signals";
 @import "sections/community";
 @import "sections/newsletter";
 @import "sections/footer";

--- a/coresite/static/coresite/scss/sections/_signals.scss
+++ b/coresite/static/coresite/scss/sections/_signals.scss
@@ -1,0 +1,79 @@
+// coresite/static/coresite/scss/sections/_signals.scss
+// -----------------------------------------------------------------------------
+// Token map:
+// white      → c(white)
+// tech-blue  → c(blue)
+// warm-gold  → c(gold)
+// border     → c(border)
+// radius-sm  → r(sm)
+// radius-md  → r(md)
+// space-1    → s(1)
+// space-2    → s(2)
+// space-3    → s(3)
+// space-6    → s(6)
+// space-7    → s(7)
+// space-8    → s(8)
+// bp.md      → mq(md)
+// bp.lg      → mq(lg)
+// -----------------------------------------------------------------------------
+
+$signals-accent: c(gold); // swap to c(blue) for all-blue scheme
+
+.section--signals {
+  background: c(white);
+  padding-block: s(6);
+  @include mq(md) { padding-block: s(7); }
+  @include mq(lg) { padding-block: s(8); }
+
+  .wrap {
+    @include container;
+    display: flex;
+    flex-direction: column;
+    gap: s(3);
+  }
+
+  .section-title { color: c(blue); }
+
+  .signals__intro { max-width: 45ch; margin: 0; }
+
+  .signals__grid {
+    display: grid;
+    gap: s(3);
+    grid-template-columns: 1fr;
+    @include mq(md) { grid-template-columns: repeat(2, 1fr); }
+    @include mq(lg) { grid-template-columns: repeat(3, 1fr); }
+  }
+
+  .signals__card {
+    background: c(white);
+    border: map-get($border-widths, sm) solid c(border);
+    border-radius: r(md);
+    padding: s(3);
+    display: flex;
+    flex-direction: column;
+    gap: s(3);
+
+    p { margin: 0; max-width: 45ch; }
+    h3 { color: c(blue); margin: 0; }
+
+    .signals__kicker {
+      align-self: flex-start;
+      padding: s(1) s(2);
+      background: $signals-accent;
+      color: c(white);
+      border-radius: r(sm);
+      font-size: fs(xs);
+    }
+
+    .signals__label { font-weight: 600; margin-right: s(1); }
+
+    .signals__cta {
+      @extend .btn;
+      @extend .btn--primary;
+      align-self: flex-start;
+      min-height: s(7);
+      @include focus-ring($signals-accent);
+    }
+  }
+}
+

--- a/coresite/templates/coresite/homepage.html
+++ b/coresite/templates/coresite/homepage.html
@@ -7,6 +7,7 @@
   {% include "coresite/partials/hero.html" %}
   {% include "coresite/partials/trust.html" %}
   {% include "coresite/partials/featured_grid.html" %}
+  {% include "coresite/partials/signals_block.html" %}
   {% include "coresite/partials/newsletter_block.html" %}
   {% include "coresite/partials/community_hook.html" %}
 {% endblock %}

--- a/coresite/templates/coresite/partials/signals_block.html
+++ b/coresite/templates/coresite/partials/signals_block.html
@@ -1,0 +1,25 @@
+<section class="section section--signals" role="region" aria-labelledby="signals-heading" data-section="signals">
+  <div class="wrap">
+    {% with level=signals.heading_level|default:'h2' %}
+      <{{ level }} id="signals-heading" class="section-title">{{ signals.headline }}</{{ level }}>
+    {% endwith %}
+    {% if signals.intro %}
+      <p class="signals__intro">{{ signals.intro }}</p>
+    {% endif %}
+    <div class="signals__grid">
+      {% for card in signals.cards %}
+        <article id="signal-{{ card.slug }}" class="signals__card" data-card="{{ card.slug }}">
+          {% if card.kicker %}<p class="signals__kicker">{{ card.kicker }}</p>{% endif %}
+          {% if card.title %}<h3 class="signals__title">{{ card.title }}</h3>{% endif %}
+          {% if card.problem %}<p class="signals__text"><span class="signals__label">Problem:</span> {{ card.problem }}</p>{% endif %}
+          {% if card.approach %}<p class="signals__text"><span class="signals__label">Approach:</span> {{ card.approach }}</p>{% endif %}
+          {% if card.evidence %}<p class="signals__text"><span class="signals__label">Evidence:</span> {{ card.evidence }}</p>{% endif %}
+          {% if card.cta_text %}
+            <a class="btn btn--primary signals__cta" href="/signals/{{ card.slug }}/">{{ card.cta_text }}</a>
+          {% endif %}
+        </article>
+      {% endfor %}
+    </div>
+    <div class="signals__status" aria-live="polite"></div>
+  </div>
+</section>

--- a/coresite/templates/coresite/signal_placeholder.html
+++ b/coresite/templates/coresite/signal_placeholder.html
@@ -1,0 +1,13 @@
+{% extends "coresite/base.html" %}
+{% block title %}Signal: {{ slug|title }}{% endblock %}
+{% block content %}
+<section class="section">
+  <div class="wrap">
+    <h1>{{ slug|title }}</h1>
+    <p>Full signal coming soon.</p>
+  </div>
+</section>
+{% endblock %}
+{% block footer %}
+  {% include "coresite/partials/footer.html" %}
+{% endblock %}

--- a/coresite/urls.py
+++ b/coresite/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.homepage, name='home'),
+    path('signals/<slug:slug>/', views.signal_detail, name='signal_detail'),
 ]

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -2,15 +2,39 @@ from django.shortcuts import render
 from newsletter.utils import log_newsletter_event
 from .models import SiteImage
 from datetime import datetime
+from .signals import get_signals_content
 
 
 def homepage(request):
     resources = [
-        {"title": "AI for Marketing", "blurb": "Boost campaigns with smarter targeting and automation.", "url": "/resources/marketing/"},
-        {"title": "AI in Operations", "blurb": "Cut waste and streamline workflows with predictive AI.", "url": "/resources/operations/"},
-        {"title": "AI Case Studies", "blurb": "See how real businesses turned AI into growth.", "url": "/case-studies/"},
+        {
+            "title": "AI for Marketing",
+            "blurb": "Boost campaigns with smarter targeting and automation.",
+            "url": "/resources/marketing/",
+        },
+        {
+            "title": "AI in Operations",
+            "blurb": "Cut waste and streamline workflows with predictive AI.",
+            "url": "/resources/operations/",
+        },
+        {
+            "title": "AI Case Studies",
+            "blurb": "See how real businesses turned AI into growth.",
+            "url": "/case-studies/",
+        },
     ]
     images = {img.key.replace("-", "_"): img for img in SiteImage.objects.all()}
-    context = {"site_images": images, "is_homepage": True, "now": datetime.now(), "resources": resources}
+    signals = get_signals_content()
+    context = {
+        "site_images": images,
+        "is_homepage": True,
+        "now": datetime.now(),
+        "resources": resources,
+        "signals": signals,
+    }
     log_newsletter_event(request, "newsletter_block_view")
     return render(request, "coresite/homepage.html", context)
+
+
+def signal_detail(request, slug: str):
+    return render(request, "coresite/signal_placeholder.html", {"slug": slug})


### PR DESCRIPTION
## Summary
- Add reusable Signals block with JSON-driven content and responsive layout
- Style section with tokenized SCSS and accent variable
- Wire up placeholder routes and views for `/signals/<slug>/`
- Reorder homepage sections to keep sequential H2 headings

## Testing
- `python -m py_compile coresite/views.py coresite/urls.py coresite/signals.py`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py runserver 8000` *(fails: ModuleNotFoundError: No module named 'django')*
- `npx --yes sass coresite/static/coresite/scss/main.scss coresite/static/coresite/scss/main.css` *(fails: npm 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c75c0408832a861d14d78e1b11d1