### PR TITLE
Refactor error pages to use standard section wrapper

### DIFF
--- a/coresite/templates/404.html
+++ b/coresite/templates/404.html
@@ -3,10 +3,12 @@
 {% block title %}Page not found{% endblock %}
 
 {% block content %}
-<section id="error-404" class="section" role="region" aria-labelledby="error-404-heading">
-  <h1 id="error-404-heading">Sorry, we can't find that page.</h1>
-  <p>The page you're looking for doesn't exist. It may have been moved or deleted.</p>
-  <p><a href="/">Return home</a></p>
+<section id="error-section" class="section error" role="region" aria-labelledby="error-heading">
+  <div class="wrap">
+    <h1 id="error-heading">Sorry, we can't find that page.</h1>
+    <p>The page you're looking for doesn't exist. It may have been moved or deleted.</p>
+    <p><a href="/">Return home</a></p>
+  </div>
 </section>
 {% endblock %}
 

--- a/coresite/templates/500.html
+++ b/coresite/templates/500.html
@@ -3,10 +3,12 @@
 {% block title %}Server error{% endblock %}
 
 {% block content %}
-<section id="error-500" class="section" role="region" aria-labelledby="error-500-heading">
-  <h1 id="error-500-heading">Something went wrong on our end.</h1>
-  <p>We're working to fix the problem. Please try again later.</p>
-  <p><a href="/">Return home</a></p>
+<section id="error-section" class="section error" role="region" aria-labelledby="error-heading">
+  <div class="wrap">
+    <h1 id="error-heading">Something went wrong on our end.</h1>
+    <p>We're working to fix the problem. Please try again later.</p>
+    <p><a href="/">Return home</a></p>
+  </div>
 </section>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- refactor 404 and 500 templates to use the global section/heading pattern with `.wrap` container for accessibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a899ca5280832ab5949c44ee5c6cbc