### PR TITLE
Fix analytics consent condition syntax

### DIFF
--- a/coresite/templates/coresite/partials/global/analytics.html
+++ b/coresite/templates/coresite/partials/global/analytics.html
@@ -1,4 +1,4 @@
-{% if (not CONSENT_REQUIRED) or request.COOKIES.analytics_consent == 'true' %}
+{% if not CONSENT_REQUIRED or request.COOKIES.analytics_consent == 'true' %}
   {% if ANALYTICS_PROVIDER == 'plausible' and ANALYTICS_SITE_ID %}
     <script defer data-domain="{{ ANALYTICS_SITE_ID }}" src="https://plausible.io/js/script.js"></script>
   {% elif ANALYTICS_PROVIDER == 'ga4' and ANALYTICS_SITE_ID %}


### PR DESCRIPTION
## Summary
- fix analytics template syntax by removing redundant parentheses

## Testing
- `python manage.py compilescss` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bc84c070832a82830c4dfb9e1cea