### PR TITLE
Scaffold about page with placeholder sections

### DIFF
--- a/coresite/static/coresite/scss/pages/_about.scss
+++ b/coresite/static/coresite/scss/pages/_about.scss
@@ -1,5 +1,14 @@
 @import "../abstracts/variables";
 
-body.about-page {
+#about-hero,
+#about-story,
+#about-principles,
+#about-team,
+#about-milestones,
+#about-trust,
+#about-cta {
+  padding-block: map-get($section-pad-y, base);
+  @include mq(md) { padding-block: map-get($section-pad-y, md); }
+  @include mq(lg) { padding-block: map-get($section-pad-y, lg); }
 }
 

--- a/coresite/templates/coresite/about.html
+++ b/coresite/templates/coresite/about.html
@@ -3,9 +3,45 @@
 {% block title %}About{% endblock %}
 
 {% block content %}
-<section class="section" role="region" aria-labelledby="about-heading">
+<section id="about-hero" class="section" role="region" aria-labelledby="about-hero-heading">
   <div class="wrap">
-    <h1 id="about-heading">About</h1>
+    <h2 id="about-hero-heading">Hero Statement Section Placeholder</h2>
+  </div>
+</section>
+
+<section id="about-story" class="section" role="region" aria-labelledby="about-story-heading">
+  <div class="wrap">
+    <h2 id="about-story-heading">The TF Story Section Placeholder</h2>
+  </div>
+</section>
+
+<section id="about-principles" class="section" role="region" aria-labelledby="about-principles-heading">
+  <div class="wrap">
+    <h2 id="about-principles-heading">Our Principles Section Placeholder</h2>
+  </div>
+</section>
+
+<section id="about-team" class="section" role="region" aria-labelledby="about-team-heading">
+  <div class="wrap">
+    <h2 id="about-team-heading">Team / Faces of TF Section Placeholder</h2>
+  </div>
+</section>
+
+<section id="about-milestones" class="section" role="region" aria-labelledby="about-milestones-heading">
+  <div class="wrap">
+    <h2 id="about-milestones-heading">Milestones / Current Status Section Placeholder</h2>
+  </div>
+</section>
+
+<section id="about-trust" class="section" role="region" aria-labelledby="about-trust-heading">
+  <div class="wrap">
+    <h2 id="about-trust-heading">Trust Signals Section Placeholder</h2>
+  </div>
+</section>
+
+<section id="about-cta" class="section" role="region" aria-labelledby="about-cta-heading">
+  <div class="wrap">
+    <h2 id="about-cta-heading">Call to Action Section Placeholder</h2>
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- build out `about.html` with seven placeholder sections and ids
- add SCSS partial to apply responsive vertical spacing using `$section-pad-y`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a80f20ac78832a90fc9c51370ba3a3