### PR TITLE
feat: populate contact page content

### DIFF
--- a/coresite/templates/coresite/partials/contact/contact-cta.html
+++ b/coresite/templates/coresite/partials/contact/contact-cta.html
@@ -1,2 +1,9 @@
-<h2 id="contact-cta-heading">Contact CTA</h2>
-<p>Soft next step placeholder [ref:cta].</p>
+<h2 id="contact-cta-heading">Ready to reach out?</h2>
+<p>Use the form to connect; we'll route your message to the right team [ref:cta].</p>
+<ul class="contact-sources">
+  <li>[ref:general] General contact handbook</li>
+  <li>[ref:support] Support process doc v2</li>
+  <li>[ref:legal] Legal contact memo</li>
+  <li>[ref:partners] Partner channel brief</li>
+  <li>[ref:cta] Marketing engagement playbook</li>
+</ul>

--- a/coresite/templates/coresite/partials/contact/contact-form.html
+++ b/coresite/templates/coresite/partials/contact/contact-form.html
@@ -1,2 +1,3 @@
-<h2 id="contact-form-heading">Contact Form</h2>
-<p>Short preface text placeholder [ref:form].</p>
+<h2 id="contact-form-heading">General inquiries</h2>
+<p>Use this form for non-urgent questions; staff reviews messages each workday [ref:general].</p>
+<p>If the form is unavailable, email <a href="mailto:contact@technofatty.com">contact@technofatty.com</a> for help [ref:general].</p>

--- a/coresite/templates/coresite/partials/contact/contact-info.html
+++ b/coresite/templates/coresite/partials/contact/contact-info.html
@@ -1,2 +1,6 @@
-<h2 id="contact-info-heading">Contact Info</h2>
-<p>Company contact channels placeholder [ref:info].</p>
+<h2 id="contact-info-heading">Support</h2>
+<p>Visit our support portal for guides and system status updates [ref:support].</p>
+<p>Need more help? Submit a ticket so technicians can review your case quickly [ref:support].</p>
+<ul>
+  <li><a href="mailto:support@technofatty.com">support@technofatty.com</a></li>
+</ul>

--- a/coresite/templates/coresite/partials/contact/contact-intro.html
+++ b/coresite/templates/coresite/partials/contact/contact-intro.html
@@ -1,3 +1,3 @@
 <h1 class="visually-hidden" id="contact-page-heading">Contact</h1>
-<h2 id="contact-intro-heading">Contact Intro</h2>
-<p>Brief welcome and purpose placeholder [ref:intro].</p>
+<h2 id="contact-intro-heading">Get in touch</h2>
+<p>Technofatty welcomes questions or proposals through the channels below [ref:general].</p>

--- a/coresite/templates/coresite/partials/contact/contact-social.html
+++ b/coresite/templates/coresite/partials/contact/contact-social.html
@@ -1,2 +1,3 @@
-<h2 id="contact-social-heading">Contact Social</h2>
-<p>Approved social channels placeholder [ref:social].</p>
+<h2 id="contact-social-heading">Legal requests</h2>
+<p>Send formal notices or privacy requests to our legal team for processing [ref:legal].</p>
+<p>Email <a href="mailto:legal@technofatty.com">legal@technofatty.com</a> with your contact details and any supporting documents [ref:legal].</p>

--- a/coresite/templates/coresite/partials/contact/contact-trust.html
+++ b/coresite/templates/coresite/partials/contact/contact-trust.html
@@ -1,2 +1,3 @@
-<h2 id="contact-trust-heading">Contact Trust</h2>
-<p>Privacy and response expectations placeholder [ref:trust].</p>
+<h2 id="contact-trust-heading">Partnerships &amp; business</h2>
+<p>We consider collaborations that align with our mission and audience [ref:partners].</p>
+<p>Share your proposal with <a href="mailto:partners@technofatty.com">partners@technofatty.com</a>; our bizdev team reviews every submission [ref:partners].</p>

--- a/docs/contact_content_draft.md
+++ b/docs/contact_content_draft.md
@@ -1,0 +1,34 @@
+# Contact Page Content Draft
+
+## Get in touch
+Technofatty welcomes questions or proposals through the channels below [ref:general].
+
+## General inquiries
+Use this form for non-urgent questions; staff reviews messages each workday [ref:general].
+
+If the form is unavailable, email contact@technofatty.com for help [ref:general].
+
+## Support
+Visit our support portal for guides and system status updates [ref:support].
+
+Need more help? Submit a ticket so technicians can review your case quickly [ref:support].
+
+## Legal requests
+Send formal notices or privacy requests to our legal team for processing [ref:legal].
+
+Email legal@technofatty.com with your contact details and any supporting documents [ref:legal].
+
+## Partnerships & business
+We consider collaborations that align with our mission and audience [ref:partners].
+
+Share your proposal with partners@technofatty.com; our bizdev team reviews every submission [ref:partners].
+
+## Call to action
+Use the form to connect; we'll route your message to the right team [ref:cta].
+
+### Sources
+- [ref:general] General contact handbook
+- [ref:support] Support process doc v2
+- [ref:legal] Legal contact memo
+- [ref:partners] Partner channel brief
+- [ref:cta] Marketing engagement playbook

--- a/docs/contact_content_sources.md
+++ b/docs/contact_content_sources.md
@@ -1,8 +1,7 @@
 # Contact Page Content Sources
 
-- intro → source pending (Content team)
-- form → source pending (UX team)
-- info → source pending (Operations)
-- social → source pending (Marketing)
-- trust → source pending (Legal)
-- cta → source pending (Marketing)
+- [ref:general] → general_contact_handbook.md (Operations)
+- [ref:support] → support_process_v2.md (Support)
+- [ref:legal] → legal_contact_memo.pdf (Legal)
+- [ref:partners] → partner_channel_brief.pdf (BizDev)
+- [ref:cta] → engagement_playbook.md (Marketing)


### PR DESCRIPTION
## Summary
- fill contact page partials with concise copy and citation markers
- add internal draft content and map references to source documents

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a84770fc68832aa1d16269b0f3a259