### PR TITLE
seo(meta): add structured data to static pages

### DIFF
--- a/coresite/templates/coresite/about.html
+++ b/coresite/templates/coresite/about.html
@@ -1,6 +1,21 @@
 {% extends "coresite/base.html" %}
 
-{% block title %}About{% endblock %}
+{% block title %}About – Technofatty{% endblock %}
+
+{% block meta_description %}Discover Technofatty's mission and team values.{% endblock %}<!-- [ref:mission] [ref:team-values] -->
+
+{% block head_extras %}
+  <link rel="canonical" href="https://technofatty.com/about/">
+  <meta name="robots" content="index,follow">
+  <meta property="og:title" content="About – Technofatty">
+  <meta property="og:description" content="Discover Technofatty's mission and team values."><!-- [ref:mission] [ref:team-values] -->
+  <meta property="og:url" content="https://technofatty.com/about/">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="About – Technofatty">
+  <meta name="twitter:description" content="Discover Technofatty's mission and team values."><!-- [ref:mission] [ref:team-values] -->
+  <meta name="twitter:url" content="https://technofatty.com/about/">
+{% endblock %}
 
 {% block content %}
 <section id="about-hero" class="section" role="region" aria-labelledby="about-hero-heading">
@@ -48,5 +63,21 @@
 
 {% block footer %}
   {% include "coresite/partials/footer.html" %}
+{% endblock %}
+
+{% block body_scripts %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "AboutPage",
+      "url": "https://technofatty.com/about/",
+      "name": "About – Technofatty",
+      "publisher": {
+        "@type": "Organization",
+        "name": "Technofatty",
+        "url": "https://technofatty.com/"
+      }
+    }
+  </script>
 {% endblock %}
 

--- a/coresite/templates/coresite/contact.html
+++ b/coresite/templates/coresite/contact.html
@@ -1,6 +1,21 @@
 {% extends "coresite/base.html" %}
 
-{% block title %}Contact{% endblock %}
+{% block title %}Contact – Technofatty{% endblock %}
+
+{% block meta_description %}Reach Technofatty for general inquiries.{% endblock %}<!-- [ref:pending-contact] -->
+
+{% block head_extras %}
+  <link rel="canonical" href="https://technofatty.com/contact/">
+  <meta name="robots" content="index,follow">
+  <meta property="og:title" content="Contact – Technofatty">
+  <meta property="og:description" content="Reach Technofatty for general inquiries."><!-- [ref:pending-contact] -->
+  <meta property="og:url" content="https://technofatty.com/contact/">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Contact – Technofatty">
+  <meta name="twitter:description" content="Reach Technofatty for general inquiries."><!-- [ref:pending-contact] -->
+  <meta name="twitter:url" content="https://technofatty.com/contact/">
+{% endblock %}
 
 {% block content %}
 <section id="contact-intro" aria-labelledby="contact-intro-heading">
@@ -42,5 +57,21 @@
 
 {% block footer %}
   {% include "coresite/partials/footer.html" %}
+{% endblock %}
+
+{% block body_scripts %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ContactPage",
+      "url": "https://technofatty.com/contact/",
+      "name": "Contact – Technofatty",
+      "publisher": {
+        "@type": "Organization",
+        "name": "Technofatty",
+        "url": "https://technofatty.com/"
+      }
+    }
+  </script>
 {% endblock %}
 

--- a/coresite/templates/coresite/legal.html
+++ b/coresite/templates/coresite/legal.html
@@ -1,6 +1,21 @@
 {% extends "coresite/base.html" %}
 
-{% block title %}Legal{% endblock %}
+{% block title %}Legal – Technofatty{% endblock %}
+
+{% block meta_description %}Review our terms and privacy practices.{% endblock %}<!-- [ref:terms] [ref:privacy] -->
+
+{% block head_extras %}
+  <link rel="canonical" href="https://technofatty.com/legal/">
+  <meta name="robots" content="index,follow">
+  <meta property="og:title" content="Legal – Technofatty">
+  <meta property="og:description" content="Review our terms and privacy practices."><!-- [ref:terms] [ref:privacy] -->
+  <meta property="og:url" content="https://technofatty.com/legal/">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Legal – Technofatty">
+  <meta name="twitter:description" content="Review our terms and privacy practices."><!-- [ref:terms] [ref:privacy] -->
+  <meta name="twitter:url" content="https://technofatty.com/legal/">
+{% endblock %}
 
 {% block content %}
 <section id="legal-intro" class="section" role="region" aria-labelledby="legal-intro-heading">
@@ -54,4 +69,20 @@
 
 {% block footer %}
   {% include "coresite/partials/footer.html" %}
+{% endblock %}
+
+{% block body_scripts %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      "url": "https://technofatty.com/legal/",
+      "name": "Legal – Technofatty",
+      "publisher": {
+        "@type": "Organization",
+        "name": "Technofatty",
+        "url": "https://technofatty.com/"
+      }
+    }
+  </script>
 {% endblock %}

--- a/coresite/templates/coresite/support.html
+++ b/coresite/templates/coresite/support.html
@@ -1,6 +1,21 @@
 {% extends "coresite/base.html" %}
 
-{% block title %}Support{% endblock %}
+{% block title %}Support – Technofatty{% endblock %}
+
+{% block meta_description %}Find help resources for Technofatty services.{% endblock %}<!-- [ref:pending-support] -->
+
+{% block head_extras %}
+  <link rel="canonical" href="https://technofatty.com/support/">
+  <meta name="robots" content="index,follow">
+  <meta property="og:title" content="Support – Technofatty">
+  <meta property="og:description" content="Find help resources for Technofatty services."><!-- [ref:pending-support] -->
+  <meta property="og:url" content="https://technofatty.com/support/">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Support – Technofatty">
+  <meta name="twitter:description" content="Find help resources for Technofatty services."><!-- [ref:pending-support] -->
+  <meta name="twitter:url" content="https://technofatty.com/support/">
+{% endblock %}
 
 {% block content %}
 <section id="support-intro" class="section" role="region" aria-labelledby="support-intro-heading">
@@ -60,5 +75,21 @@
 
 {% block footer %}
   {% include "coresite/partials/footer.html" %}
+{% endblock %}
+
+{% block body_scripts %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      "url": "https://technofatty.com/support/",
+      "name": "Support – Technofatty",
+      "publisher": {
+        "@type": "Organization",
+        "name": "Technofatty",
+        "url": "https://technofatty.com/"
+      }
+    }
+  </script>
 {% endblock %}
 

--- a/docs/seo_meta_sources.md
+++ b/docs/seo_meta_sources.md
@@ -1,0 +1,8 @@
+# SEO Meta Sources
+
+- mission → internal mission statement draft (2024-03)
+- team-values → team values survey 2023
+- pending-contact → source pending (Content team)
+- pending-support → source pending (Support team)
+- terms → counsel-approved ToS draft (Legal team)
+- privacy → privacy policy baseline (Privacy team)


### PR DESCRIPTION
## Summary
- add canonical URLs, Open Graph/Twitter tags, and JSON-LD to About, Contact, Support, and Legal pages
- document meta descriptor sources for traceability

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a83c367590832ab71d5ca6aadd6669