### PR TITLE
feat: add header offset token and page spacing

### DIFF
--- a/coresite/static/coresite/scss/abstracts/_variables.scss
+++ b/coresite/static/coresite/scss/abstracts/_variables.scss
@@ -26,6 +26,10 @@ $colors: (
 $container-max: 68rem; // ≈1088px target content width
 $container-max-width-wide: 90rem; // ≈1440px wide container
 
+/* Header height */
+$header-h-mobile: 4rem; // 64px
+$header-h-desktop: 5rem; // 80px
+
 /* Featured card dimensions */
 $featured-card-min-width: 17.5rem; // 280px
 $featured-card-img-height: 10rem; // 160px
@@ -153,4 +157,9 @@ $dur: 200ms;
   --easing-standard: #{$easing-standard};
   --dur-fast: #{$dur-fast};
   --dur: #{$dur};
+  --header-h: calc(#{$header-h-mobile} + env(safe-area-inset-top, 0px));
+}
+
+@media (min-width: map-get($bp, md)) {
+  :root { --header-h: calc(#{$header-h-desktop} + env(safe-area-inset-top, 0px)); }
 }

--- a/coresite/static/coresite/scss/base/_utilities.scss
+++ b/coresite/static/coresite/scss/base/_utilities.scss
@@ -1,3 +1,7 @@
+html { scroll-padding-top: var(--header-h); }
+h1, h2, h3, [id] { scroll-margin-top: var(--header-h); }
+body:not(.is-home) main { padding-top: var(--header-h); }
+
 .container { @include container; }
 .container-wide {
   @include container;

--- a/coresite/templates/coresite/base.html
+++ b/coresite/templates/coresite/base.html
@@ -12,7 +12,8 @@
   {% block head_extras %}{% endblock %}
 </head>
 
-<body data-analytics-enabled="{{ ANALYTICS_ENABLED|yesno:'true,false' }}"
+<body {% block body_class %}{% endblock %}
+      data-analytics-enabled="{{ ANALYTICS_ENABLED|yesno:'true,false' }}"
       data-analytics-provider="{{ ANALYTICS_PROVIDER }}"
       data-analytics-site-id="{{ ANALYTICS_SITE_ID }}"
       data-consent-required="{{ CONSENT_REQUIRED|yesno:'true,false' }}">
@@ -24,7 +25,7 @@
 
   {% include 'coresite/partials/global/header_nav.html' %}
 
-  <main id="main">
+  <main id="main" tabindex="-1">
     {# Site-wide notice placeholder — renders nothing by default #}
     {% include 'coresite/partials/global/notice.html' %}
     {% block content %}{% endblock %}

--- a/coresite/templates/coresite/homepage.html
+++ b/coresite/templates/coresite/homepage.html
@@ -1,5 +1,6 @@
 {% extends "coresite/base.html" %}
 {% load static %}
+{% block body_class %}class="is-home"{% endblock %}
 {% block title %}Technofatty Front Page{% endblock %}
 {% block meta_description %}Modern tech resources—fast, accessible, and community-driven.{% endblock %}
 


### PR DESCRIPTION
## Summary
- add header height tokens and CSS variable
- offset inner page content and anchor scrolling using `--header-h`
- tag homepage body and make main focusable for skip link

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a97157436c832a898e5ea932016de6