### PR TITLE
a11y: normalize headings and section wrappers

### DIFF
--- a/coresite/templates/coresite/contact.html
+++ b/coresite/templates/coresite/contact.html
@@ -17,37 +17,37 @@
 {% endblock %}
 
 {% block content %}
-<section id="contact-intro" aria-labelledby="contact-intro-heading">
+<section id="contact-intro" class="section" role="region" aria-labelledby="contact-intro-heading">
   <div class="wrap">
     {% include "coresite/partials/contact/contact-intro.html" %}
   </div>
 </section>
 
-<section id="contact-form" aria-labelledby="contact-form-heading">
+<section id="contact-form" class="section" role="region" aria-labelledby="contact-form-heading">
   <div class="wrap">
     {% include "coresite/partials/contact/contact-form.html" %}
   </div>
 </section>
 
-<section id="contact-info" aria-labelledby="contact-info-heading">
+<section id="contact-info" class="section" role="region" aria-labelledby="contact-info-heading">
   <div class="wrap">
     {% include "coresite/partials/contact/contact-info.html" %}
   </div>
 </section>
 
-<section id="contact-social" aria-labelledby="contact-social-heading">
+<section id="contact-social" class="section" role="region" aria-labelledby="contact-social-heading">
   <div class="wrap">
     {% include "coresite/partials/contact/contact-social.html" %}
   </div>
 </section>
 
-<section id="contact-trust" aria-labelledby="contact-trust-heading">
+<section id="contact-trust" class="section" role="region" aria-labelledby="contact-trust-heading">
   <div class="wrap">
     {% include "coresite/partials/contact/contact-trust.html" %}
   </div>
 </section>
 
-<section id="contact-cta" aria-labelledby="contact-cta-heading">
+<section id="contact-cta" class="section" role="region" aria-labelledby="contact-cta-heading">
   <div class="wrap">
     {% include "coresite/partials/contact/contact-cta.html" %}
   </div>

--- a/coresite/templates/coresite/partials/about/about-hero.html
+++ b/coresite/templates/coresite/partials/about/about-hero.html
@@ -1,2 +1,3 @@
+<h1 class="visually-hidden" id="about-page-heading">About</h1>
 <h2 id="about-hero-heading">Engineering nutrition for modern life [ref:mission]</h2>
 <p>We turn complex fat science into everyday guidance so healthier choices feel natural [ref:vision].</p>

--- a/coresite/templates/coresite/signal_placeholder.html
+++ b/coresite/templates/coresite/signal_placeholder.html
@@ -1,9 +1,10 @@
 {% extends "coresite/base.html" %}
 {% block title %}Signal: {{ slug|title }}{% endblock %}
 {% block content %}
-<section class="section">
+<section class="section" role="region" aria-labelledby="signal-placeholder-heading">
   <div class="wrap">
-    <h1>{{ slug|title }}</h1>
+    <h1 class="visually-hidden" id="signal-placeholder-heading">{{ slug|title }}</h1>
+    <h2>{{ slug|title }}</h2>
     <p>Full signal coming soon.</p>
   </div>
 </section>

--- a/docs/change_logs/20250822_global_cleanup.md
+++ b/docs/change_logs/20250822_global_cleanup.md
@@ -1,0 +1,13 @@
+# Global cleanup log – 2025-08-22
+
+## About page canonical H1
+- **before**: `coresite/templates/coresite/partials/about/about-hero.html` began with an `<h2>`; page rendered with no `<h1>`.
+- **after**: added `<h1 class="visually-hidden" id="about-page-heading">About</h1>` above the existing `<h2>` so the About page now exposes a single page-level heading.
+
+## Contact section wrappers
+- **before**: Sections in `coresite/templates/coresite/contact.html` lacked the standard `class="section"` and `role="region"` semantics.
+- **after**: each `<section>` now includes `class="section" role="region"` with unchanged `aria-labelledby` references, restoring wrapper parity.
+
+## Signal placeholder semantics
+- **before**: `coresite/templates/coresite/signal_placeholder.html` used a visible `<h1>` and omitted `role`/`aria-labelledby` on its section wrapper.
+- **after**: section now has `role="region" aria-labelledby="signal-placeholder-heading"`; inserted a hidden `<h1>` with that ID and converted the visible heading to `<h2>` to maintain hierarchy.


### PR DESCRIPTION
## Summary
- add canonical hidden H1 to About hero so page exposes a single heading
- standardize Contact page section wrappers with `class="section"` and `role="region"`
- align Signal placeholder with section wrapper convention and hidden H1
- log before/after notes for all changes in `docs/change_logs`

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a866adf27c832a9c9f571f84984255