### PR TITLE
Add contact page scaffolding

### DIFF
--- a/coresite/static/coresite/scss/pages/_contact.scss
+++ b/coresite/static/coresite/scss/pages/_contact.scss
@@ -1,5 +1,14 @@
 @import "../abstracts/variables";
+@import "../abstracts/mixins";
 
-body.contact-page {
+#contact-intro,
+#contact-form,
+#contact-info,
+#contact-social,
+#contact-trust,
+#contact-cta {
+  padding-block: map-get($section-pad-y, base);
+  @include mq(md) { padding-block: map-get($section-pad-y, md); }
+  @include mq(lg) { padding-block: map-get($section-pad-y, lg); }
 }
 

--- a/coresite/templates/coresite/contact.html
+++ b/coresite/templates/coresite/contact.html
@@ -3,9 +3,39 @@
 {% block title %}Contact{% endblock %}
 
 {% block content %}
-<section class="section" role="region" aria-labelledby="contact-heading">
+<section id="contact-intro">
   <div class="wrap">
-    <h1 id="contact-heading">Contact</h1>
+    <h2>Contact Intro</h2>
+  </div>
+</section>
+
+<section id="contact-form">
+  <div class="wrap">
+    <h2>Contact Form Placeholder</h2>
+  </div>
+</section>
+
+<section id="contact-info">
+  <div class="wrap">
+    <h2>Direct Contact Info</h2>
+  </div>
+</section>
+
+<section id="contact-social">
+  <div class="wrap">
+    <h2>Social Links</h2>
+  </div>
+</section>
+
+<section id="contact-trust">
+  <div class="wrap">
+    <h2>Trust &amp; Privacy Note</h2>
+  </div>
+</section>
+
+<section id="contact-cta">
+  <div class="wrap">
+    <h2>Call to Action</h2>
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- scaffold contact page template with six semantic sections
- apply consistent section spacing via dedicated SCSS partial

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a810223c7c832a945a67790396151d