### PR TITLE
Scaffold case studies and resources pages and toggleable shared footer links

### DIFF
--- a/coresite/templates/coresite/case_studies.html
+++ b/coresite/templates/coresite/case_studies.html
@@ -1,0 +1,11 @@
+{% extends "coresite/base.html" %}
+{% block content %}
+<main id="main" role="main">
+  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+    <div class="wrap">
+      <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
+      <div class="scaffold__body"></div>
+    </div>
+  </section>
+</main>
+{% endblock %}

--- a/coresite/templates/coresite/includes/footer_links.html
+++ b/coresite/templates/coresite/includes/footer_links.html
@@ -1,0 +1,11 @@
+<ul class="footer__links">
+  {% include "coresite/partials/global/nav_links.html" with id_prefix="footer-nav" show_home=False %}
+  {% if user.is_authenticated %}
+    <li><a href="{% url 'account' %}">Account</a></li>
+  {% else %}
+    <li><a href="{% url 'join' %}">Join Free</a></li>
+  {% endif %}
+  <li><a href="{% url 'about' %}">About</a></li>
+  <li><a href="{% url 'contact' %}">Contact</a></li>
+  <li><a href="{% url 'legal' %}">Legal</a></li>
+</ul>

--- a/coresite/templates/coresite/partials/global/footer.html
+++ b/coresite/templates/coresite/partials/global/footer.html
@@ -10,27 +10,31 @@
       {% if footer.intro %}
         <p class="footer__intro">{{ footer.intro }}</p>
       {% endif %}
-      <ul class="footer__links">
-        <li><a href="{% url 'knowledge' %}" data-analytics-event="footer_link_click" data-analytics-label="Knowledge" data-analytics-url="{% url 'knowledge' %}">Knowledge</a></li>
-        <li><a href="{% url 'tools' %}" data-analytics-event="footer_link_click" data-analytics-label="Tools" data-analytics-url="{% url 'tools' %}">Tools</a></li>
-        <li>
+      {% if use_shared_footer_links %}
+        {% include "coresite/includes/footer_links.html" %}
+      {% else %}
+        <ul class="footer__links">
+          <li><a href="{% url 'knowledge' %}" data-analytics-event="footer_link_click" data-analytics-label="Knowledge" data-analytics-url="{% url 'knowledge' %}">Knowledge</a></li>
+          <li><a href="{% url 'tools' %}" data-analytics-event="footer_link_click" data-analytics-label="Tools" data-analytics-url="{% url 'tools' %}">Tools</a></li>
+          <li>
+            {% if user.is_authenticated %}
+              <a href="{% url 'community' %}" data-analytics-event="footer_link_click" data-analytics-label="Community" data-analytics-url="{% url 'community' %}">Community</a>
+            {% else %}
+              <a href="{% url 'join' %}" aria-describedby="footer-community-locked" data-analytics-event="footer_link_click" data-analytics-label="Community" data-analytics-url="{% url 'join' %}">Community</a>
+              <span id="footer-community-locked" class="sr-only">Available after you join.</span>
+            {% endif %}
+          </li>
+          <li><a href="{% url 'blog' %}" data-analytics-event="footer_link_click" data-analytics-label="Blog" data-analytics-url="{% url 'blog' %}">Blog</a></li>
           {% if user.is_authenticated %}
-            <a href="{% url 'community' %}" data-analytics-event="footer_link_click" data-analytics-label="Community" data-analytics-url="{% url 'community' %}">Community</a>
+            <li><a href="{% url 'account' %}" data-analytics-event="footer_link_click" data-analytics-label="Account" data-analytics-url="{% url 'account' %}">Account</a></li>
           {% else %}
-            <a href="{% url 'join' %}" aria-describedby="footer-community-locked" data-analytics-event="footer_link_click" data-analytics-label="Community" data-analytics-url="{% url 'join' %}">Community</a>
-            <span id="footer-community-locked" class="sr-only">Available after you join.</span>
+            <li><a href="{% url 'join' %}" data-analytics-event="footer_link_click" data-analytics-label="Join Free" data-analytics-url="{% url 'join' %}">Join Free</a></li>
           {% endif %}
-        </li>
-        <li><a href="{% url 'blog' %}" data-analytics-event="footer_link_click" data-analytics-label="Blog" data-analytics-url="{% url 'blog' %}">Blog</a></li>
-        {% if user.is_authenticated %}
-          <li><a href="{% url 'account' %}" data-analytics-event="footer_link_click" data-analytics-label="Account" data-analytics-url="{% url 'account' %}">Account</a></li>
-        {% else %}
-          <li><a href="{% url 'join' %}" data-analytics-event="footer_link_click" data-analytics-label="Join Free" data-analytics-url="{% url 'join' %}">Join Free</a></li>
-        {% endif %}
-        <li><a href="{% url 'about' %}" data-analytics-event="footer_link_click" data-analytics-label="About" data-analytics-url="{% url 'about' %}">About</a></li>
-        <li><a href="{% url 'contact' %}" data-analytics-event="footer_link_click" data-analytics-label="Contact" data-analytics-url="{% url 'contact' %}">Contact</a></li>
-        <li><a href="{% url 'legal' %}" data-analytics-event="footer_link_click" data-analytics-label="Legal" data-analytics-url="{% url 'legal' %}">Legal</a></li>
-      </ul>
+          <li><a href="{% url 'about' %}" data-analytics-event="footer_link_click" data-analytics-label="About" data-analytics-url="{% url 'about' %}">About</a></li>
+          <li><a href="{% url 'contact' %}" data-analytics-event="footer_link_click" data-analytics-label="Contact" data-analytics-url="{% url 'contact' %}">Contact</a></li>
+          <li><a href="{% url 'legal' %}" data-analytics-event="footer_link_click" data-analytics-label="Legal" data-analytics-url="{% url 'legal' %}">Legal</a></li>
+        </ul>
+      {% endif %}
     </div>
   </nav>
   {% if footer.meta %}

--- a/coresite/templates/coresite/partials/global/nav_links.html
+++ b/coresite/templates/coresite/partials/global/nav_links.html
@@ -1,5 +1,5 @@
 {% with prefix=id_prefix|default:'nav' %}
-<li><a href="/">Home</a></li>
+{% if show_home|default:True %}<li><a href="/">Home</a></li>{% endif %}
 <li><a href="{% url 'knowledge' %}">Knowledge</a></li>
 <li><a href="{% url 'tools' %}">Tools</a></li>
 <li>

--- a/coresite/templates/coresite/resources.html
+++ b/coresite/templates/coresite/resources.html
@@ -1,0 +1,11 @@
+{% extends "coresite/base.html" %}
+{% block content %}
+<main id="main" role="main">
+  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+    <div class="wrap">
+      <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
+      <div class="scaffold__body"></div>
+    </div>
+  </section>
+</main>
+{% endblock %}

--- a/coresite/urls.py
+++ b/coresite/urls.py
@@ -4,6 +4,8 @@ from . import views
 urlpatterns = [
     path("", views.homepage, name="home"),
     path("knowledge/", views.knowledge, name="knowledge"),
+    path("case-studies/", views.case_studies, name="case_studies"),
+    path("resources/", views.resources, name="resources"),
     path("tools/", views.tools, name="tools"),
     path("community/", views.community, name="community"),
     path("blog/", views.blog, name="blog"),

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -84,6 +84,34 @@ def knowledge(request):
     )
 
 
+def case_studies(request):
+    footer = get_footer_content()
+    return render(
+        request,
+        "coresite/case_studies.html",
+        {
+            "footer": footer,
+            "page_id": "case-studies",
+            "page_title": "Case Studies",
+            "canonical_url": f"{BASE_CANONICAL}/case-studies/",
+        },
+    )
+
+
+def resources(request):
+    footer = get_footer_content()
+    return render(
+        request,
+        "coresite/resources.html",
+        {
+            "footer": footer,
+            "page_id": "resources",
+            "page_title": "Resources",
+            "canonical_url": f"{BASE_CANONICAL}/resources/",
+        },
+    )
+
+
 def tools(request):
     footer = get_footer_content()
     return render(


### PR DESCRIPTION
## Summary
- add minimal placeholder pages for Case Studies and Resources
- add routes and views for new pages
- allow footer to switch to shared nav data via new include, defaulting to existing list
- make nav links reusable in footer by allowing home link to be toggled

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a96646dcc4832a98dd19d00d8aaf29