### PR TITLE
content(support): introduce section partials + refs register

### DIFF
--- a/coresite/templates/coresite/partials/support/support-accessibility.html
+++ b/coresite/templates/coresite/partials/support/support-accessibility.html
@@ -1,0 +1,2 @@
+<h2 id="support-accessibility-heading">Accessibility Support</h2>
+<p>Assistance channels and formats placeholder [ref:accessibility].</p>

--- a/coresite/templates/coresite/partials/support/support-account-billing.html
+++ b/coresite/templates/coresite/partials/support/support-account-billing.html
@@ -1,0 +1,2 @@
+<h2 id="support-account-billing-heading">Account &amp; Billing Help</h2>
+<p>What goes here and where it routes placeholder [ref:account-billing].</p>

--- a/coresite/templates/coresite/partials/support/support-contact.html
+++ b/coresite/templates/coresite/partials/support/support-contact.html
@@ -1,0 +1,2 @@
+<h2 id="support-contact-heading">Contact Support / Ticket Intake</h2>
+<p>Final nudge to contact or open a ticket placeholder [ref:contact].</p>

--- a/coresite/templates/coresite/partials/support/support-faqs.html
+++ b/coresite/templates/coresite/partials/support/support-faqs.html
@@ -1,0 +1,2 @@
+<h2 id="support-faqs-heading">Top FAQs</h2>
+<p>Brief lead-in and placeholder examples [ref:faqs].</p>

--- a/coresite/templates/coresite/partials/support/support-guides.html
+++ b/coresite/templates/coresite/partials/support/support-guides.html
@@ -1,0 +1,2 @@
+<h2 id="support-guides-heading">Guides &amp; Documentation</h2>
+<p>Short explainer and placeholder list intro [ref:guides].</p>

--- a/coresite/templates/coresite/partials/support/support-intro.html
+++ b/coresite/templates/coresite/partials/support/support-intro.html
@@ -1,0 +1,3 @@
+<h1 class="visually-hidden" id="support-page-heading">Support</h1>
+<h2 id="support-intro-heading">Support Intro</h2>
+<p>Page purpose and who it serves placeholder [ref:intro].</p>

--- a/coresite/templates/coresite/partials/support/support-privacy-security.html
+++ b/coresite/templates/coresite/partials/support/support-privacy-security.html
@@ -1,0 +1,2 @@
+<h2 id="support-privacy-security-heading">Data Privacy &amp; Security</h2>
+<p>Data handling and response boundaries placeholder [ref:privacy-security].</p>

--- a/coresite/templates/coresite/partials/support/support-status.html
+++ b/coresite/templates/coresite/partials/support/support-status.html
@@ -1,0 +1,2 @@
+<h2 id="support-status-heading">System Status &amp; Updates</h2>
+<p>Link-out intent only placeholder [ref:status].</p>

--- a/coresite/templates/coresite/partials/support/support-troubleshooting.html
+++ b/coresite/templates/coresite/partials/support/support-troubleshooting.html
@@ -1,0 +1,2 @@
+<h2 id="support-troubleshooting-heading">Troubleshooting &amp; Known Issues</h2>
+<p>Scope note and escalation cue placeholder [ref:troubleshooting].</p>

--- a/coresite/templates/coresite/support.html
+++ b/coresite/templates/coresite/support.html
@@ -5,55 +5,55 @@
 {% block content %}
 <section id="support-intro" class="section" role="region" aria-labelledby="support-intro-heading">
   <div class="wrap">
-    <h2 id="support-intro-heading">Support Intro Section Placeholder</h2>
+    {% include "coresite/partials/support/support-intro.html" %}
   </div>
 </section>
 
 <section id="support-faqs" class="section" role="region" aria-labelledby="support-faqs-heading">
   <div class="wrap">
-    <h2 id="support-faqs-heading">Top FAQs Section Placeholder</h2>
+    {% include "coresite/partials/support/support-faqs.html" %}
   </div>
 </section>
 
 <section id="support-guides" class="section" role="region" aria-labelledby="support-guides-heading">
   <div class="wrap">
-    <h2 id="support-guides-heading">Guides &amp; Documentation Index Placeholder</h2>
+    {% include "coresite/partials/support/support-guides.html" %}
   </div>
 </section>
 
 <section id="support-troubleshooting" class="section" role="region" aria-labelledby="support-troubleshooting-heading">
   <div class="wrap">
-    <h2 id="support-troubleshooting-heading">Troubleshooting &amp; Known Issues Section Placeholder</h2>
+    {% include "coresite/partials/support/support-troubleshooting.html" %}
   </div>
 </section>
 
 <section id="support-account-billing" class="section" role="region" aria-labelledby="support-account-billing-heading">
   <div class="wrap">
-    <h2 id="support-account-billing-heading">Account &amp; Billing Help Section Placeholder</h2>
+    {% include "coresite/partials/support/support-account-billing.html" %}
   </div>
 </section>
 
 <section id="support-privacy-security" class="section" role="region" aria-labelledby="support-privacy-security-heading">
   <div class="wrap">
-    <h2 id="support-privacy-security-heading">Data Privacy &amp; Security Notes Section Placeholder</h2>
+    {% include "coresite/partials/support/support-privacy-security.html" %}
   </div>
 </section>
 
 <section id="support-accessibility" class="section" role="region" aria-labelledby="support-accessibility-heading">
   <div class="wrap">
-    <h2 id="support-accessibility-heading">Accessibility Support Section Placeholder</h2>
+    {% include "coresite/partials/support/support-accessibility.html" %}
   </div>
 </section>
 
 <section id="support-status" class="section" role="region" aria-labelledby="support-status-heading">
   <div class="wrap">
-    <h2 id="support-status-heading">System Status &amp; Updates Section Placeholder</h2>
+    {% include "coresite/partials/support/support-status.html" %}
   </div>
 </section>
 
 <section id="support-contact" class="section" role="region" aria-labelledby="support-contact-heading">
   <div class="wrap">
-    <h2 id="support-contact-heading">Contact Support / Ticket Intake Section Placeholder</h2>
+    {% include "coresite/partials/support/support-contact.html" %}
   </div>
 </section>
 {% endblock %}

--- a/docs/support_content_sources.md
+++ b/docs/support_content_sources.md
@@ -1,0 +1,11 @@
+# Support Page Content Sources
+
+- intro → source pending (Content team)
+- faqs → source pending (Support team)
+- guides → source pending (Documentation team)
+- troubleshooting → source pending (Engineering)
+- account-billing → source pending (Finance)
+- privacy-security → source pending (Legal)
+- accessibility → source pending (Accessibility team)
+- status → source pending (DevOps)
+- contact → source pending (Support team)


### PR DESCRIPTION
## Summary
- split Support page content into section partials with placeholder copy and reference markers
- wire up support template to include new partials
- track placeholders in docs/support_content_sources.md

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a8306eb6ec832abc07623d6278a2b9