### PR TITLE
a11y(error): standardize 404/500 section wrappers

### DIFF
--- a/coresite/templates/404.html
+++ b/coresite/templates/404.html
@@ -3,8 +3,8 @@
 {% block title %}Page not found{% endblock %}
 
 {% block content %}
-<section class="error">
-  <h1>Sorry, we can't find that page.</h1>
+<section id="error-404" class="section" role="region" aria-labelledby="error-404-heading">
+  <h1 id="error-404-heading">Sorry, we can't find that page.</h1>
   <p>The page you're looking for doesn't exist. It may have been moved or deleted.</p>
   <p><a href="/">Return home</a></p>
 </section>

--- a/coresite/templates/500.html
+++ b/coresite/templates/500.html
@@ -3,8 +3,8 @@
 {% block title %}Server error{% endblock %}
 
 {% block content %}
-<section class="error">
-  <h1>Something went wrong on our end.</h1>
+<section id="error-500" class="section" role="region" aria-labelledby="error-500-heading">
+  <h1 id="error-500-heading">Something went wrong on our end.</h1>
   <p>We're working to fix the problem. Please try again later.</p>
   <p><a href="/">Return home</a></p>
 </section>

--- a/docs/change_logs/20250822_error_wrappers.md
+++ b/docs/change_logs/20250822_error_wrappers.md
@@ -1,0 +1,4 @@
+# Standardize error page section wrappers
+
+- `coresite/templates/404.html`: replaced `<section class="error">` with `<section id="error-404" class="section" role="region" aria-labelledby="error-404-heading">; the page `<h1>` now carries `id="error-404-heading"`.
+- `coresite/templates/500.html`: replaced `<section class="error">` with `<section id="error-500" class="section" role="region" aria-labelledby="error-500-heading">; the page `<h1>` now carries `id="error-500-heading"`.


### PR DESCRIPTION
## Summary
- wrap 404 and 500 templates with semantic section wrappers linked to their H1 via `aria-labelledby`
- document error template wrapper changes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a898252154832a85136aa78f9ed38e