### PR TITLE
Add basic About, Services, and Contact pages with styling placeholders

### DIFF
--- a/coresite/static/coresite/scss/main.scss
+++ b/coresite/static/coresite/scss/main.scss
@@ -35,3 +35,6 @@
 
 // Pages
 @import "pages/home";
+@import "pages/about";
+@import "pages/services";
+@import "pages/contact";

--- a/coresite/static/coresite/scss/pages/_about.scss
+++ b/coresite/static/coresite/scss/pages/_about.scss
@@ -1,0 +1,5 @@
+@import "../abstracts/variables";
+
+body.about-page {
+}
+

--- a/coresite/static/coresite/scss/pages/_contact.scss
+++ b/coresite/static/coresite/scss/pages/_contact.scss
@@ -1,0 +1,5 @@
+@import "../abstracts/variables";
+
+body.contact-page {
+}
+

--- a/coresite/static/coresite/scss/pages/_services.scss
+++ b/coresite/static/coresite/scss/pages/_services.scss
@@ -1,0 +1,5 @@
+@import "../abstracts/variables";
+
+body.services-page {
+}
+

--- a/coresite/templates/coresite/about.html
+++ b/coresite/templates/coresite/about.html
@@ -1,0 +1,16 @@
+{% extends "coresite/base.html" %}
+
+{% block title %}About{% endblock %}
+
+{% block content %}
+<section class="section" role="region" aria-labelledby="about-heading">
+  <div class="wrap">
+    <h1 id="about-heading">About</h1>
+  </div>
+</section>
+{% endblock %}
+
+{% block footer %}
+  {% include "coresite/partials/footer.html" %}
+{% endblock %}
+

--- a/coresite/templates/coresite/base.html
+++ b/coresite/templates/coresite/base.html
@@ -23,9 +23,9 @@
         </div>
         <ul class="desktop-nav__links">
           <li><a href="/">Home</a></li>
-          <li><a href="/about/">About</a></li>
-          <li><a href="/services/">Services</a></li>
-          <li><a href="/contact/">Contact</a></li>
+          <li><a href="{% url 'about' %}">About</a></li>
+          <li><a href="{% url 'services' %}">Services</a></li>
+          <li><a href="{% url 'contact' %}">Contact</a></li>
         </ul>
         <div class="desktop-nav__cta">
           <a class="btn btn--cta" href="/community/join/">Join Us</a>
@@ -52,9 +52,9 @@
       <button class="menu-overlay__close" aria-label="Close menu">&times;</button>
       <ul class="menu-overlay__links">
         <li><a href="/">Home</a></li>
-        <li><a href="/about/">About</a></li>
-        <li><a href="/services/">Services</a></li>
-        <li><a href="/contact/">Contact</a></li>
+        <li><a href="{% url 'about' %}">About</a></li>
+        <li><a href="{% url 'services' %}">Services</a></li>
+        <li><a href="{% url 'contact' %}">Contact</a></li>
         <li><a class="btn btn--cta" href="/community/join/">Join Us</a></li>
       </ul>
     </div>

--- a/coresite/templates/coresite/contact.html
+++ b/coresite/templates/coresite/contact.html
@@ -1,0 +1,16 @@
+{% extends "coresite/base.html" %}
+
+{% block title %}Contact{% endblock %}
+
+{% block content %}
+<section class="section" role="region" aria-labelledby="contact-heading">
+  <div class="wrap">
+    <h1 id="contact-heading">Contact</h1>
+  </div>
+</section>
+{% endblock %}
+
+{% block footer %}
+  {% include "coresite/partials/footer.html" %}
+{% endblock %}
+

--- a/coresite/templates/coresite/services.html
+++ b/coresite/templates/coresite/services.html
@@ -1,0 +1,16 @@
+{% extends "coresite/base.html" %}
+
+{% block title %}Services{% endblock %}
+
+{% block content %}
+<section class="section" role="region" aria-labelledby="services-heading">
+  <div class="wrap">
+    <h1 id="services-heading">Services</h1>
+  </div>
+</section>
+{% endblock %}
+
+{% block footer %}
+  {% include "coresite/partials/footer.html" %}
+{% endblock %}
+

--- a/coresite/urls.py
+++ b/coresite/urls.py
@@ -2,7 +2,10 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.homepage, name='home'),
-    path('signals/<slug:slug>/', views.signal_detail, name='signal_detail'),
-    path('community/join/', views.community_join, name='community_join'),
+    path("", views.homepage, name="home"),
+    path("about/", views.about, name="about"),
+    path("services/", views.services, name="services"),
+    path("contact/", views.contact, name="contact"),
+    path("signals/<slug:slug>/", views.signal_detail, name="signal_detail"),
+    path("community/join/", views.community_join, name="community_join"),
 ]

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -61,3 +61,18 @@ def community_join(request):
     """
     footer = get_footer_content()
     return render(request, "coresite/community_join.html", {"footer": footer})
+
+
+def about(request):
+    footer = get_footer_content()
+    return render(request, "coresite/about.html", {"footer": footer})
+
+
+def services(request):
+    footer = get_footer_content()
+    return render(request, "coresite/services.html", {"footer": footer})
+
+
+def contact(request):
+    footer = get_footer_content()
+    return render(request, "coresite/contact.html", {"footer": footer})


### PR DESCRIPTION
## Summary
- add placeholder templates for About, Services, and Contact pages
- wire up views and URL routes for new pages
- add page-level SCSS placeholders and hook navigation links to routes

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68a7a2a54a70832a9ddda5931457ac55