### PR TITLE
Add status placeholder to community template

### DIFF
--- a/coresite/templates/coresite/community.html
+++ b/coresite/templates/coresite/community.html
@@ -6,6 +6,7 @@
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
       <div class="scaffold__body">
+        {% include "coresite/partials/global/status_placeholder.html" %}
         <!-- Empty placeholder container. Content to be built in later passes. -->
       </div>
     </div>


### PR DESCRIPTION
## Summary
- include global status placeholder in community scaffold

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a9cf9ea8a4832a8900d6c587c5a20b