### PR TITLE
style: refine footer layout and spacing

### DIFF
--- a/coresite/static/coresite/scss/sections/_footer.scss
+++ b/coresite/static/coresite/scss/sections/_footer.scss
@@ -4,6 +4,7 @@
 .footer {
   background: c(white);
   color: c(text);
+  border-top: map-get($border-widths, sm) solid c(border);
   padding-block: s(6);
   @include mq(md) { padding-block: s(7); }
   @include mq(lg) { padding-block: s(8); }
@@ -45,35 +46,48 @@
     display: flex;
     flex-direction: column;
     gap: s(1);
-  }
 
-  .footer__links a {
-    display: inline-block;
-    padding: s(2);
-    min-height: s(7);
-    color: inherit;
-    text-decoration: none;
-    border-radius: r(sm);
-    @include focus-ring(c(blue));
+    a {
+      display: inline;
+      color: inherit;
+      text-decoration: none;
+      border-radius: r(sm);
+      line-height: 1.35;
+      @include focus-ring(c(blue));
+
+      &:hover { text-decoration: underline; }
+    }
   }
 
   .footer__meta {
-    border-top: map-get($border-widths, sm) solid c(border);
     margin-top: s(6);
     padding-top: s(4);
     font-size: fs(sm);
+
+    p { margin: 0; }
 
     .wrap {
       @include container;
       display: flex;
       flex-direction: column;
       gap: s(1);
+
+      @include mq(md) {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        gap: s(2);
+        flex-wrap: wrap;
+      }
     }
 
     a {
       color: inherit;
       text-decoration: none;
+      white-space: nowrap;
       @include focus-ring(c(blue));
+
+      &:hover { text-decoration: underline; }
     }
   }
 }


### PR DESCRIPTION
## Summary
- tighten footer link spacing with inline display, compact line height, and hover underline
- allow meta row to wrap while keeping email unbroken and aligning items across larger screens

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68a74aea0b10832ab76cd7b36a5725db