### PR TITLE
Add semantic, token-driven footer

### DIFF
--- a/coresite/content/footer.json
+++ b/coresite/content/footer.json
@@ -1,0 +1,27 @@
+{
+  "heading_level": "h2",
+  "headline": "Technofatty",
+  "intro": "Modern tech resources—fast, accessible, and community-driven.",
+  "link_groups": [
+    {
+      "label": "Explore",
+      "links": [
+        {"label": "About", "url": "/about/"},
+        {"label": "Resources", "url": "/resources/"},
+        {"label": "Contact", "url": "/contact/"}
+      ]
+    },
+    {
+      "label": "Company",
+      "links": [
+        {"label": "Privacy", "url": "/legal/privacy/"},
+        {"label": "Terms", "url": "/legal/terms/"}
+      ]
+    }
+  ],
+  "meta": {
+    "copyright": "© {{year}} Technofatty",
+    "made_in": "Built in Scotland.",
+    "email": "hello@technofatty.com"
+  }
+}

--- a/coresite/footer.py
+++ b/coresite/footer.py
@@ -1,0 +1,33 @@
+"""Footer content loader."""
+
+import json
+from datetime import datetime
+from functools import lru_cache
+from pathlib import Path
+from copy import deepcopy
+
+
+@lru_cache(maxsize=1)
+def _load_footer_json() -> dict:
+    """Load footer JSON from disk once per process."""
+    path = Path(__file__).resolve().parent / "content" / "footer.json"
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_footer_content() -> dict:
+    """Return footer content with current year injected.
+
+    The JSON is cached in-process to avoid disk I/O on each request. Each call
+    injects the current year so the rendered copyright stays fresh.
+    """
+
+    content = deepcopy(_load_footer_json())
+
+    year = str(datetime.now().year)
+    meta = content.get("meta", {})
+    copyright = meta.get("copyright")
+    if copyright:
+        meta["copyright"] = copyright.replace("{{year}}", year)
+
+    return content

--- a/coresite/static/coresite/scss/sections/_footer.scss
+++ b/coresite/static/coresite/scss/sections/_footer.scss
@@ -1,12 +1,79 @@
-/* Brand footer */
-.footer{ background:c(blue); color:#fff; padding:s(6); }
-.footer__inner{ @include container; display:flex; flex-direction:column; gap:s(4);
-  @include mq(md){ flex-direction:row; justify-content:space-between; align-items:flex-start; }
+// coresite/static/coresite/scss/sections/_footer.scss
+// Tokens used: c(white), c(text), c(blue), c(border), s(1), s(2), s(3), s(4), s(6), s(7), s(8), r(sm), mq(md|lg), fs(sm)
+
+.footer {
+  background: c(white);
+  color: c(text);
+  padding-block: s(6);
+  @include mq(md) { padding-block: s(7); }
+  @include mq(lg) { padding-block: s(8); }
+
+  nav .wrap {
+    @include container;
+    display: flex;
+    flex-direction: column;
+    gap: s(4);
+  }
+
+  .footer__headline { color: c(blue); margin: 0; }
+  .footer__intro { margin: 0; max-width: 60ch; }
+
+  .footer__groups {
+    display: grid;
+    gap: s(4);
+    grid-template-columns: 1fr;
+    @include mq(md) { grid-template-columns: repeat(2, 1fr); }
+    @include mq(lg) { grid-template-columns: repeat(3, 1fr); }
+  }
+
+  .footer__group {
+    display: flex;
+    flex-direction: column;
+    gap: s(2);
+  }
+
+  .footer__group-label {
+    margin: 0;
+    font-weight: 600;
+    color: c(blue);
+  }
+
+  .footer__links {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: s(1);
+  }
+
+  .footer__links a {
+    display: inline-block;
+    padding: s(2);
+    min-height: s(7);
+    color: inherit;
+    text-decoration: none;
+    border-radius: r(sm);
+    @include focus-ring(c(blue));
+  }
+
+  .footer__meta {
+    border-top: map-get($border-widths, sm) solid c(border);
+    margin-top: s(6);
+    padding-top: s(4);
+    font-size: fs(sm);
+
+    .wrap {
+      @include container;
+      display: flex;
+      flex-direction: column;
+      gap: s(1);
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+      @include focus-ring(c(blue));
+    }
+  }
 }
-.footer__links{ display:flex; flex-wrap:wrap; gap:s(4); list-style:none; margin:0; padding:0; }
-.footer__links a{
-  @include focus-ring(c(gold));
-  color:#fff; text-decoration:none; padding:.125rem .25rem; border-radius:.25rem;
-  &:hover,&:focus{ color:#000; background:c(gold); }
-}
-.footer__meta{ opacity:.85; font-size:.875rem; }

--- a/coresite/templates/coresite/base.html
+++ b/coresite/templates/coresite/base.html
@@ -64,9 +64,7 @@
     {% block content %}{% endblock %}
   </main>
 
-  <footer class="site-footer">
-    {% block footer %}{% endblock %}
-  </footer>
+  {% block footer %}{% endblock %}
 
   <script src="{% static 'coresite/js/main.js' %}?v={{ now|date:'U' }}" defer></script>
   {% block body_scripts %}{% endblock %}

--- a/coresite/templates/coresite/partials/footer.html
+++ b/coresite/templates/coresite/partials/footer.html
@@ -1,7 +1,45 @@
+{% if footer %}
+<footer class="footer">
   <nav aria-label="Footer">
-    <ul class="footer__links">
-      <li><a href="/about/">About</a></li>
-      <li><a href="/resources/">Resources</a></li>
-      <li><a href="/contact/">Contact</a></li>
-    </ul>
+    <div class="wrap">
+      {% if footer.headline %}
+        {% with tag=footer.heading_level|default:'h2' %}
+          <{{ tag }} class="footer__headline">{{ footer.headline }}</{{ tag }}>
+        {% endwith %}
+      {% endif %}
+      {% if footer.intro %}
+        <p class="footer__intro">{{ footer.intro }}</p>
+      {% endif %}
+      {% if footer.link_groups %}
+        <div class="footer__groups">
+          {% for group in footer.link_groups %}
+            {% if group.links %}
+              <div class="footer__group">
+                {% if group.label %}<p class="footer__group-label">{{ group.label }}</p>{% endif %}
+                <ul class="footer__links">
+                  {% for link in group.links %}
+                    <li><a href="{{ link.url }}"
+                           data-analytics-event="footer_link_click"
+                           data-analytics-group="{{ group.label }}"
+                           data-analytics-label="{{ link.label }}"
+                           data-analytics-url="{{ link.url }}">{{ link.label }}</a></li>
+                  {% endfor %}
+                </ul>
+              </div>
+            {% endif %}
+          {% endfor %}
+        </div>
+      {% endif %}
+    </div>
   </nav>
+  {% if footer.meta %}
+    <div class="footer__meta">
+      <div class="wrap">
+        {% if footer.meta.copyright %}<p>{{ footer.meta.copyright }}</p>{% endif %}
+        {% if footer.meta.made_in %}<p>{{ footer.meta.made_in }}</p>{% endif %}
+        {% if footer.meta.email %}<p><a href="mailto:{{ footer.meta.email }}">{{ footer.meta.email }}</a></p>{% endif %}
+      </div>
+    </div>
+  {% endif %}
+</footer>
+{% endif %}

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from .signals import get_signals_content
 from .support import get_support_content
 from .community import get_community_content
+from .footer import get_footer_content
 
 
 def homepage(request):
@@ -29,6 +30,7 @@ def homepage(request):
     signals = get_signals_content()
     support = get_support_content()
     community = get_community_content()
+    footer = get_footer_content()
     context = {
         "site_images": images,
         "is_homepage": True,
@@ -37,13 +39,19 @@ def homepage(request):
         "signals": signals,
         "support": support,
         "community": community,
+        "footer": footer,
     }
     log_newsletter_event(request, "newsletter_block_view")
     return render(request, "coresite/homepage.html", context)
 
 
 def signal_detail(request, slug: str):
-    return render(request, "coresite/signal_placeholder.html", {"slug": slug})
+    footer = get_footer_content()
+    return render(
+        request,
+        "coresite/signal_placeholder.html",
+        {"slug": slug, "footer": footer},
+    )
 
 
 def community_join(request):
@@ -51,4 +59,5 @@ def community_join(request):
     Lightweight landing stub for the Community primary CTA.
     Keeps everything server-rendered and accessible. No JS dependence.
     """
-    return render(request, "coresite/community_join.html", {})
+    footer = get_footer_content()
+    return render(request, "coresite/community_join.html", {"footer": footer})


### PR DESCRIPTION
## Summary
- Add JSON-driven footer content spec and loader with automatic year injection
- Replace footer partial with semantic `<footer>` and token-based styles
- Pass footer context through views and clean up base template wrapper
- Memoize footer content to avoid repeated disk reads and inject analytics placeholders for future tracking

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*
- `python manage.py collectstatic --noinput` *(fails: ModuleNotFoundError: No module named 'django')*
- `python -m py_compile coresite/footer.py coresite/views.py`


------
https://chatgpt.com/codex/tasks/task_e_68a73f754c38832abd91315fc475221c