### PR TITLE
feat: widen card sections and add background bands

### DIFF
--- a/coresite/static/coresite/scss/abstracts/_variables.scss
+++ b/coresite/static/coresite/scss/abstracts/_variables.scss
@@ -14,11 +14,14 @@ $colors: (
   ph:      #D5EDF2,  // placeholder blocks for images
   text:    #333333,
   border:  #DDDDDD,  // neutral border color
-  black:   #000000
+  black:   #000000,
+  bg-alt:  #F9FAFB,  // pale background bands
+  bg-accent-light: #F5FBFF  // light accent backgrounds
 );
 
 /* Layout width */
 $container-max: 68rem; // ≈1088px target content width
+$container-max-width-wide: 90rem; // ≈1440px wide container
 
 /* Spacing scale (t-shirt friendly) */
 $space: (
@@ -118,6 +121,7 @@ $dur: 200ms;
   }
 
   --container-max: #{$container-max};
+  --container-max-width-wide: #{$container-max-width-wide};
 
   // Radii
   @each $name, $value in $radii {

--- a/coresite/static/coresite/scss/base/_utilities.scss
+++ b/coresite/static/coresite/scss/base/_utilities.scss
@@ -1,4 +1,8 @@
 .container { @include container; }
+.container-wide {
+  @include container;
+  max-width: $container-max-width-wide;
+}
 .skip-link { @include sr-only; }
 .skip-link:focus {
   position: fixed; left: 8px; top: 8px;

--- a/coresite/static/coresite/scss/sections/_newsletter.scss
+++ b/coresite/static/coresite/scss/sections/_newsletter.scss
@@ -24,8 +24,8 @@
   @include focus-ring(c(gold));
 }
 
-#signup.section--newsletter {
-  background: c(white);
+.newsletter-band {
+  background: c(bg-accent-light);
   padding-block: s(6);
   @include mq(md) { padding-block: s(7); }
   @include mq(lg) { padding-block: s(8); }
@@ -84,7 +84,7 @@
 }
 
 // Optional decorative motif
-// .section--newsletter.has-motif {
+// .newsletter-band.has-motif {
 //   position: relative;
 //   &::before {
 //     content: '';
@@ -99,7 +99,7 @@
 /* Checklist:
 - no hex or pixel literals; only design tokens and mixins.
 - input and button use focus-ring mixin and min-height s(7) for ≥44px tap targets.
-- white section background with c(white); heading uses c(blue); CTA uses existing .btn-cta.
+ - light accent background with c(bg-accent-light); heading uses c(blue); CTA uses existing .btn-cta.
 - inner spacing uses s(6) padding and s(3) gaps.
 - layout remains single column at all widths; tested ~360–400px.
 - this partial is imported in main.scss under Sections.

--- a/coresite/static/coresite/scss/sections/_signals.scss
+++ b/coresite/static/coresite/scss/sections/_signals.scss
@@ -25,8 +25,7 @@ $signals-accent: c(gold); // swap to c(blue) for all-blue scheme
   @include mq(md) { padding-block: s(7); }
   @include mq(lg) { padding-block: s(8); }
 
-  .wrap {
-    @include container;
+  .container-wide {
     display: flex;
     flex-direction: column;
     gap: s(3);

--- a/coresite/static/coresite/scss/sections/_trust.scss
+++ b/coresite/static/coresite/scss/sections/_trust.scss
@@ -52,16 +52,14 @@
   margin: 0;
 }
 
-.trust__cta {
+.cta-band {
+  background: c(bg-alt);
+  padding-block: s(7);
   text-align: center;
-  margin-top: s(8);
-  padding-top: s(6);
-  border-top: 1px solid rgba(c(blue), 0.2);
 
   p {
-    max-width: 45ch; // Improve readability
-    margin-inline: auto;
-    margin-bottom: s(4);
+    max-width: 45ch;
+    margin: 0 auto s(4);
   }
 }
 

--- a/coresite/templates/coresite/partials/featured_grid.html
+++ b/coresite/templates/coresite/partials/featured_grid.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 <section id="featured" class="featured" aria-labelledby="featured-heading">
-  <div class="wrap">
+  <div class="container-wide">
     <h2 id="featured-heading" class="section-title">Featured Resources</h2>
 
     <div class="cards">

--- a/coresite/templates/coresite/partials/newsletter_block.html
+++ b/coresite/templates/coresite/partials/newsletter_block.html
@@ -1,6 +1,6 @@
 <!-- TODO: Stakeholder decision: headline_scope (music) -->
 <section id="signup"
-         class="section section--newsletter newsletter-block surface radius-md space-3"
+         class="newsletter-band"
          role="region"
          aria-labelledby="newsletter-heading"
          data-section="newsletter"

--- a/coresite/templates/coresite/partials/signals_block.html
+++ b/coresite/templates/coresite/partials/signals_block.html
@@ -1,5 +1,5 @@
 <section class="section section--signals" role="region" aria-labelledby="signals-heading" data-section="signals">
-  <div class="wrap">
+  <div class="container-wide">
     {% with level=signals.heading_level|default:'h2' %}
       <{{ level }} id="signals-heading" class="section-title">{{ signals.headline }}</{{ level }}>
     {% endwith %}

--- a/coresite/templates/coresite/partials/trust.html
+++ b/coresite/templates/coresite/partials/trust.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 <section class="trust" aria-labelledby="trust-heading">
-  <div class="wrap">
+  <div class="container-wide">
     <!-- Reusable SVG gradient definition -->
 
     <h2 id="trust-heading" class="section-title">Your AI Advantage Starts Here</h2>
@@ -69,10 +69,12 @@
       <p class="trust__copy">Spot trends, fix problems, and act faster than your competitors — all on autopilot.</p>
     </li>
   </ul>
+  </div>
+</section>
 
-    <div class="trust__cta">
-      <p id="cta-context">See how we've helped businesses like yours transform their operations.</p>
-      <a href="/case-studies/" class="btn btn-secondary" aria-describedby="cta-context">See How It Works</a>
-    </div>
+<section class="cta-band" aria-labelledby="cta-context">
+  <div class="wrap">
+    <p id="cta-context">See how we've helped businesses like yours transform their operations.</p>
+    <a href="/case-studies/" class="btn btn-secondary" aria-describedby="cta-context">See How It Works</a>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- add wide container utility and design tokens for full-bleed bands
- widen feature, resources, and signals grids and add CTA band
- wrap newsletter signup in pale accent band

## Testing
- `python -m pytest`
- `npm test` *(fails: Missing script "test")*
- `python manage.py test` *(fails: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68a76953af60832abbd1ab9391b675d2