### PR TITLE
Contextual navigation with Resources submenu

### DIFF
--- a/coresite/static/coresite/scss/components/_desktop-nav.scss
+++ b/coresite/static/coresite/scss/components/_desktop-nav.scss
@@ -42,6 +42,37 @@
         border-bottom-color: map-get($colors, gold);
       }
     }
+
+    li {
+      position: relative;
+    }
+
+    .sub-menu {
+      display: none;
+      position: absolute;
+      top: 100%;
+      left: 0;
+      list-style: none;
+      margin: 0;
+      padding: map-get($space, 3) map-get($space, 4);
+      background-color: map-get($colors, white);
+      box-shadow: map-get($shadows, sm);
+    }
+
+    li:focus-within > .sub-menu,
+    li:hover > .sub-menu {
+      display: block;
+    }
+
+    .sub-menu li {
+      margin: 0;
+    }
+
+    .sub-menu a {
+      display: block;
+      padding: map-get($space, 1) 0;
+      white-space: nowrap;
+    }
   }
 
   &__cta {

--- a/coresite/static/coresite/scss/components/_menu-overlay.scss
+++ b/coresite/static/coresite/scss/components/_menu-overlay.scss
@@ -71,6 +71,16 @@ $overlay-bg: rgba(map-get($colors, blue), 0.9);
         color: map-get($colors, gold);
       }
     }
+
+    .sub-menu {
+      list-style: none;
+      margin: map-get($space, 2) 0 0;
+      padding-left: map-get($space, 4);
+    }
+
+    .sub-menu li {
+      margin-bottom: map-get($space, 2);
+    }
   }
 }
 

--- a/coresite/templates/coresite/partials/global/nav_links.html
+++ b/coresite/templates/coresite/partials/global/nav_links.html
@@ -1,5 +1,6 @@
 {% with prefix=id_prefix|default:'nav' %}
-{% if show_home|default:True %}
+{% if show_home|default:None != None %}
+{% if show_home %}
 <li><a href="/" data-analytics-event="nav_link_click" data-analytics-label="Home" data-analytics-url="/">Home</a></li>
 {% endif %}
 <li><a href="{% url 'knowledge' %}" data-analytics-event="nav_link_click" data-analytics-label="Knowledge" data-analytics-url="{% url 'knowledge' %}">Knowledge</a></li>
@@ -14,4 +15,37 @@
   {% endif %}
 </li>
 <li><a href="{% url 'blog' %}" data-analytics-event="nav_link_click" data-analytics-label="Blog" data-analytics-url="{% url 'blog' %}">Blog</a></li>
+{% elif request.resolver_match.url_name == 'home' %}
+<li><a href="{% url 'knowledge' %}" data-analytics-event="nav_link_click" data-analytics-label="Knowledge" data-analytics-url="{% url 'knowledge' %}">Knowledge</a></li>
+<li><a href="{% url 'tools' %}" data-analytics-event="nav_link_click" data-analytics-label="Tools" data-analytics-url="{% url 'tools' %}">Tools</a></li>
+<li><a href="{% url 'case_studies_landing' %}" data-analytics-event="nav_link_click" data-analytics-label="Case Studies" data-analytics-url="{% url 'case_studies_landing' %}">Case Studies</a></li>
+<li>
+  {% if user.is_authenticated %}
+    <a href="{% url 'community' %}" data-analytics-event="nav_link_click" data-analytics-label="Community" data-analytics-url="{% url 'community' %}">Community</a>
+  {% else %}
+    <a href="{% url 'join' %}" aria-describedby="{{ prefix }}-community-locked" data-analytics-event="nav_link_click" data-analytics-label="Community" data-analytics-url="{% url 'join' %}">Community</a>
+    <span id="{{ prefix }}-community-locked" class="sr-only">Available after you join.</span>
+  {% endif %}
+</li>
+<li><a href="{% url 'blog' %}" data-analytics-event="nav_link_click" data-analytics-label="Blog" data-analytics-url="{% url 'blog' %}">Blog</a></li>
+{% else %}
+<li><a href="/" data-analytics-event="nav_link_click" data-analytics-label="Home" data-analytics-url="/">Home</a></li>
+<li><a href="{% url 'knowledge' %}" data-analytics-event="nav_link_click" data-analytics-label="Knowledge" data-analytics-url="{% url 'knowledge' %}">Knowledge</a></li>
+<li class="has-submenu">
+  <a href="{% url 'resources' %}" data-analytics-event="nav_link_click" data-analytics-label="Resources" data-analytics-url="{% url 'resources' %}" aria-haspopup="true">Resources</a>
+  <ul class="sub-menu">
+    <li><a href="{% url 'tools' %}" data-analytics-event="nav_link_click" data-analytics-label="Tools" data-analytics-url="{% url 'tools' %}">Tools</a></li>
+    <li><a href="{% url 'case_studies_landing' %}" data-analytics-event="nav_link_click" data-analytics-label="Case Studies" data-analytics-url="{% url 'case_studies_landing' %}">Case Studies</a></li>
+  </ul>
+</li>
+<li>
+  {% if user.is_authenticated %}
+    <a href="{% url 'community' %}" data-analytics-event="nav_link_click" data-analytics-label="Community" data-analytics-url="{% url 'community' %}">Community</a>
+  {% else %}
+    <a href="{% url 'join' %}" aria-describedby="{{ prefix }}-community-locked" data-analytics-event="nav_link_click" data-analytics-label="Community" data-analytics-url="{% url 'join' %}">Community</a>
+    <span id="{{ prefix }}-community-locked" class="sr-only">Available after you join.</span>
+  {% endif %}
+</li>
+<li><a href="{% url 'blog' %}" data-analytics-event="nav_link_click" data-analytics-label="Blog" data-analytics-url="{% url 'blog' %}">Blog</a></li>
+{% endif %}
 {% endwith %}


### PR DESCRIPTION
## Summary
- Switch header nav based on page context to feature pillars on home and compact links on inner pages
- Add Resources menu grouping Tools and Case Studies with accessible hover/focus styles and mobile drawer support

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68a9813dc7f4832aab4047f9396c3b86