### PR TITLE
Standardize homepage container widths

### DIFF
--- a/coresite/static/coresite/scss/components/_desktop-nav.scss
+++ b/coresite/static/coresite/scss/components/_desktop-nav.scss
@@ -1,8 +1,10 @@
+
 .desktop-nav {
   display: none;
   align-items: center;
   justify-content: space-between;
-  padding: map-get($space, 1) map-get($space, 6);
+  @include container;
+  padding-block: map-get($space, 1);
 
   @include mq(sm) {
     display: flex;

--- a/coresite/static/coresite/scss/sections/_featured.scss
+++ b/coresite/static/coresite/scss/sections/_featured.scss
@@ -2,7 +2,6 @@
 
 .featured {
   position: relative;
-  padding: 0 2rem;
   background: #fff;
   overflow: hidden;
 

--- a/coresite/static/coresite/scss/sections/_trust.scss
+++ b/coresite/static/coresite/scss/sections/_trust.scss
@@ -1,6 +1,7 @@
 /* Three-up trust points */
+
 .trust {
-  padding: s(8) s(6);
+  padding-block: s(8);
 }
 
 /* Reduce top padding when following the hero on the homepage */

--- a/coresite/templates/coresite/partials/featured_grid.html
+++ b/coresite/templates/coresite/partials/featured_grid.html
@@ -1,17 +1,19 @@
 {% load static %}
 
 <section id="featured" class="featured" aria-labelledby="featured-heading">
-  <h2 id="featured-heading" class="section-title">Featured Resources</h2>
+  <div class="wrap">
+    <h2 id="featured-heading" class="section-title">Featured Resources</h2>
 
-<div class="cards">
-  {% for resource in resources %}
-    <article class="card">
-      <div class="card__img" role="img" aria-label="{{ resource.image_alt|default:'Resource image' }}"></div>
-      <h3 class="card__title">{{ resource.title }}</h3>
-      <p class="card__blurb">{{ resource.blurb }}</p>
-      <a class="card__link" href="{{ resource.url }}">Read more</a>
-    </article>
-  {% endfor %}
-</div>
+    <div class="cards">
+      {% for resource in resources %}
+        <article class="card">
+          <div class="card__img" role="img" aria-label="{{ resource.image_alt|default:'Resource image' }}"></div>
+          <h3 class="card__title">{{ resource.title }}</h3>
+          <p class="card__blurb">{{ resource.blurb }}</p>
+          <a class="card__link" href="{{ resource.url }}">Read more</a>
+        </article>
+      {% endfor %}
+    </div>
+  </div>
 
 </section>

--- a/coresite/templates/coresite/partials/trust.html
+++ b/coresite/templates/coresite/partials/trust.html
@@ -1,9 +1,10 @@
 {% load static %}
 
 <section class="trust" aria-labelledby="trust-heading">
-  <!-- Reusable SVG gradient definition -->
+  <div class="wrap">
+    <!-- Reusable SVG gradient definition -->
 
-  <h2 id="trust-heading" class="section-title">Your AI Advantage Starts Here</h2>
+    <h2 id="trust-heading" class="section-title">Your AI Advantage Starts Here</h2>
   
   <p class="trust__intro">
     AI that works the late shift, crunches the numbers, and never needs coffee. Save time, cut costs, and act faster than your competitors.
@@ -69,8 +70,9 @@
     </li>
   </ul>
 
-  <div class="trust__cta">
-    <p id="cta-context">See how we've helped businesses like yours transform their operations.</p>
-    <a href="/case-studies/" class="btn btn-secondary" aria-describedby="cta-context">See How It Works</a>
+    <div class="trust__cta">
+      <p id="cta-context">See how we've helped businesses like yours transform their operations.</p>
+      <a href="/case-studies/" class="btn btn-secondary" aria-describedby="cta-context">See How It Works</a>
+    </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Wrap homepage trust and featured sections in the shared `wrap` container for consistent content alignment
- Use container mixin in desktop navigation and remove extra padding from trust and featured styles

## Testing
- ⚠️ `python manage.py test` *(missing Django)*

------
https://chatgpt.com/codex/tasks/task_e_68a763b16db0832ab38c2cb1323a1694