### PR TITLE
content(contact): introduce section partials + refs register

### DIFF
--- a/coresite/templates/coresite/contact.html
+++ b/coresite/templates/coresite/contact.html
@@ -3,39 +3,39 @@
 {% block title %}Contact{% endblock %}
 
 {% block content %}
-<section id="contact-intro">
+<section id="contact-intro" aria-labelledby="contact-intro-heading">
   <div class="wrap">
-    <h2>Contact Intro</h2>
+    {% include "coresite/partials/contact/contact-intro.html" %}
   </div>
 </section>
 
-<section id="contact-form">
+<section id="contact-form" aria-labelledby="contact-form-heading">
   <div class="wrap">
-    <h2>Contact Form Placeholder</h2>
+    {% include "coresite/partials/contact/contact-form.html" %}
   </div>
 </section>
 
-<section id="contact-info">
+<section id="contact-info" aria-labelledby="contact-info-heading">
   <div class="wrap">
-    <h2>Direct Contact Info</h2>
+    {% include "coresite/partials/contact/contact-info.html" %}
   </div>
 </section>
 
-<section id="contact-social">
+<section id="contact-social" aria-labelledby="contact-social-heading">
   <div class="wrap">
-    <h2>Social Links</h2>
+    {% include "coresite/partials/contact/contact-social.html" %}
   </div>
 </section>
 
-<section id="contact-trust">
+<section id="contact-trust" aria-labelledby="contact-trust-heading">
   <div class="wrap">
-    <h2>Trust &amp; Privacy Note</h2>
+    {% include "coresite/partials/contact/contact-trust.html" %}
   </div>
 </section>
 
-<section id="contact-cta">
+<section id="contact-cta" aria-labelledby="contact-cta-heading">
   <div class="wrap">
-    <h2>Call to Action</h2>
+    {% include "coresite/partials/contact/contact-cta.html" %}
   </div>
 </section>
 {% endblock %}

--- a/coresite/templates/coresite/partials/contact/contact-cta.html
+++ b/coresite/templates/coresite/partials/contact/contact-cta.html
@@ -1,0 +1,2 @@
+<h2 id="contact-cta-heading">Contact CTA</h2>
+<p>Soft next step placeholder [ref:cta].</p>

--- a/coresite/templates/coresite/partials/contact/contact-form.html
+++ b/coresite/templates/coresite/partials/contact/contact-form.html
@@ -1,0 +1,2 @@
+<h2 id="contact-form-heading">Contact Form</h2>
+<p>Short preface text placeholder [ref:form].</p>

--- a/coresite/templates/coresite/partials/contact/contact-info.html
+++ b/coresite/templates/coresite/partials/contact/contact-info.html
@@ -1,0 +1,2 @@
+<h2 id="contact-info-heading">Contact Info</h2>
+<p>Company contact channels placeholder [ref:info].</p>

--- a/coresite/templates/coresite/partials/contact/contact-intro.html
+++ b/coresite/templates/coresite/partials/contact/contact-intro.html
@@ -1,0 +1,3 @@
+<h1 class="visually-hidden" id="contact-page-heading">Contact</h1>
+<h2 id="contact-intro-heading">Contact Intro</h2>
+<p>Brief welcome and purpose placeholder [ref:intro].</p>

--- a/coresite/templates/coresite/partials/contact/contact-social.html
+++ b/coresite/templates/coresite/partials/contact/contact-social.html
@@ -1,0 +1,2 @@
+<h2 id="contact-social-heading">Contact Social</h2>
+<p>Approved social channels placeholder [ref:social].</p>

--- a/coresite/templates/coresite/partials/contact/contact-trust.html
+++ b/coresite/templates/coresite/partials/contact/contact-trust.html
@@ -1,0 +1,2 @@
+<h2 id="contact-trust-heading">Contact Trust</h2>
+<p>Privacy and response expectations placeholder [ref:trust].</p>

--- a/docs/contact_content_sources.md
+++ b/docs/contact_content_sources.md
@@ -1,0 +1,8 @@
+# Contact Page Content Sources
+
+- intro → source pending (Content team)
+- form → source pending (UX team)
+- info → source pending (Operations)
+- social → source pending (Marketing)
+- trust → source pending (Legal)
+- cta → source pending (Marketing)


### PR DESCRIPTION
## Summary
- render Contact page sections through dedicated content partials
- register placeholder copy sources for contact content

## Testing
- `python -m pytest`
- `python manage.py test` *(fails: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68a823a3d050832aa8d1785dcde8b76c