### PR TITLE
Reorganize navigation with placeholder scaffolding

### DIFF
--- a/coresite/templates/coresite/account.html
+++ b/coresite/templates/coresite/account.html
@@ -1,0 +1,15 @@
+{% extends "coresite/base.html" %}
+
+{% block content %}
+<main id="main" role="main">
+  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+    <div class="wrap">
+      <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
+      <div class="scaffold__body">
+        <!-- Empty placeholder container. Content to be built in later passes. -->
+      </div>
+    </div>
+  </section>
+</main>
+{% endblock %}
+

--- a/coresite/templates/coresite/blog.html
+++ b/coresite/templates/coresite/blog.html
@@ -1,0 +1,15 @@
+{% extends "coresite/base.html" %}
+
+{% block content %}
+<main id="main" role="main">
+  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+    <div class="wrap">
+      <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
+      <div class="scaffold__body">
+        <!-- Empty placeholder container. Content to be built in later passes. -->
+      </div>
+    </div>
+  </section>
+</main>
+{% endblock %}
+

--- a/coresite/templates/coresite/community.html
+++ b/coresite/templates/coresite/community.html
@@ -1,0 +1,15 @@
+{% extends "coresite/base.html" %}
+
+{% block content %}
+<main id="main" role="main">
+  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+    <div class="wrap">
+      <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
+      <div class="scaffold__body">
+        <!-- Empty placeholder container. Content to be built in later passes. -->
+      </div>
+    </div>
+  </section>
+</main>
+{% endblock %}
+

--- a/coresite/templates/coresite/knowledge.html
+++ b/coresite/templates/coresite/knowledge.html
@@ -1,0 +1,15 @@
+{% extends "coresite/base.html" %}
+
+{% block content %}
+<main id="main" role="main">
+  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+    <div class="wrap">
+      <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
+      <div class="scaffold__body">
+        <!-- Empty placeholder container. Content to be built in later passes. -->
+      </div>
+    </div>
+  </section>
+</main>
+{% endblock %}
+

--- a/coresite/templates/coresite/partials/global/nav_cta.html
+++ b/coresite/templates/coresite/partials/global/nav_cta.html
@@ -1,1 +1,5 @@
-<a class="btn btn--cta" href="/community/join/" data-analytics-event="cta.nav.join">Join Us</a>
+{% if user.is_authenticated %}
+<a class="btn btn--cta" href="{% url 'account' %}">Account</a>
+{% else %}
+<a class="btn btn--cta" href="{% url 'signup' %}">Sign Up</a>
+{% endif %}

--- a/coresite/templates/coresite/partials/global/nav_links.html
+++ b/coresite/templates/coresite/partials/global/nav_links.html
@@ -1,4 +1,5 @@
 <li><a href="/">Home</a></li>
-<li><a href="{% url 'about' %}">About</a></li>
-<li><a href="{% url 'services' %}">Services</a></li>
-<li><a href="{% url 'contact' %}">Contact</a></li>
+<li><a href="{% url 'knowledge' %}">Knowledge</a></li>
+<li><a href="{% url 'tools' %}">Tools</a></li>
+<li><a href="{% url 'community' %}">Community</a></li>
+<li><a href="{% url 'blog' %}">Blog</a></li>

--- a/coresite/templates/coresite/signup.html
+++ b/coresite/templates/coresite/signup.html
@@ -1,0 +1,15 @@
+{% extends "coresite/base.html" %}
+
+{% block content %}
+<main id="main" role="main">
+  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+    <div class="wrap">
+      <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
+      <div class="scaffold__body">
+        <!-- Empty placeholder container. Content to be built in later passes. -->
+      </div>
+    </div>
+  </section>
+</main>
+{% endblock %}
+

--- a/coresite/templates/coresite/tools.html
+++ b/coresite/templates/coresite/tools.html
@@ -1,0 +1,15 @@
+{% extends "coresite/base.html" %}
+
+{% block content %}
+<main id="main" role="main">
+  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+    <div class="wrap">
+      <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
+      <div class="scaffold__body">
+        <!-- Empty placeholder container. Content to be built in later passes. -->
+      </div>
+    </div>
+  </section>
+</main>
+{% endblock %}
+

--- a/coresite/urls.py
+++ b/coresite/urls.py
@@ -3,6 +3,12 @@ from . import views
 
 urlpatterns = [
     path("", views.homepage, name="home"),
+    path("knowledge/", views.knowledge, name="knowledge"),
+    path("tools/", views.tools, name="tools"),
+    path("community/", views.community, name="community"),
+    path("blog/", views.blog, name="blog"),
+    path("signup/", views.signup, name="signup"),
+    path("account/", views.account, name="account"),
     path("about/", views.about, name="about"),
     path("services/", views.services, name="services"),
     path("contact/", views.contact, name="contact"),

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -70,6 +70,90 @@ def community_join(request):
     return render(request, "coresite/community_join.html", {"footer": footer})
 
 
+def knowledge(request):
+    footer = get_footer_content()
+    return render(
+        request,
+        "coresite/knowledge.html",
+        {
+            "footer": footer,
+            "page_id": "knowledge",
+            "page_title": "Knowledge",
+            "canonical_url": f"{BASE_CANONICAL}/knowledge/",
+        },
+    )
+
+
+def tools(request):
+    footer = get_footer_content()
+    return render(
+        request,
+        "coresite/tools.html",
+        {
+            "footer": footer,
+            "page_id": "tools",
+            "page_title": "Tools",
+            "canonical_url": f"{BASE_CANONICAL}/tools/",
+        },
+    )
+
+
+def community(request):
+    footer = get_footer_content()
+    return render(
+        request,
+        "coresite/community.html",
+        {
+            "footer": footer,
+            "page_id": "community",
+            "page_title": "Community",
+            "canonical_url": f"{BASE_CANONICAL}/community/",
+        },
+    )
+
+
+def blog(request):
+    footer = get_footer_content()
+    return render(
+        request,
+        "coresite/blog.html",
+        {
+            "footer": footer,
+            "page_id": "blog",
+            "page_title": "Blog",
+            "canonical_url": f"{BASE_CANONICAL}/blog/",
+        },
+    )
+
+
+def signup(request):
+    footer = get_footer_content()
+    return render(
+        request,
+        "coresite/signup.html",
+        {
+            "footer": footer,
+            "page_id": "signup",
+            "page_title": "Sign Up",
+            "canonical_url": f"{BASE_CANONICAL}/signup/",
+        },
+    )
+
+
+def account(request):
+    footer = get_footer_content()
+    return render(
+        request,
+        "coresite/account.html",
+        {
+            "footer": footer,
+            "page_id": "account",
+            "page_title": "Account",
+            "canonical_url": f"{BASE_CANONICAL}/account/",
+        },
+    )
+
+
 def about(request):
     footer = get_footer_content()
     return render(


### PR DESCRIPTION
## Summary
- reorganize primary navigation with Knowledge, Tools, Community, Blog, and conditional Signup/Account CTA
- add Django views, URLs, and scaffold templates for new nav-linked pages

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `python -m pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f1ffd6b4832a8c314bae4e24dec1