### PR TITLE
Align Case Studies landing with site scaffold

### DIFF
--- a/coresite/templates/coresite/case_studies/landing.html
+++ b/coresite/templates/coresite/case_studies/landing.html
@@ -1,8 +1,14 @@
 {% extends "coresite/base.html" %}
 
 {% block content %}
-<h1>Case Studies</h1>
-{% include "coresite/partials/global/status_placeholder.html" %}
-
-<div class="container content"></div>
+<main id="main" role="main">
+  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+    <div class="wrap">
+      <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
+      <div class="scaffold__body">
+        {% include "coresite/partials/global/status_placeholder.html" %}
+      </div>
+    </div>
+  </section>
+</main>
 {% endblock %}


### PR DESCRIPTION
## Summary
- align `/case-studies/` landing page with the standard scaffold and base template
- provide `<main>` region labelled by the page heading and an empty scaffold body for future content

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: 403 Client Error: Forbidden for url)*

## QA
- Screenshots not generated due to missing Django/npm dependencies; please run locally to capture desktop and mobile views.
- Confirm there is a single `<h1>` and the skip link targets `#main` with content starting below the sticky header.
- Diff summary:
  - `coresite/templates/coresite/case_studies/landing.html`


------
https://chatgpt.com/codex/tasks/task_e_68a9caea46c4832a90a5d3c56bb25984