### PR TITLE
style: refine footer layout and spacing

### DIFF
--- a/coresite/static/coresite/scss/sections/_footer.scss
+++ b/coresite/static/coresite/scss/sections/_footer.scss
@@ -4,6 +4,7 @@
 .footer {
   background: c(white);
   color: c(text);
+  border-top: map-get($border-widths, sm) solid c(border);
   padding-block: s(6);
   @include mq(md) { padding-block: s(7); }
   @include mq(lg) { padding-block: s(8); }
@@ -48,9 +49,6 @@
   }
 
   .footer__links a {
-    display: inline-block;
-    padding: s(2);
-    min-height: s(7);
     color: inherit;
     text-decoration: none;
     border-radius: r(sm);
@@ -58,16 +56,24 @@
   }
 
   .footer__meta {
-    border-top: map-get($border-widths, sm) solid c(border);
     margin-top: s(6);
     padding-top: s(4);
     font-size: fs(sm);
+
+    p { margin: 0; }
 
     .wrap {
       @include container;
       display: flex;
       flex-direction: column;
       gap: s(1);
+
+      @include mq(md) {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        gap: s(2);
+      }
     }
 
     a {


### PR DESCRIPTION
## Summary
- add single top border on footer and remove duplicate meta border
- simplify footer link styling to focus ring only
- align footer meta content horizontally at md+ breakpoints and remove default paragraph margins

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a74aea0b10832ab76cd7b36a5725db