### PR TITLE
Add content-driven community block

### DIFF
--- a/coresite/community.py
+++ b/coresite/community.py
@@ -1,0 +1,9 @@
+import json
+from pathlib import Path
+
+
+def get_community_content() -> dict:
+    """Load community content spec from JSON."""
+    path = Path(__file__).resolve().parent / "content" / "community.json"
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)

--- a/coresite/content/community.json
+++ b/coresite/content/community.json
@@ -1,0 +1,31 @@
+{
+  "heading_level": "h2",
+  "headline": "Join the Community",
+  "intro": "Get updates, tools, and early access while we’re building.",
+  "primary_cta": {
+    "label": "Join Us",
+    "url": "/community/join/"
+  },
+  "secondary_links": [
+    {
+      "slug": "newsletter",
+      "label": "Newsletter",
+      "description": "Short, useful AI tips every Friday.",
+      "url": "#signup"
+    },
+    {
+      "slug": "updates",
+      "label": "Product updates",
+      "description": "What’s new, fixed, and improved.",
+      "url": "/support/updates/"
+    }
+  ],
+  "tokens": {
+    "accent": "blue",
+    "radius": "r(md)",
+    "spacing": "s(3)"
+  },
+  "messages": {
+    "empty": "Community links will appear here."
+  }
+}

--- a/coresite/static/coresite/scss/sections/_community.scss
+++ b/coresite/static/coresite/scss/sections/_community.scss
@@ -1,12 +1,56 @@
-/* Community hook (CTA + image) */
-.community{ padding:s(8) s(6); }
-.community__inner{ @extend .split; align-items:center; }
+// coresite/static/coresite/scss/sections/_community.scss
+// Tokens used: c(white), c(blue), c(border), r(md), s(1), s(3), s(6..8), mq(md|lg)
 
-.community__copy h2{ color:c(blue); margin:0 0 .5rem; }
-.community__copy p{ margin:0 0 s(4); }
+.section--community {
+  background: c(white);
+  padding-block: s(6);
+  @include mq(md) { padding-block: s(7); }
+  @include mq(lg) { padding-block: s(8); }
 
-.community__img{
-  /* When adding real image, ensure descriptive alt text or empty alt if decorative */
-  width:100%; @include ratio(16,9); border-radius:r(sm);
-  /* swap to <img> later; keep space with placeholder until assets arrive */
+  .wrap {
+    @include container;
+    display: flex;
+    flex-direction: column;
+    gap: s(3);
+  }
+
+  .section-title { color: c(blue); }
+  .community__intro { margin: 0; max-width: 60ch; }
+
+  .community__actions {
+    display: flex;
+    gap: s(3);
+  }
+
+  .community__cta {
+    @extend .btn;
+    @extend .btn--cta;
+    border-radius: r(md);
+    min-height: s(7);
+    @include focus-ring(c(blue));
+  }
+
+  .community__grid {
+    display: grid;
+    gap: s(3);
+    grid-template-columns: 1fr;
+    @include mq(md) { grid-template-columns: repeat(2, 1fr); }
+    @include mq(lg) { grid-template-columns: repeat(3, 1fr); }
+  }
+
+  .community__card {
+    background: c(white);
+    border: map-get($border-widths, sm) solid c(border);
+    border-radius: r(md);
+    padding: s(3);
+    text-decoration: none;
+    color: inherit;
+    display: flex;
+    flex-direction: column;
+    gap: s(1);
+    @include focus-ring(c(blue));
+  }
+
+  .community__label { font-weight: 600; margin: 0; }
+  .community__description, .community__empty { margin: 0; max-width: 60ch; }
 }

--- a/coresite/templates/coresite/community_join.html
+++ b/coresite/templates/coresite/community_join.html
@@ -1,0 +1,37 @@
+{% extends "coresite/base.html" %}
+{% load static %}
+{% block title %}Join the Technofatty Community{% endblock %}
+{% block meta_description %}Join the Technofatty community for updates, tools, and early access while we’re building.{% endblock %}
+
+{% block content %}
+<section class="section" role="region" aria-labelledby="community-join-heading" data-section="community-join">
+  <div class="wrap">
+    <h1 id="community-join-heading">Join the Community</h1>
+    <p>We’re building in stealth. Here are the best ways to plug in right now.</p>
+
+    <div class="cards" style="margin-top: var(--space-3);">
+      <article class="card">
+        <h2 class="card__title">Newsletter</h2>
+        <p class="card__blurb">Short, useful AI tips every Friday. No fluff.</p>
+        <a class="card__link" href="/#signup">Subscribe</a>
+      </article>
+
+      <article class="card">
+        <h2 class="card__title">Product updates</h2>
+        <p class="card__blurb">What’s new, fixed, and improved as we ship.</p>
+        <a class="card__link" href="/support/updates/">View updates</a>
+      </article>
+
+      <article class="card">
+        <h2 class="card__title">Say hello</h2>
+        <p class="card__blurb">Got feedback or want to collaborate? We’re listening.</p>
+        <a class="card__link" href="/contact/">Contact us</a>
+      </article>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block footer %}
+  {% include "coresite/partials/footer.html" %}
+{% endblock %}

--- a/coresite/templates/coresite/homepage.html
+++ b/coresite/templates/coresite/homepage.html
@@ -10,7 +10,7 @@
   {% include "coresite/partials/newsletter_block.html" %}
   {% include "coresite/partials/signals_block.html" %}
   {% include "coresite/partials/support_block.html" %}
-  {% include "coresite/partials/community_hook.html" %}
+  {% include "coresite/partials/community_block.html" %}
 {% endblock %}
 
 {% block footer %}

--- a/coresite/templates/coresite/partials/community_block.html
+++ b/coresite/templates/coresite/partials/community_block.html
@@ -1,0 +1,32 @@
+<section class="section section--community" role="region" aria-labelledby="community-heading" data-section="community">
+  <div class="wrap">
+    {% with level=community.heading_level|default:'h2' %}
+      <{{ level }} id="community-heading" class="section-title">{{ community.headline }}</{{ level }}>
+    {% endwith %}
+
+    {% if community.intro %}
+      <p class="community__intro">{{ community.intro }}</p>
+    {% endif %}
+
+    <div class="community__actions">
+      {% if community.primary_cta %}
+        <a class="btn btn--cta community__cta" href="{{ community.primary_cta.url }}">{{ community.primary_cta.label }}</a>
+      {% endif %}
+    </div>
+
+    {% if community.secondary_links %}
+      <div class="community__grid">
+        {% for link in community.secondary_links %}
+          <a id="community-{{ link.slug }}" class="community__card" href="{{ link.url }}" aria-describedby="community-desc-{{ link.slug }}">
+            <span class="community__label">{{ link.label }}</span>
+            <p id="community-desc-{{ link.slug }}" class="community__description">{{ link.description }}</p>
+          </a>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="community__empty">{{ community.messages.empty }}</p>
+    {% endif %}
+
+    <div class="community__status" aria-live="polite"></div>
+  </div>
+</section>

--- a/coresite/templates/coresite/partials/community_hook.html
+++ b/coresite/templates/coresite/partials/community_hook.html
@@ -1,6 +1,0 @@
-<section class="community" aria-labelledby="community-heading">
-  <h2 id="community-heading" class="section-title">Join the Community</h2>
-  <p>Get updates, tools, and early access.</p>
-  <a class="btn btn-cta" href="#">Join Us</a>
-  <div class="community__img" role="img" aria-label="Community image placeholder"></div>
-</section>

--- a/coresite/urls.py
+++ b/coresite/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [
     path('', views.homepage, name='home'),
     path('signals/<slug:slug>/', views.signal_detail, name='signal_detail'),
+    path('community/join/', views.community_join, name='community_join'),
 ]

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -4,6 +4,7 @@ from .models import SiteImage
 from datetime import datetime
 from .signals import get_signals_content
 from .support import get_support_content
+from .community import get_community_content
 
 
 def homepage(request):
@@ -27,6 +28,7 @@ def homepage(request):
     images = {img.key.replace("-", "_"): img for img in SiteImage.objects.all()}
     signals = get_signals_content()
     support = get_support_content()
+    community = get_community_content()
     context = {
         "site_images": images,
         "is_homepage": True,
@@ -34,6 +36,7 @@ def homepage(request):
         "resources": resources,
         "signals": signals,
         "support": support,
+        "community": community,
     }
     log_newsletter_event(request, "newsletter_block_view")
     return render(request, "coresite/homepage.html", context)
@@ -41,3 +44,11 @@ def homepage(request):
 
 def signal_detail(request, slug: str):
     return render(request, "coresite/signal_placeholder.html", {"slug": slug})
+
+
+def community_join(request):
+    """
+    Lightweight landing stub for the Community primary CTA.
+    Keeps everything server-rendered and accessible. No JS dependence.
+    """
+    return render(request, "coresite/community_join.html", {})


### PR DESCRIPTION
## Summary
- add JSON-backed community content and loader
- render community block partial and styles
- wire community data into homepage view and template
- stub out server-rendered community join page for primary CTA

## Testing
- `python manage.py test` *(fails: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68a737819b7c832ab9e1b96597fa5132