### PR TITLE
refactor: tokenize scss values

### DIFF
--- a/coresite/static/coresite/scss/abstracts/_variables.scss
+++ b/coresite/static/coresite/scss/abstracts/_variables.scss
@@ -13,6 +13,9 @@ $colors: (
   magenta: #D94BCD,  // rare accent
   ph:      #D5EDF2,  // placeholder blocks for images
   text:    #333333,
+  text-strong: #222222, // strong headings
+  text-muted:  #555555, // muted text
+  gray-light:  #F5F5F5, // neutral light surfaces
   border:  #DDDDDD,  // neutral border color
   black:   #000000,
   bg-alt:  #F9FAFB,  // pale background bands
@@ -22,6 +25,10 @@ $colors: (
 /* Layout width */
 $container-max: 68rem; // ≈1088px target content width
 $container-max-width-wide: 90rem; // ≈1440px wide container
+
+/* Featured card dimensions */
+$featured-card-min-width: 17.5rem; // 280px
+$featured-card-img-height: 10rem; // 160px
 
 /* Spacing scale (t-shirt friendly) */
 $space: (
@@ -47,6 +54,7 @@ $section-pad-y: (
 $font-sizes: (
   xs: 0.75rem,    // 12px
   sm: 0.875rem,   // 14px
+  sm-md: 0.95rem, // ≈15px
   base: 1rem,     // 16px
   md: 1.125rem,   // 18px
   lg: 1.25rem,    // 20px
@@ -109,7 +117,9 @@ $z: (
 $shadows: (
   sm: 0 1px 2px rgba(map-get($colors, black), 0.05),
   md: 0 2px 6px rgba(map-get($colors, black), 0.15),
-  lg: -4px 0 12px rgba(map-get($colors, black), 0.3)
+  lg: -4px 0 12px rgba(map-get($colors, black), 0.3),
+  card: 0 4px 12px rgba(map-get($colors, black), 0.08),
+  card-hover: 0 6px 18px rgba(map-get($colors, black), 0.12)
 );
 
 /* Timing & easing (nice-to-have) */

--- a/coresite/static/coresite/scss/base/_utilities.scss
+++ b/coresite/static/coresite/scss/base/_utilities.scss
@@ -5,7 +5,7 @@
 }
 .skip-link { @include sr-only; }
 .skip-link:focus {
-  position: fixed; left: 8px; top: 8px;
-  background: #000; color: #fff; padding: .5rem;
+  position: fixed; left: s(2); top: s(2);
+  background: c(black); color: c(white); padding: s(2);
   z-index: z(overlay);
 }

--- a/coresite/static/coresite/scss/sections/_featured.scss
+++ b/coresite/static/coresite/scss/sections/_featured.scss
@@ -1,72 +1,73 @@
 // coresite/static/coresite/scss/sections/_featured.scss
 
+
 .featured {
   position: relative;
-  background: #fff;
+  background: c(white);
   overflow: hidden;
 
   // section title
   .section-title {
     text-align: center;
-    margin-bottom: 3rem;
-    font-size: 2rem;
+    margin-bottom: s(7);
+    font-size: fs(xxl);
     font-weight: 700;
-    color: var(--tf-blue, #4B6CB7);
+    color: var(--tf-blue, c(blue));
     position: relative;
-    z-index: 1;
+    z-index: z(content);
   }
 
   // card grid
   .cards {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax($featured-card-min-width, 1fr));
+    gap: s(6);
     position: relative;
-    z-index: 1;
+    z-index: z(content);
   }
 
   // card
   .card {
-    background: #fff;
-    border-radius: 1rem;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-    padding: 2rem;
+    background: c(white);
+    border-radius: r(lg);
+    box-shadow: map-get($shadows, card);
+    padding: s(6);
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    transition: transform $dur ease, box-shadow $dur ease;
 
     &:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+      transform: translateY(-s(1));
+      box-shadow: map-get($shadows, card-hover);
     }
 
     .card__img {
       width: 100%;
-      height: 160px;
-      background: #f5f5f5;
-      border-radius: 0.75rem;
-      margin-bottom: 1rem;
+      height: $featured-card-img-height;
+      background: c(gray-light);
+      border-radius: r(md);
+      margin-bottom: s(4);
     }
 
     .card__title {
-      font-size: 1.25rem;
+      font-size: fs(lg);
       font-weight: 600;
-      margin-bottom: 0.5rem;
-      color: #222;
+      margin-bottom: s(2);
+      color: c(text-strong);
     }
 
     .card__blurb {
-      font-size: 1rem;
-      color: #555;
-      margin-bottom: 1rem;
+      font-size: fs(base);
+      color: c(text-muted);
+      margin-bottom: s(4);
       flex-grow: 1;
     }
 
     .card__link {
-      font-size: 0.95rem;
+      font-size: fs(sm-md);
       font-weight: 500;
-      color: var(--tf-blue, #4B6CB7);
+      color: var(--tf-blue, c(blue));
       text-decoration: none;
       margin-top: auto;
 

--- a/docs/change_logs/20250923_scss_tokens_cleanup.md
+++ b/docs/change_logs/20250923_scss_tokens_cleanup.md
@@ -1,0 +1,4 @@
+# SCSS token cleanup
+
+- Replaced hardcoded color `#000` with token `c(black)` in `.skip-link:focus`.
+- Converted spacing `margin-bottom: 3rem` to `margin-bottom: s(7)` in `.featured .section-title`.


### PR DESCRIPTION
## Summary
- replace hardcoded featured section styles with design tokens
- swap hardcoded skip-link colors and spacing for variables
- add new color, size, and shadow tokens for reused values

## Testing
- `npm test` (fails: Missing script "test")
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a878b37d20832ab1eb629399365653