### PR TITLE
refactor(nav): centralize header+primary nav into global partial; add aria-label

### DIFF
--- a/coresite/templates/coresite/base.html
+++ b/coresite/templates/coresite/base.html
@@ -15,51 +15,7 @@
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
 
-  <header class="site-header {% if request.path == '/' %}hero-mode{% else %}fixed-mode{% endif %}">
-    {% block header %}
-      <!-- Desktop Navigation -->
-      <nav class="desktop-nav">
-        <div class="desktop-nav__logo">
-          <a href="/">Technofatty</a>
-        </div>
-        <ul class="desktop-nav__links">
-          <li><a href="/">Home</a></li>
-          <li><a href="{% url 'about' %}">About</a></li>
-          <li><a href="{% url 'services' %}">Services</a></li>
-          <li><a href="{% url 'contact' %}">Contact</a></li>
-        </ul>
-        <div class="desktop-nav__cta">
-          <a class="btn btn--cta" href="/community/join/">Join Us</a>
-        </div>
-      </nav>
-
-      <!-- Global Hamburger -->
-      <div class="global-hamburger">
-        <button class="hamburger-btn" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="menu-overlay">
-          <span class="hamburger-line"></span>
-          <span class="hamburger-line"></span>
-          <span class="hamburger-line"></span>
-        </button>
-      </div>
-    {% endblock %}
-  </header>
-
-  <!-- Backdrop -->
-  <div class="menu-backdrop"></div>
-
-  <!-- Slide-in Menu Overlay -->
-  <nav id="menu-overlay" class="menu-overlay" aria-hidden="true">
-    <div class="menu-overlay__content">
-      <button class="menu-overlay__close" aria-label="Close menu">&times;</button>
-      <ul class="menu-overlay__links">
-        <li><a href="/">Home</a></li>
-        <li><a href="{% url 'about' %}">About</a></li>
-        <li><a href="{% url 'services' %}">Services</a></li>
-        <li><a href="{% url 'contact' %}">Contact</a></li>
-        <li><a class="btn btn--cta" href="/community/join/">Join Us</a></li>
-      </ul>
-    </div>
-  </nav>
+  {% include 'coresite/partials/global/header_nav.html' %}
 
   <main id="main">
     {% block content %}{% endblock %}

--- a/coresite/templates/coresite/partials/global/header_nav.html
+++ b/coresite/templates/coresite/partials/global/header_nav.html
@@ -1,0 +1,37 @@
+<header class="site-header {% if request.path == '/' %}hero-mode{% else %}fixed-mode{% endif %}">
+  <!-- Desktop Navigation -->
+  <nav class="desktop-nav" aria-label="Primary">
+    <div class="desktop-nav__logo">
+      <a href="/">Technofatty</a>
+    </div>
+    <ul class="desktop-nav__links">
+      {% include 'coresite/partials/global/nav_links.html' %}
+    </ul>
+    <div class="desktop-nav__cta">
+      {% include 'coresite/partials/global/nav_cta.html' %}
+    </div>
+  </nav>
+
+  <!-- Global Hamburger -->
+  <div class="global-hamburger">
+    <button class="hamburger-btn" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="menu-overlay">
+      <span class="hamburger-line"></span>
+      <span class="hamburger-line"></span>
+      <span class="hamburger-line"></span>
+    </button>
+  </div>
+</header>
+
+<!-- Backdrop -->
+<div class="menu-backdrop"></div>
+
+<!-- Slide-in Menu Overlay -->
+<div id="menu-overlay" class="menu-overlay" aria-hidden="true">
+  <div class="menu-overlay__content">
+    <button class="menu-overlay__close" aria-label="Close menu">&times;</button>
+    <ul class="menu-overlay__links">
+      {% include 'coresite/partials/global/nav_links.html' %}
+      <li>{% include 'coresite/partials/global/nav_cta.html' %}</li>
+    </ul>
+  </div>
+</div>

--- a/coresite/templates/coresite/partials/global/nav_cta.html
+++ b/coresite/templates/coresite/partials/global/nav_cta.html
@@ -1,0 +1,1 @@
+<a class="btn btn--cta" href="/community/join/">Join Us</a>

--- a/coresite/templates/coresite/partials/global/nav_links.html
+++ b/coresite/templates/coresite/partials/global/nav_links.html
@@ -1,0 +1,4 @@
+<li><a href="/">Home</a></li>
+<li><a href="{% url 'about' %}">About</a></li>
+<li><a href="{% url 'services' %}">Services</a></li>
+<li><a href="{% url 'contact' %}">Contact</a></li>

--- a/docs/change_logs/20250822_header_nav_unify.md
+++ b/docs/change_logs/20250822_header_nav_unify.md
@@ -1,0 +1,19 @@
+# Header & Navigation Global Partial Unification
+
+## Before
+- Template with header/nav markup: `coresite/templates/coresite/base.html`
+- Duplicate link lists existed in desktop nav and overlay menu.
+- Link order was consistent (`Home`, `About`, `Services`, `Contact`), but the "Join Us" CTA was outside the desktop list and inside the overlay list.
+
+## After
+- Single partial path: `coresite/templates/coresite/partials/global/header_nav.html`
+- Pages inheriting the partial via `base.html`:
+  - `coresite/templates/coresite/about.html`
+  - `coresite/templates/coresite/community_join.html`
+  - `coresite/templates/coresite/contact.html`
+  - `coresite/templates/coresite/homepage.html`
+  - `coresite/templates/coresite/legal.html`
+  - `coresite/templates/coresite/services.html`
+  - `coresite/templates/coresite/support.html`
+  - `coresite/templates/coresite/signal_placeholder.html`
+- CTA wording standardized to "Join Us".

--- a/docs/task_specs/header_nav_global_partial_spec.md
+++ b/docs/task_specs/header_nav_global_partial_spec.md
@@ -1,0 +1,26 @@
+# Task Spec: Header & Navigation — Global Partial and De‑duplication (Technofatty)
+
+Objective
+Unify the site header and primary navigation into a single global partial to remove duplicated link markup, add missing accessibility labels, and ensure every page consumes the same source of truth. No design changes, no JavaScript, no new dependencies.
+
+Scope
+Extract the current header and nav markup from base.html and any page‑level templates that repeat it. Create one global partial for header+nav and include it from base.html so all pages inherit it automatically. Preserve existing link order, link text, URLs, and classes. Add an explicit aria-label to the <nav> element to identify its purpose. Where both desktop and overlay menus exist, both must render from the same include so link lists are not duplicated.
+
+Constraints
+Do not alter visual styles or introduce new classes. Do not change routing or link destinations. Do not modify any SCSS tokens; if styles reference hardcoded values elsewhere, leave them for the separate SCSS tokenization task. Keep the current skip link behavior intact. No new dropdown or menu logic.
+
+Accessibility requirements
+One primary <nav> landmark with aria-label="Primary". Heading order must remain unchanged. Focus order through the header must be logical and match the visual order. If there is an overlay or secondary nav pattern, it must consume the same list of links via the global partial so screen readers encounter identical link sets.
+
+File and path conventions
+Place the new partial at coresite/templates/coresite/partials/global/header_nav.html. Reference it from coresite/templates/coresite/base.html. Remove any page‑level nav duplicates and ensure only the base template includes the header partial. If there is a separate overlay menu shell, keep its container but include the shared link list inside it rather than re‑writing the links.
+
+Evidence handling
+Before: record the template paths that currently contain header/nav markup and note any differences in link order or labels. After: list the single partial path and the pages that now inherit it through base.html. Store these notes in docs/change_logs/<YYYYMMDD>_header_nav_unify.md. If any link text differs between duplicates, flag it and resolve to the currently approved wording; note the decision in the change log.
+
+Verification
+Run the site and inspect any page. Confirm there is exactly one primary <nav> landmark, the aria-label is present, and both desktop and overlay menus show identical link lists. Use keyboard only to tab through the header; focus rings remain visible and traversal order is unchanged. View source on two different pages and confirm the header markup is identical. No console errors, no template include errors.
+
+Acceptance
+All pages render the same header from a single include. The primary <nav> has an aria-label. No visual diffs beyond the removal of duplicated markup. No broken or missing links. Skip link remains functional. Commit message: refactor(nav): centralize header+primary nav into global partial; add aria-label.
+


### PR DESCRIPTION
## Summary
- move shared header and nav markup into `partials/global/header_nav.html`
- reuse one list of nav links across desktop and overlay menus
- add "Primary" aria-label to main navigation

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a8723e905c832aa4b4db8e6f27d8cc