### PR TITLE
Add reusable status placeholder and styling

### DIFF
--- a/coresite/static/coresite/js/main.js
+++ b/coresite/static/coresite/js/main.js
@@ -3,6 +3,15 @@ document.addEventListener('DOMContentLoaded', function () {
   const hamburgerBtn = document.querySelector('.hamburger-btn');
   const closeBtn = document.querySelector('.menu-overlay__close');
   const backdrop = document.querySelector('.menu-backdrop');
+  const siteStatus = document.getElementById('site-status');
+
+  window.setStatusMessage = (message, state) => {
+    if (!siteStatus) return;
+    siteStatus.textContent = message || '';
+    siteStatus.className = 'status-placeholder';
+    if (state) siteStatus.classList.add(`status-placeholder--${state}`);
+  };
+
   const focusableSelectors = 'a, button';
   let firstFocusable = null;
   let lastFocusable = null;

--- a/coresite/static/coresite/scss/components/_status.scss
+++ b/coresite/static/coresite/scss/components/_status.scss
@@ -1,0 +1,10 @@
+/* Status placeholder for dynamic messages */
+.status-placeholder {
+  min-height: fs(sm);
+  margin-top: s(2);
+  color: c(text-muted);
+}
+
+.status-placeholder--success { color: c(green); }
+.status-placeholder--error { color: c(magenta); }
+

--- a/coresite/static/coresite/scss/main.scss
+++ b/coresite/static/coresite/scss/main.scss
@@ -19,6 +19,7 @@
 @import 'components/hamburger';
 @import 'components/menu-overlay';
 @import 'components/desktop-nav';
+@import 'components/status';
 
 // Layout
 @import "layout/grid";

--- a/coresite/templates/coresite/account.html
+++ b/coresite/templates/coresite/account.html
@@ -6,6 +6,7 @@
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
       <div class="scaffold__body">
+          {% include "coresite/partials/global/status_placeholder.html" %}
         <!-- Empty placeholder container. Content to be built in later passes. -->
       </div>
     </div>

--- a/coresite/templates/coresite/blog.html
+++ b/coresite/templates/coresite/blog.html
@@ -7,6 +7,7 @@
       <h1 id="{{ page_id }}-heading"><a href="{% url 'blog' %}">{{ page_title }}</a></h1>
         <a href="{% url 'blog_rss' %}">RSS</a>
         <div class="scaffold__body">
+          {% include "coresite/partials/global/status_placeholder.html" %}
           <p>Latest news and insights from Technofatty.</p>
           <div class="blog-layout">
             <div class="blog-layout__main">

--- a/coresite/templates/coresite/blog_category.html
+++ b/coresite/templates/coresite/blog_category.html
@@ -5,6 +5,7 @@
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
       <div class="scaffold__body">
+          {% include "coresite/partials/global/status_placeholder.html" %}
         <p><a href="{% url 'blog' %}">Back to Blog</a></p>
         <ul class="post-list">
           {% for post in posts %}

--- a/coresite/templates/coresite/blog_detail.html
+++ b/coresite/templates/coresite/blog_detail.html
@@ -4,6 +4,7 @@
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
         <div class="scaffold__body">
+          {% include "coresite/partials/global/status_placeholder.html" %}
           <p class="back-link"><a href="{% url 'blog' %}">← Back to Blog</a></p>
           <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
           <p class="post-meta">

--- a/coresite/templates/coresite/blog_rss.html
+++ b/coresite/templates/coresite/blog_rss.html
@@ -5,6 +5,7 @@
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
       <div class="scaffold__body">
+          {% include "coresite/partials/global/status_placeholder.html" %}
         <p>RSS feed coming soon.</p>
       </div>
     </div>

--- a/coresite/templates/coresite/blog_tag.html
+++ b/coresite/templates/coresite/blog_tag.html
@@ -5,6 +5,7 @@
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
       <div class="scaffold__body">
+          {% include "coresite/partials/global/status_placeholder.html" %}
         <p><a href="{% url 'blog' %}">Back to Blog</a></p>
         <ul class="post-list">
           {% for post in posts %}

--- a/coresite/templates/coresite/case_studies/detail.html
+++ b/coresite/templates/coresite/case_studies/detail.html
@@ -2,5 +2,7 @@
 
 {% block content %}
 <h1>Case Study Title</h1>
+{% include "coresite/partials/global/status_placeholder.html" %}
+
 <div class="container content"></div>
 {% endblock %}

--- a/coresite/templates/coresite/case_studies/landing.html
+++ b/coresite/templates/coresite/case_studies/landing.html
@@ -2,5 +2,7 @@
 
 {% block content %}
 <h1>Case Studies</h1>
+{% include "coresite/partials/global/status_placeholder.html" %}
+
 <div class="container content"></div>
 {% endblock %}

--- a/coresite/templates/coresite/join.html
+++ b/coresite/templates/coresite/join.html
@@ -5,7 +5,9 @@
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
-      <div class="scaffold__body"></div>
+      <div class="scaffold__body">
+          {% include "coresite/partials/global/status_placeholder.html" %}
+        </div>
     </div>
   </section>
 </main>

--- a/coresite/templates/coresite/knowledge/article.html
+++ b/coresite/templates/coresite/knowledge/article.html
@@ -4,6 +4,8 @@
 <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
   <div class="wrap">
     <h1 id="{{ page_id }}-heading">{{ article.title }}</h1>
+    {% include "coresite/partials/global/status_placeholder.html" %}
+    
     <div class="knowledge__article-body">
       <!-- Future article content goes here -->
     </div>

--- a/coresite/templates/coresite/knowledge/category.html
+++ b/coresite/templates/coresite/knowledge/category.html
@@ -4,6 +4,8 @@
 <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
   <div class="wrap">
     <h1 id="{{ page_id }}-heading">{{ category.title }}</h1>
+    {% include "coresite/partials/global/status_placeholder.html" %}
+    
     <div class="knowledge__articles">
       {% for article in articles %}
       <article class="knowledge__teaser">

--- a/coresite/templates/coresite/knowledge/glossary.html
+++ b/coresite/templates/coresite/knowledge/glossary.html
@@ -2,5 +2,7 @@
 
 {% block content %}
 <h1>Glossary</h1>
+{% include "coresite/partials/global/status_placeholder.html" %}
+
 <div class="container-wide"></div>
 {% endblock %}

--- a/coresite/templates/coresite/knowledge/guides.html
+++ b/coresite/templates/coresite/knowledge/guides.html
@@ -2,5 +2,8 @@
 
 {% block content %}
 <h1>Guides</h1>
+{% include "coresite/partials/global/status_placeholder.html" %}
+
+
 <div class="container-wide"></div>
 {% endblock %}

--- a/coresite/templates/coresite/knowledge/hub.html
+++ b/coresite/templates/coresite/knowledge/hub.html
@@ -4,6 +4,8 @@
 <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
   <div class="wrap">
     <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
+    {% include "coresite/partials/global/status_placeholder.html" %}
+    
     <p>Welcome to the Knowledge hub. Explore categories to learn more.</p>
       <ul class="knowledge__categories">
         {% for category in categories %}

--- a/coresite/templates/coresite/knowledge/quick_wins.html
+++ b/coresite/templates/coresite/knowledge/quick_wins.html
@@ -2,5 +2,7 @@
 
 {% block content %}
 <h1>Quick Wins</h1>
+{% include "coresite/partials/global/status_placeholder.html" %}
+
 <div class="container-wide"></div>
 {% endblock %}

--- a/coresite/templates/coresite/knowledge/signals.html
+++ b/coresite/templates/coresite/knowledge/signals.html
@@ -2,5 +2,7 @@
 
 {% block content %}
 <h1>Signals</h1>
+{% include "coresite/partials/global/status_placeholder.html" %}
+
 <div class="container-wide"></div>
 {% endblock %}

--- a/coresite/templates/coresite/partials/global/status_placeholder.html
+++ b/coresite/templates/coresite/partials/global/status_placeholder.html
@@ -1,0 +1,2 @@
+<div id="site-status" class="status-placeholder" role="status" aria-live="polite" aria-atomic="true"></div>
+

--- a/coresite/templates/coresite/resources.html
+++ b/coresite/templates/coresite/resources.html
@@ -4,7 +4,9 @@
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
-      <div class="scaffold__body"></div>
+      <div class="scaffold__body">
+          {% include "coresite/partials/global/status_placeholder.html" %}
+        </div>
     </div>
   </section>
 </main>

--- a/coresite/templates/coresite/signup.html
+++ b/coresite/templates/coresite/signup.html
@@ -6,6 +6,7 @@
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
       <div class="scaffold__body">
+          {% include "coresite/partials/global/status_placeholder.html" %}
         <!-- Empty placeholder container. Content to be built in later passes. -->
       </div>
     </div>

--- a/coresite/templates/coresite/tools.html
+++ b/coresite/templates/coresite/tools.html
@@ -6,6 +6,7 @@
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
       <div class="scaffold__body">
+          {% include "coresite/partials/global/status_placeholder.html" %}
         <!-- Empty placeholder container. Content to be built in later passes. -->
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add global status placeholder partial for dynamic messages
- include status snippet in blog, knowledge, and scaffold templates
- style status area and expose JS helper for consistent updates

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a9c108ccf8832ab02bac5c5cc81f61