### PR TITLE
content(legal): introduce section partials + refs register

### DIFF
--- a/coresite/templates/coresite/legal.html
+++ b/coresite/templates/coresite/legal.html
@@ -5,49 +5,49 @@
 {% block content %}
 <section id="legal-intro" class="section" role="region" aria-labelledby="legal-intro-heading">
   <div class="wrap">
-    <h2 id="legal-intro-heading">Legal Intro Section Placeholder</h2>
+    {% include "coresite/partials/legal/legal-intro.html" %}
   </div>
 </section>
 
 <section id="legal-terms" class="section" role="region" aria-labelledby="legal-terms-heading">
   <div class="wrap">
-    <h2 id="legal-terms-heading">Terms of Service Placeholder</h2>
+    {% include "coresite/partials/legal/legal-terms.html" %}
   </div>
 </section>
 
 <section id="legal-privacy" class="section" role="region" aria-labelledby="legal-privacy-heading">
   <div class="wrap">
-    <h2 id="legal-privacy-heading">Privacy Policy Placeholder</h2>
+    {% include "coresite/partials/legal/legal-privacy.html" %}
   </div>
 </section>
 
 <section id="legal-cookies" class="section" role="region" aria-labelledby="legal-cookies-heading">
   <div class="wrap">
-    <h2 id="legal-cookies-heading">Cookie Policy Placeholder</h2>
+    {% include "coresite/partials/legal/legal-cookies.html" %}
   </div>
 </section>
 
 <section id="legal-accessibility" class="section" role="region" aria-labelledby="legal-accessibility-heading">
   <div class="wrap">
-    <h2 id="legal-accessibility-heading">Accessibility Statement Placeholder</h2>
+    {% include "coresite/partials/legal/legal-accessibility.html" %}
   </div>
 </section>
 
 <section id="legal-licensing" class="section" role="region" aria-labelledby="legal-licensing-heading">
   <div class="wrap">
-    <h2 id="legal-licensing-heading">Licensing & Attributions Placeholder</h2>
+    {% include "coresite/partials/legal/legal-licensing.html" %}
   </div>
 </section>
 
 <section id="legal-compliance" class="section" role="region" aria-labelledby="legal-compliance-heading">
   <div class="wrap">
-    <h2 id="legal-compliance-heading">Compliance Notices Placeholder</h2>
+    {% include "coresite/partials/legal/legal-compliance.html" %}
   </div>
 </section>
 
 <section id="legal-contact" class="section" role="region" aria-labelledby="legal-contact-heading">
   <div class="wrap">
-    <h2 id="legal-contact-heading">Legal Contact & Requests Placeholder</h2>
+    {% include "coresite/partials/legal/legal-contact.html" %}
   </div>
 </section>
 {% endblock %}

--- a/coresite/templates/coresite/partials/legal/legal-accessibility.html
+++ b/coresite/templates/coresite/partials/legal/legal-accessibility.html
@@ -1,0 +1,2 @@
+<h2 id="legal-accessibility-heading">Accessibility</h2>
+<p>WCAG commitment placeholder [ref:accessibility].</p>

--- a/coresite/templates/coresite/partials/legal/legal-compliance.html
+++ b/coresite/templates/coresite/partials/legal/legal-compliance.html
@@ -1,0 +1,2 @@
+<h2 id="legal-compliance-heading">Compliance</h2>
+<p>Jurisdiction and frameworks placeholder [ref:compliance].</p>

--- a/coresite/templates/coresite/partials/legal/legal-contact.html
+++ b/coresite/templates/coresite/partials/legal/legal-contact.html
@@ -1,0 +1,2 @@
+<h2 id="legal-contact-heading">Contact</h2>
+<p>Rights requests and DSR/DSAR intake placeholder [ref:contact].</p>

--- a/coresite/templates/coresite/partials/legal/legal-cookies.html
+++ b/coresite/templates/coresite/partials/legal/legal-cookies.html
@@ -1,0 +1,2 @@
+<h2 id="legal-cookies-heading">Cookie Policy</h2>
+<p>Cookie categories and purposes placeholder [ref:cookies].</p>

--- a/coresite/templates/coresite/partials/legal/legal-intro.html
+++ b/coresite/templates/coresite/partials/legal/legal-intro.html
@@ -1,0 +1,3 @@
+<h1 class="visually-hidden" id="legal-page-heading">Legal</h1>
+<h2 id="legal-intro-heading">Legal Overview</h2>
+<p>Page purpose, scope, and versioning placeholder [ref:intro][ref:pending].</p>

--- a/coresite/templates/coresite/partials/legal/legal-licensing.html
+++ b/coresite/templates/coresite/partials/legal/legal-licensing.html
@@ -1,0 +1,2 @@
+<h2 id="legal-licensing-heading">Licensing &amp; Attributions</h2>
+<p>Third-party attributions placeholder [ref:licensing].</p>

--- a/coresite/templates/coresite/partials/legal/legal-privacy.html
+++ b/coresite/templates/coresite/partials/legal/legal-privacy.html
@@ -1,0 +1,2 @@
+<h2 id="legal-privacy-heading">Privacy Policy</h2>
+<p>Data handling summary placeholder [ref:privacy].</p>

--- a/coresite/templates/coresite/partials/legal/legal-terms.html
+++ b/coresite/templates/coresite/partials/legal/legal-terms.html
@@ -1,0 +1,2 @@
+<h2 id="legal-terms-heading">Terms of Service</h2>
+<p>Terms of Service placeholder [ref:terms].</p>

--- a/docs/legal_content_sources.md
+++ b/docs/legal_content_sources.md
@@ -1,0 +1,11 @@
+# Legal Page Content Sources
+
+- intro → page purpose, scope, and versioning note draft (Legal team - pending)
+- terms → counsel-approved ToS draft (Legal team)
+- privacy → privacy policy baseline (Privacy team)
+- cookies → cookie inventory (Marketing & Privacy teams)
+- accessibility → accessibility statement source (Accessibility team)
+- licensing → third-party licensing spreadsheet (Engineering)
+- compliance → jurisdiction and frameworks register (Compliance team)
+- contact → rights request procedure document (Privacy team)
+- pending → source pending (owner TBD)


### PR DESCRIPTION
## Summary
- split legal page content into dedicated partial templates with placeholder copy and reference tokens
- register source tokens for legal claims

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a838146320832a863d9cd57c4a1c5c