### PR TITLE
Add Knowledge sub-section scaffolding

### DIFF
--- a/coresite/templates/coresite/knowledge/glossary.html
+++ b/coresite/templates/coresite/knowledge/glossary.html
@@ -1,0 +1,6 @@
+{% extends "coresite/base.html" %}
+
+{% block content %}
+<h1>Glossary</h1>
+<div class="container-wide"></div>
+{% endblock %}

--- a/coresite/templates/coresite/knowledge/guides.html
+++ b/coresite/templates/coresite/knowledge/guides.html
@@ -1,0 +1,6 @@
+{% extends "coresite/base.html" %}
+
+{% block content %}
+<h1>Guides</h1>
+<div class="container-wide"></div>
+{% endblock %}

--- a/coresite/templates/coresite/knowledge/hub.html
+++ b/coresite/templates/coresite/knowledge/hub.html
@@ -5,17 +5,22 @@
   <div class="wrap">
     <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
     <p>Welcome to the Knowledge hub. Explore categories to learn more.</p>
-    <ul class="knowledge__categories">
-      {% for category in categories %}
-      <li>
-        <a href="{% url 'knowledge_category' category.slug %}"
-           data-analytics-event="knowledge_category_click"
-           data-analytics-label="{{ category.title }}"
-           data-analytics-url="{% url 'knowledge_category' category.slug %}">{{ category.title }}</a>
-      </li>
-      {% endfor %}
-    </ul>
-  </div>
-</section>
+      <ul class="knowledge__categories">
+        {% for category in categories %}
+        <li>
+          <a href="{% url 'knowledge_category' category.slug %}"
+             data-analytics-event="knowledge_category_click"
+             data-analytics-label="{{ category.title }}"
+             data-analytics-url="{% url 'knowledge_category' category.slug %}">{{ category.title }}</a>
+        </li>
+        {% endfor %}
+      </ul>
+      <ul class="knowledge__sections">
+        {% for section in sub_sections %}
+        <li><a href="{% url section.url_name %}">{{ section.title }}</a></li>
+        {% endfor %}
+      </ul>
+    </div>
+  </section>
 {% endblock %}
 

--- a/coresite/templates/coresite/knowledge/quick_wins.html
+++ b/coresite/templates/coresite/knowledge/quick_wins.html
@@ -1,0 +1,6 @@
+{% extends "coresite/base.html" %}
+
+{% block content %}
+<h1>Quick Wins</h1>
+<div class="container-wide"></div>
+{% endblock %}

--- a/coresite/templates/coresite/knowledge/signals.html
+++ b/coresite/templates/coresite/knowledge/signals.html
@@ -1,0 +1,6 @@
+{% extends "coresite/base.html" %}
+
+{% block content %}
+<h1>Signals</h1>
+<div class="container-wide"></div>
+{% endblock %}

--- a/coresite/urls.py
+++ b/coresite/urls.py
@@ -4,6 +4,10 @@ from . import views
 urlpatterns = [
     path("", views.homepage, name="home"),
     path("knowledge/", views.knowledge, name="knowledge"),
+    path("knowledge/guides/", views.knowledge_guides, name="knowledge_guides"),
+    path("knowledge/signals/", views.knowledge_signals, name="knowledge_signals"),
+    path("knowledge/glossary/", views.knowledge_glossary, name="knowledge_glossary"),
+    path("knowledge/quick-wins/", views.knowledge_quick_wins, name="knowledge_quick_wins"),
     path(
         "knowledge/<slug:category_slug>/<slug:article_slug>/",
         views.knowledge_article,

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -39,6 +39,14 @@ KNOWLEDGE_ARTICLES = {
 }
 
 
+KNOWLEDGE_SUB_SECTIONS = [
+    {"title": "Guides", "url_name": "knowledge_guides"},
+    {"title": "Signals", "url_name": "knowledge_signals"},
+    {"title": "Glossary", "url_name": "knowledge_glossary"},
+    {"title": "Quick Wins", "url_name": "knowledge_quick_wins"},
+]
+
+
 BLOG_POSTS = [
     {
         "title": "Getting Started with Our Blog",
@@ -164,6 +172,7 @@ def knowledge(request):
         "page_id": "knowledge",
         "page_title": "Knowledge",
         "categories": KNOWLEDGE_CATEGORIES,
+        "sub_sections": KNOWLEDGE_SUB_SECTIONS,
         "canonical_url": f"{BASE_CANONICAL}/knowledge/",
     }
     return render(request, "coresite/knowledge/hub.html", context)
@@ -214,6 +223,50 @@ def knowledge_article(request, category_slug: str, article_slug: str):
         "canonical_url": f"{BASE_CANONICAL}/knowledge/{category_slug}/{article_slug}/",
     }
     return render(request, "coresite/knowledge/article.html", context)
+
+
+def knowledge_guides(request):
+    footer = get_footer_content()
+    context = {
+        "footer": footer,
+        "page_id": "knowledge-guides",
+        "page_title": "Guides",
+        "canonical_url": f"{BASE_CANONICAL}/knowledge/guides/",
+    }
+    return render(request, "coresite/knowledge/guides.html", context)
+
+
+def knowledge_signals(request):
+    footer = get_footer_content()
+    context = {
+        "footer": footer,
+        "page_id": "knowledge-signals",
+        "page_title": "Signals",
+        "canonical_url": f"{BASE_CANONICAL}/knowledge/signals/",
+    }
+    return render(request, "coresite/knowledge/signals.html", context)
+
+
+def knowledge_glossary(request):
+    footer = get_footer_content()
+    context = {
+        "footer": footer,
+        "page_id": "knowledge-glossary",
+        "page_title": "Glossary",
+        "canonical_url": f"{BASE_CANONICAL}/knowledge/glossary/",
+    }
+    return render(request, "coresite/knowledge/glossary.html", context)
+
+
+def knowledge_quick_wins(request):
+    footer = get_footer_content()
+    context = {
+        "footer": footer,
+        "page_id": "knowledge-quick-wins",
+        "page_title": "Quick Wins",
+        "canonical_url": f"{BASE_CANONICAL}/knowledge/quick-wins/",
+    }
+    return render(request, "coresite/knowledge/quick_wins.html", context)
 
 
 def case_studies(request):


### PR DESCRIPTION
## Summary
- Scaffold new Knowledge subsections: Guides, Signals, Glossary, and Quick Wins
- Link Knowledge subsections from landing page
- Add placeholder templates for each subsection

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a978b72b04832ab0c618236150165f