### PR TITLE
Scaffold community page layout

### DIFF
--- a/coresite/templates/coresite/community.html
+++ b/coresite/templates/coresite/community.html
@@ -2,12 +2,27 @@
 
 {% block content %}
 <main id="main" role="main">
-  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+  <section class="section section--community" role="region" aria-labelledby="{{ page_id }}-heading" data-section="community">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
-      <div class="scaffold__body">
-        <!-- Empty placeholder container. Content to be built in later passes. -->
+      <p class="community__intro">Get updates, tools, and early access while we’re building.</p>
+
+      <div class="community__actions">
+        <a class="btn btn--cta community__cta" href="/community/join/" data-analytics-event="cta.community.primary">Join Us</a>
       </div>
+
+      <div class="community__grid">
+        <a id="community-newsletter" class="community__card" href="#signup" aria-describedby="community-desc-newsletter">
+          <span class="community__label">Newsletter</span>
+          <p id="community-desc-newsletter" class="community__description">Placeholder description</p>
+        </a>
+        <a id="community-updates" class="community__card" href="/support/updates/" aria-describedby="community-desc-updates">
+          <span class="community__label">Product Updates</span>
+          <p id="community-desc-updates" class="community__description">Placeholder description</p>
+        </a>
+      </div>
+
+      <div class="community__status" aria-live="polite"></div>
     </div>
   </section>
 </main>


### PR DESCRIPTION
## Summary
- build first-draft Community page scaffold with intro text, Join Us CTA, sub-link cards, and status placeholder

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a997b1408c832a8476ac915d1a5f20