### PR TITLE
content(about): partials + refs pass 1

### DIFF
--- a/coresite/templates/coresite/about.html
+++ b/coresite/templates/coresite/about.html
@@ -5,43 +5,43 @@
 {% block content %}
 <section id="about-hero" class="section" role="region" aria-labelledby="about-hero-heading">
   <div class="wrap">
-    <h2 id="about-hero-heading">Hero Statement Section Placeholder</h2>
+    {% include "coresite/partials/about/about-hero.html" %}
   </div>
 </section>
 
 <section id="about-story" class="section" role="region" aria-labelledby="about-story-heading">
   <div class="wrap">
-    <h2 id="about-story-heading">The TF Story Section Placeholder</h2>
+    {% include "coresite/partials/about/about-story.html" %}
   </div>
 </section>
 
 <section id="about-principles" class="section" role="region" aria-labelledby="about-principles-heading">
   <div class="wrap">
-    <h2 id="about-principles-heading">Our Principles Section Placeholder</h2>
+    {% include "coresite/partials/about/about-principles.html" %}
   </div>
 </section>
 
 <section id="about-team" class="section" role="region" aria-labelledby="about-team-heading">
   <div class="wrap">
-    <h2 id="about-team-heading">Team / Faces of TF Section Placeholder</h2>
+    {% include "coresite/partials/about/about-team.html" %}
   </div>
 </section>
 
 <section id="about-milestones" class="section" role="region" aria-labelledby="about-milestones-heading">
   <div class="wrap">
-    <h2 id="about-milestones-heading">Milestones / Current Status Section Placeholder</h2>
+    {% include "coresite/partials/about/about-milestones.html" %}
   </div>
 </section>
 
 <section id="about-trust" class="section" role="region" aria-labelledby="about-trust-heading">
   <div class="wrap">
-    <h2 id="about-trust-heading">Trust Signals Section Placeholder</h2>
+    {% include "coresite/partials/about/about-trust.html" %}
   </div>
 </section>
 
 <section id="about-cta" class="section" role="region" aria-labelledby="about-cta-heading">
   <div class="wrap">
-    <h2 id="about-cta-heading">Call to Action Section Placeholder</h2>
+    {% include "coresite/partials/about/about-cta.html" %}
   </div>
 </section>
 {% endblock %}

--- a/coresite/templates/coresite/partials/about/about-cta.html
+++ b/coresite/templates/coresite/partials/about/about-cta.html
@@ -1,0 +1,2 @@
+<h2 id="about-cta-heading">Stay connected</h2>
+<p>Join our waitlist to follow Technofatty's progress and be first to try new tools [ref:cta].</p>

--- a/coresite/templates/coresite/partials/about/about-hero.html
+++ b/coresite/templates/coresite/partials/about/about-hero.html
@@ -1,0 +1,2 @@
+<h2 id="about-hero-heading">Engineering nutrition for modern life [ref:mission]</h2>
+<p>We turn complex fat science into everyday guidance so healthier choices feel natural [ref:vision].</p>

--- a/coresite/templates/coresite/partials/about/about-milestones.html
+++ b/coresite/templates/coresite/partials/about/about-milestones.html
@@ -1,0 +1,3 @@
+<h2 id="about-milestones-heading">Where we are now</h2>
+<p>Technofatty is currently in a private beta with select partner clinics [ref:status].</p>
+<p>Our near-term focus is converting early feedback into a publicly accessible toolkit [ref:focus].</p>

--- a/coresite/templates/coresite/partials/about/about-principles.html
+++ b/coresite/templates/coresite/partials/about/about-principles.html
@@ -1,0 +1,6 @@
+<h2 id="about-principles-heading">Our principles</h2>
+<ul>
+  <li>Open data builds trust and accountability [ref:open-data].</li>
+  <li>Measurements matter more than marketing [ref:measurements].</li>
+  <li>Iteration beats intuition when guiding nutrition [ref:iteration].</li>
+</ul>

--- a/coresite/templates/coresite/partials/about/about-story.html
+++ b/coresite/templates/coresite/partials/about/about-story.html
@@ -1,0 +1,4 @@
+<h2 id="about-story-heading">The Technofatty story</h2>
+<p>Technofatty exists to demystify dietary fats, empowering people with clear, actionable guidance [ref:purpose].</p>
+<p>Conflicting advice and opaque labels leave most eaters unsure how fats affect their wellbeing [ref:problem].</p>
+<p>We translate peer-reviewed research into practical tools, testing everything against measurable outcomes [ref:approach].</p>

--- a/coresite/templates/coresite/partials/about/about-team.html
+++ b/coresite/templates/coresite/partials/about/about-team.html
@@ -1,0 +1,3 @@
+<h2 id="about-team-heading">Meet the team</h2>
+<p>Our crew combines clinical dietitians, food technologists, and product engineers [ref:team-roles].</p>
+<p>Together they craft evidence-based tools that respect privacy and adapt to user feedback [ref:team-values].</p>

--- a/coresite/templates/coresite/partials/about/about-trust.html
+++ b/coresite/templates/coresite/partials/about/about-trust.html
@@ -1,0 +1,6 @@
+<h2 id="about-trust-heading">Proof you can trust</h2>
+<ul>
+  <li>Annual third-party security audits [ref:pending]</li>
+  <li>Compliance with recognized nutrition standards [ref:pending]</li>
+  <li>Partnerships with research institutions under review [ref:pending]</li>
+</ul>

--- a/docs/about_content_sources.md
+++ b/docs/about_content_sources.md
@@ -1,0 +1,16 @@
+# About Page Content Sources
+
+- mission → internal mission statement draft (2024-03)
+- vision → product vision memo 2024
+- purpose → stakeholder workshop notes
+- problem → user research summary
+- approach → methodology outline
+- open-data → data transparency guidelines
+- measurements → metrics framework
+- iteration → experimentation playbook
+- team-roles → org chart v2
+- team-values → team values survey 2023
+- status → beta program overview
+- focus → roadmap Q1 2025
+- cta → marketing plan Q1 2025
+- pending → source to be confirmed


### PR DESCRIPTION
## Summary
- extract About page copy into per-section partials with inline `[ref:x]` markers
- add `/docs/about_content_sources.md` register mapping tokens to internal sources

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django'; attempted `pip install django` but proxy prevented download)*

------
https://chatgpt.com/codex/tasks/task_e_68a81c2c7da4832a87d187fc4b76e456