### PR TITLE
Align navigation CTA and improve homepage accessibility

### DIFF
--- a/coresite/static/coresite/js/main.js
+++ b/coresite/static/coresite/js/main.js
@@ -44,6 +44,14 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
+  const newsletterForm = document.getElementById('newsletter_form');
+  if (newsletterForm) {
+    newsletterForm.addEventListener('submit', function () {
+      newsletterForm.classList.add('is-busy');
+      newsletterForm.setAttribute('aria-busy', 'true');
+    }, { once: true });
+  }
+
   // Sticky Header with Opacity Transition
   const header = document.querySelector('.site-header');
   const scrollThresholdForFullOpacity = 200; // Scroll distance in pixels for full opacity

--- a/coresite/static/coresite/scss/sections/_footer.scss
+++ b/coresite/static/coresite/scss/sections/_footer.scss
@@ -56,6 +56,10 @@
       @include focus-ring(c(blue));
 
       &:hover { text-decoration: underline; }
+      &:focus-visible {
+        outline: 2px solid c(blue);
+        outline-offset: 2px;
+      }
     }
   }
 

--- a/coresite/static/coresite/scss/sections/_newsletter.scss
+++ b/coresite/static/coresite/scss/sections/_newsletter.scss
@@ -47,17 +47,28 @@
     gap: s(3);
     width: 100%;
 
-    label { margin-bottom: 0; }
+    fieldset {
+      border: 0;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: s(3);
 
-    input[type="email"] {
-      @extend %form-control-shared;
-      padding-inline: s(3);
-    }
+      label { margin-bottom: 0; }
 
-    .btn {
-      @extend %form-control-shared;
-      // CTA inherits .btn-cta (tech-blue)
-      // TODO: swap to warm-gold if design updates
+      input[type="email"] {
+        @extend %form-control-shared;
+        padding-inline: s(3);
+      }
+
+      .btn {
+        @extend %form-control-shared;
+        // CTA inherits .btn-cta (tech-blue)
+        // TODO: swap to warm-gold if design updates
+      }
+
+      .form-message { min-height: 1em; }
     }
 
     &.is-error {
@@ -103,5 +114,5 @@
 - inner spacing uses s(6) padding and s(3) gaps.
 - layout remains single column at all widths; tested ~360–400px.
 - this partial is imported in main.scss under Sections.
-- no HTML or JS changes.
+ - HTML/JS updated for fieldset semantics and busy state.
 */

--- a/coresite/templates/coresite/base.html
+++ b/coresite/templates/coresite/base.html
@@ -28,7 +28,7 @@
           <li><a href="/contact/">Contact</a></li>
         </ul>
         <div class="desktop-nav__cta">
-          <a class="btn btn--cta" href="#">Join Us</a>
+          <a class="btn btn--cta" href="/community/join/">Join Us</a>
         </div>
       </nav>
 
@@ -55,7 +55,7 @@
         <li><a href="/about/">About</a></li>
         <li><a href="/services/">Services</a></li>
         <li><a href="/contact/">Contact</a></li>
-        <li><a class="btn btn--cta" href="#">Join Us</a></li>
+        <li><a class="btn btn--cta" href="/community/join/">Join Us</a></li>
       </ul>
     </div>
   </nav>

--- a/coresite/templates/coresite/partials/newsletter_block.html
+++ b/coresite/templates/coresite/partials/newsletter_block.html
@@ -12,32 +12,38 @@
     {% if messages %}
       {% for m in messages %}
         {% if forloop.first %}
-          <form id="newsletter_form" method="post" action="{% url 'newsletter_subscribe' %}" class="is-{{ m.tags }}">
+          <form id="newsletter_form" method="post" action="{% url 'newsletter_subscribe' %}" class="is-{{ m.tags }}" aria-busy="false">
             {% csrf_token %}
-            <label for="newsletter-email">Email address</label>
-            <input type="email" id="newsletter-email" name="email"
-                   placeholder="name@example.com"
-                   aria-label="Email address for newsletter subscription"
-                   required autocomplete="email" inputmode="email" spellcheck="false"
-                   aria-describedby="newsletter-privacy">
-            <input type="text" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" hidden>
-            <button type="submit" aria-label="Subscribe to the newsletter" class="btn btn--cta radius-md">{{ APPROVED_CTA|default:'Subscribe' }}</button>
-            <div role="status" aria-live="polite" class="form-message is-{{ m.tags }}">{{ m }}</div>
+            <fieldset>
+              <legend class="visually-hidden">Newsletter</legend>
+              <label for="newsletter-email">Email address</label>
+              <input type="email" id="newsletter-email" name="email"
+                     placeholder="name@example.com"
+                     aria-label="Email address for newsletter subscription"
+                     required autocomplete="email" inputmode="email" spellcheck="false"
+                     aria-describedby="newsletter-privacy newsletter-status">
+              <input type="text" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" hidden>
+              <button type="submit" aria-label="Subscribe to the newsletter" class="btn btn--cta radius-md">{{ APPROVED_CTA|default:'Subscribe' }}</button>
+              <div id="newsletter-status" role="status" aria-live="polite" class="form-message is-{{ m.tags }}">{{ m }}</div>
+            </fieldset>
           </form>
         {% endif %}
       {% endfor %}
     {% else %}
-      <form id="newsletter_form" method="post" action="{% url 'newsletter_subscribe' %}">
+      <form id="newsletter_form" method="post" action="{% url 'newsletter_subscribe' %}" aria-busy="false">
         {% csrf_token %}
-        <label for="newsletter-email">Email address</label>
-        <input type="email" id="newsletter-email" name="email"
-               placeholder="name@example.com"
-               aria-label="Email address for newsletter subscription"
-               required autocomplete="email" inputmode="email" spellcheck="false"
-               aria-describedby="newsletter-privacy">
-        <input type="text" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" hidden>
-        <button type="submit" aria-label="Subscribe to the newsletter" class="btn btn--cta radius-md">{{ APPROVED_CTA|default:'Subscribe' }}</button>
-        <div role="status" aria-live="polite" class="form-message"></div>
+        <fieldset>
+          <legend class="visually-hidden">Newsletter</legend>
+          <label for="newsletter-email">Email address</label>
+          <input type="email" id="newsletter-email" name="email"
+                 placeholder="name@example.com"
+                 aria-label="Email address for newsletter subscription"
+                 required autocomplete="email" inputmode="email" spellcheck="false"
+                 aria-describedby="newsletter-privacy newsletter-status">
+          <input type="text" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" hidden>
+          <button type="submit" aria-label="Subscribe to the newsletter" class="btn btn--cta radius-md">{{ APPROVED_CTA|default:'Subscribe' }}</button>
+          <div id="newsletter-status" role="status" aria-live="polite" class="form-message"></div>
+        </fieldset>
       </form>
     {% endif %}
 

--- a/coresite/templates/coresite/partials/signals_block.html
+++ b/coresite/templates/coresite/partials/signals_block.html
@@ -10,7 +10,7 @@
       {% for card in signals.cards %}
         <article id="signal-{{ card.slug }}" class="signals__card" data-card="{{ card.slug }}">
           {% if card.kicker %}<p class="signals__kicker">{{ card.kicker }}</p>{% endif %}
-          {% if card.title %}<h3 class="signals__title">{{ card.title }}</h3>{% endif %}
+          {% if card.title %}<h3 class="signals__title"><a href="/signals/{{ card.slug }}/">{{ card.title }}</a></h3>{% endif %}
           {% if card.problem %}<p class="signals__text"><span class="signals__label">Problem:</span> {{ card.problem }}</p>{% endif %}
           {% if card.approach %}<p class="signals__text"><span class="signals__label">Approach:</span> {{ card.approach }}</p>{% endif %}
           {% if card.evidence %}<p class="signals__text"><span class="signals__label">Evidence:</span> {{ card.evidence }}</p>{% endif %}

--- a/coresite/templates/coresite/partials/trust.html
+++ b/coresite/templates/coresite/partials/trust.html
@@ -15,13 +15,13 @@
       <div class="trust__icon">
         <svg class="trust__icon-svg--clock" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Clock icon, time savings.">
           <defs>
-            <linearGradient id="clock-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <linearGradient id="trust-clock-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
               <stop offset="0%" stop-color="var(--bs-primary)" />
               <stop offset="100%" stop-color="var(--bs-danger)" />
             </linearGradient>
           </defs>
-          <circle cx="12" cy="12" r="10" stroke="url(#clock-gradient)"></circle>
-          <polyline class="clock-hand" points="12 6 12 12 16 14" stroke="url(#clock-gradient)"></polyline>
+          <circle cx="12" cy="12" r="10" stroke="url(#trust-clock-gradient)"></circle>
+          <polyline class="clock-hand" points="12 6 12 12 16 14" stroke="url(#trust-clock-gradient)"></polyline>
         </svg>
       </div>
       <h3 class="trust__title">Save Hours Every Week</h3>
@@ -31,12 +31,12 @@
       <div class="trust__icon">
         <svg class="trust__icon-svg--dollar" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 47 47" role="img" aria-label="Dollar symbol icon, cost savings.">
           <defs>
-            <linearGradient id="dollar-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <linearGradient id="trust-dollar-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
               <stop offset="0%" stop-color="var(--bs-primary)" />
               <stop offset="100%" stop-color="var(--bs-danger)" />
             </linearGradient>
           </defs>
-          <g fill="url(#dollar-gradient)">
+          <g fill="url(#trust-dollar-gradient)">
             <path d="M23.501,7.705c0.55,0,1-0.45,1-1V1c0-0.55-0.45-1-1-1s-1,0.45-1,1v5.704C22.501,7.254,22.951,7.705,23.501,7.705z"></path>
             <path d="M23.501,39.295c-0.55,0-1,0.45-1,1V46c0,0.55,0.45,1,1,1s1-0.45,1-1v-5.704C24.501,39.746,24.051,39.295,23.501,39.295z"></path>
             <path d="M8.299,6.884c-0.389-0.389-1.025-0.389-1.414,0c-0.389,0.389-0.389,1.025,0,1.414l4.033,4.032 c0.389,0.389,1.025,0.389,1.414,0.001c0.388-0.389,0.388-1.025-0.001-1.414L8.299,6.884z"></path>
@@ -56,13 +56,13 @@
       <div class="trust__icon">
         <svg class="trust__icon-svg--arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Upward-right arrow icon, new opportunities.">
           <defs>
-            <linearGradient id="arrow-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <linearGradient id="trust-arrow-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
               <stop offset="0%" stop-color="var(--bs-primary)" />
               <stop offset="100%" stop-color="var(--bs-danger)" />
             </linearGradient>
           </defs>
-          <line x1="5" y1="19" x2="19" y2="5" stroke="url(#arrow-gradient)"></line>
-          <polyline points="9 5 19 5 19 15" stroke="url(#arrow-gradient)"></polyline>
+          <line x1="5" y1="19" x2="19" y2="5" stroke="url(#trust-arrow-gradient)"></line>
+          <polyline points="9 5 19 5 19 15" stroke="url(#trust-arrow-gradient)"></polyline>
         </svg>
       </div>
       <h3 class="trust__title">Never Miss an Opportunity</h3>


### PR DESCRIPTION
## Summary
- Point desktop and overlay nav "Join Us" buttons to `/community/join/`
- Prefix trust block SVG gradients with unique IDs to avoid collisions
- Strengthen footer link focus-visible outline
- Improve newsletter form semantics and aria-busy handling
- Link signal card titles to their detail pages

## Testing
- `npx --yes html-validate coresite/templates/coresite/partials/trust.html` *(fails: 403 Forbidden)*
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7707dad68832a9882f4823c893093