### PR TITLE
Add Support Hub section

### DIFF
--- a/coresite/content/support.json
+++ b/coresite/content/support.json
@@ -1,0 +1,39 @@
+{
+  "heading_level": "h2",
+  "headline": "Support Hub",
+  "intro": "Quick links to help, updates, and how to reach us.",
+  "links": [
+    {
+      "slug": "faq",
+      "label": "FAQ",
+      "description": "Short answers to common questions while we’re in early access.",
+      "url": "/support/faq/"
+    },
+    {
+      "slug": "status",
+      "label": "System status",
+      "description": "Current uptime and any incidents. (Stub during stealth.)",
+      "url": "/support/status/"
+    },
+    {
+      "slug": "contact",
+      "label": "Contact support",
+      "description": "Email us with issues or feedback — we reply fast.",
+      "url": "/contact/"
+    },
+    {
+      "slug": "updates",
+      "label": "Updates",
+      "description": "What’s new, fixed, and improved.",
+      "url": "/support/updates/"
+    }
+  ],
+  "tokens": {
+    "accent": "blue",
+    "spacing": "s(3)",
+    "radius": "r(md)"
+  },
+  "messages": {
+    "empty": "Support resources are coming soon."
+  }
+}

--- a/coresite/static/coresite/scss/main.scss
+++ b/coresite/static/coresite/scss/main.scss
@@ -28,6 +28,7 @@
 @import "sections/trust";
 @import "sections/featured";
 @import "sections/signals";
+@import "sections/support";
 @import "sections/community";
 @import "sections/newsletter";
 @import "sections/footer";

--- a/coresite/static/coresite/scss/sections/_support.scss
+++ b/coresite/static/coresite/scss/sections/_support.scss
@@ -1,0 +1,59 @@
+// coresite/static/coresite/scss/sections/_support.scss
+// -----------------------------------------------------------------------------
+// Token map:
+// white      → c(white)
+// tech-blue  → c(blue)
+// border     → c(border)
+// radius-md  → r(md)
+// space-1    → s(1)
+// space-3    → s(3)
+// space-6    → s(6)
+// space-7    → s(7)
+// space-8    → s(8)
+// bp.md      → mq(md)
+// bp.lg      → mq(lg)
+// -----------------------------------------------------------------------------
+
+.section--support {
+  background: c(white);
+  padding-block: s(6);
+  @include mq(md) { padding-block: s(7); }
+  @include mq(lg) { padding-block: s(8); }
+
+  .wrap {
+    @include container;
+    display: flex;
+    flex-direction: column;
+    gap: s(3);
+  }
+
+  .section-title { color: c(blue); }
+
+  .support__intro { max-width: 60ch; margin: 0; }
+
+  .support__grid {
+    display: grid;
+    gap: s(3);
+    grid-template-columns: 1fr;
+    @include mq(md) { grid-template-columns: repeat(2, 1fr); }
+    @include mq(lg) { grid-template-columns: repeat(3, 1fr); }
+  }
+
+  .support__card {
+    background: c(white);
+    border: map-get($border-widths, sm) solid c(border);
+    border-radius: r(md);
+    padding: s(3);
+    display: flex;
+    flex-direction: column;
+    gap: s(1);
+    min-height: s(7);
+    text-decoration: none;
+    color: inherit;
+    @include focus-ring(c(blue));
+  }
+
+  .support__label { font-weight: 600; margin: 0; }
+  .support__description { margin: 0; max-width: 60ch; }
+  .support__empty { margin: 0; }
+}

--- a/coresite/support.py
+++ b/coresite/support.py
@@ -1,0 +1,9 @@
+import json
+from pathlib import Path
+
+
+def get_support_content() -> dict:
+    """Load support content spec from JSON."""
+    path = Path(__file__).resolve().parent / "content" / "support.json"
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)

--- a/coresite/templates/coresite/homepage.html
+++ b/coresite/templates/coresite/homepage.html
@@ -9,6 +9,7 @@
   {% include "coresite/partials/featured_grid.html" %}
   {% include "coresite/partials/newsletter_block.html" %}
   {% include "coresite/partials/signals_block.html" %}
+  {% include "coresite/partials/support_block.html" %}
   {% include "coresite/partials/community_hook.html" %}
 {% endblock %}
 

--- a/coresite/templates/coresite/partials/support_block.html
+++ b/coresite/templates/coresite/partials/support_block.html
@@ -1,0 +1,23 @@
+<section class="section section--support" role="region" aria-labelledby="support-heading" data-section="support">
+  <div class="wrap">
+    {% with level=support.heading_level|default:'h2' %}
+      <{{ level }} id="support-heading" class="section-title">{{ support.headline }}</{{ level }}>
+    {% endwith %}
+    {% if support.intro %}
+      <p class="support__intro">{{ support.intro }}</p>
+    {% endif %}
+    {% if support.links %}
+      <div class="support__grid">
+        {% for link in support.links %}
+          <a id="support-{{ link.slug }}" class="support__card" href="{{ link.url }}" aria-describedby="support-desc-{{ link.slug }}">
+            <span class="support__label">{{ link.label }}</span>
+            <p id="support-desc-{{ link.slug }}" class="support__description">{{ link.description }}</p>
+          </a>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="support__empty">{{ support.messages.empty }}</p>
+    {% endif %}
+    <div class="support__status" aria-live="polite"></div>
+  </div>
+</section>

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -3,6 +3,7 @@ from newsletter.utils import log_newsletter_event
 from .models import SiteImage
 from datetime import datetime
 from .signals import get_signals_content
+from .support import get_support_content
 
 
 def homepage(request):
@@ -25,12 +26,14 @@ def homepage(request):
     ]
     images = {img.key.replace("-", "_"): img for img in SiteImage.objects.all()}
     signals = get_signals_content()
+    support = get_support_content()
     context = {
         "site_images": images,
         "is_homepage": True,
         "now": datetime.now(),
         "resources": resources,
         "signals": signals,
+        "support": support,
     }
     log_newsletter_event(request, "newsletter_block_view")
     return render(request, "coresite/homepage.html", context)


### PR DESCRIPTION
## Summary
- load Support Hub content from JSON
- render Support Hub links on homepage
- style Support Hub section with design tokens

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68a72dbf806c832abe19790bae4d92c1