### PR TITLE
Add global status placeholders to legacy pages

### DIFF
--- a/coresite/templates/coresite/about.html
+++ b/coresite/templates/coresite/about.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block content %}
-<section id="about-hero" class="section" role="region" aria-labelledby="about-hero-heading">
+<section id="about-hero" class="section section--scaffold" role="region" aria-labelledby="about-hero-heading">
   <div class="wrap">
     {% include "coresite/partials/about/about-hero.html" %}
   </div>

--- a/coresite/templates/coresite/community_join.html
+++ b/coresite/templates/coresite/community_join.html
@@ -4,29 +4,32 @@
 {% block meta_description %}Join the Technofatty community for updates, tools, and early access while we’re building.{% endblock %}
 
 {% block content %}
-<section class="section" role="region" aria-labelledby="community-join-heading" data-section="community-join">
+<section class="section section--scaffold" role="region" aria-labelledby="community-join-heading" data-section="community-join">
   <div class="wrap">
     <h1 id="community-join-heading">Join the Community</h1>
-    <p>We’re building in stealth. Here are the best ways to plug in right now.</p>
+    <div class="scaffold__body">
+      {% include "coresite/partials/global/status_placeholder.html" %}
+      <p>We’re building in stealth. Here are the best ways to plug in right now.</p>
 
-    <div class="cards" style="margin-top: var(--space-3);">
-      <article class="card">
-        <h2 class="card__title">Newsletter</h2>
-        <p class="card__blurb">Short, useful AI tips every Friday. No fluff.</p>
-        <a class="card__link" href="/#signup">Subscribe</a>
-      </article>
+      <div class="cards" style="margin-top: var(--space-3);">
+        <article class="card">
+          <h2 class="card__title">Newsletter</h2>
+          <p class="card__blurb">Short, useful AI tips every Friday. No fluff.</p>
+          <a class="card__link" href="/#signup">Subscribe</a>
+        </article>
 
-      <article class="card">
-        <h2 class="card__title">Product updates</h2>
-        <p class="card__blurb">What’s new, fixed, and improved as we ship.</p>
-        <a class="card__link" href="/support/updates/">View updates</a>
-      </article>
+        <article class="card">
+          <h2 class="card__title">Product updates</h2>
+          <p class="card__blurb">What’s new, fixed, and improved as we ship.</p>
+          <a class="card__link" href="/support/updates/">View updates</a>
+        </article>
 
-      <article class="card">
-        <h2 class="card__title">Say hello</h2>
-        <p class="card__blurb">Got feedback or want to collaborate? We’re listening.</p>
-        <a class="card__link" href="/contact/">Contact us</a>
-      </article>
+        <article class="card">
+          <h2 class="card__title">Say hello</h2>
+          <p class="card__blurb">Got feedback or want to collaborate? We’re listening.</p>
+          <a class="card__link" href="/contact/">Contact us</a>
+        </article>
+      </div>
     </div>
   </div>
 </section>

--- a/coresite/templates/coresite/contact.html
+++ b/coresite/templates/coresite/contact.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block content %}
-<section id="contact-intro" class="section" role="region" aria-labelledby="contact-intro-heading">
+<section id="contact-intro" class="section section--scaffold" role="region" aria-labelledby="contact-intro-heading">
   <div class="wrap">
     {% include "coresite/partials/contact/contact-intro.html" %}
   </div>

--- a/coresite/templates/coresite/legal.html
+++ b/coresite/templates/coresite/legal.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block content %}
-<section id="legal-intro" class="section" role="region" aria-labelledby="legal-intro-heading">
+<section id="legal-intro" class="section section--scaffold" role="region" aria-labelledby="legal-intro-heading">
   <div class="wrap">
     {% include "coresite/partials/legal/legal-intro.html" %}
   </div>

--- a/coresite/templates/coresite/partials/about/about-hero.html
+++ b/coresite/templates/coresite/partials/about/about-hero.html
@@ -1,3 +1,6 @@
 <h1 class="visually-hidden" id="about-page-heading">About</h1>
-<h2 id="about-hero-heading">Engineering nutrition for modern life [ref:mission]</h2>
-<p>We turn complex fat science into everyday guidance so healthier choices feel natural [ref:vision].</p>
+<div class="scaffold__body">
+  {% include "coresite/partials/global/status_placeholder.html" %}
+  <h2 id="about-hero-heading">Engineering nutrition for modern life [ref:mission]</h2>
+  <p>We turn complex fat science into everyday guidance so healthier choices feel natural [ref:vision].</p>
+</div>

--- a/coresite/templates/coresite/partials/contact/contact-intro.html
+++ b/coresite/templates/coresite/partials/contact/contact-intro.html
@@ -1,3 +1,6 @@
 <h1 class="visually-hidden" id="contact-page-heading">Contact</h1>
-<h2 id="contact-intro-heading">Get in touch</h2>
-<p>Technofatty welcomes questions or proposals through the channels below [ref:general].</p>
+<div class="scaffold__body">
+  {% include "coresite/partials/global/status_placeholder.html" %}
+  <h2 id="contact-intro-heading">Get in touch</h2>
+  <p>Technofatty welcomes questions or proposals through the channels below [ref:general].</p>
+</div>

--- a/coresite/templates/coresite/partials/hero.html
+++ b/coresite/templates/coresite/partials/hero.html
@@ -77,10 +77,13 @@
 
     <div class="wrap container-wide">
       <h1>Turn AI into Your Competitive Edge</h1>
-      <p class="hero__sub">
-        Technofatty is your hub for AI strategies, tools, and case studies that grow your bottom line.
-      </p>
-      <a class="btn btn--primary" href="#signup" data-analytics-event="cta.hero.signup">Get AI Growth Tips</a>
+      <div class="scaffold__body">
+        {% include "coresite/partials/global/status_placeholder.html" %}
+        <p class="hero__sub">
+          Technofatty is your hub for AI strategies, tools, and case studies that grow your bottom line.
+        </p>
+        <a class="btn btn--primary" href="#signup" data-analytics-event="cta.hero.signup">Get AI Growth Tips</a>
+      </div>
     </div>
   </div>
 </section>

--- a/coresite/templates/coresite/partials/legal/legal-intro.html
+++ b/coresite/templates/coresite/partials/legal/legal-intro.html
@@ -1,7 +1,10 @@
 <h1 class="visually-hidden" id="legal-page-heading">Legal</h1>
-<h2 id="legal-intro-heading">Legal Overview</h2>
-<p>This page summarizes Technofatty's legal terms and policies.
-  It outlines commitments that govern our services. [ref:intro]</p>
-<p>Information here is general and not a substitute for medical or
-  legal advice. Consult qualified professionals for guidance on your
-  situation. [ref:intro]</p>
+<div class="scaffold__body">
+  {% include "coresite/partials/global/status_placeholder.html" %}
+  <h2 id="legal-intro-heading">Legal Overview</h2>
+  <p>This page summarizes Technofatty's legal terms and policies.
+    It outlines commitments that govern our services. [ref:intro]</p>
+  <p>Information here is general and not a substitute for medical or
+    legal advice. Consult qualified professionals for guidance on your
+    situation. [ref:intro]</p>
+</div>

--- a/coresite/templates/coresite/partials/support/support-intro.html
+++ b/coresite/templates/coresite/partials/support/support-intro.html
@@ -1,6 +1,9 @@
 <h1 class="visually-hidden" id="support-page-heading">Support</h1>
-<h2 id="support-intro-heading">Start here</h2>
-<p>This page centralizes help for Technofatty users managing their account or
-product questions [ref:intro].</p>
-<p>Browse the sections below to find FAQs, guides, and contact options
-[ref:intro].</p>
+<div class="scaffold__body">
+  {% include "coresite/partials/global/status_placeholder.html" %}
+  <h2 id="support-intro-heading">Start here</h2>
+  <p>This page centralizes help for Technofatty users managing their account or
+  product questions [ref:intro].</p>
+  <p>Browse the sections below to find FAQs, guides, and contact options
+  [ref:intro].</p>
+</div>

--- a/coresite/templates/coresite/support.html
+++ b/coresite/templates/coresite/support.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block content %}
-<section id="support-intro" class="section" role="region" aria-labelledby="support-intro-heading">
+<section id="support-intro" class="section section--scaffold" role="region" aria-labelledby="support-intro-heading">
   <div class="wrap">
     {% include "coresite/partials/support/support-intro.html" %}
   </div>


### PR DESCRIPTION
## Summary
- reserve global status area on legacy About, Contact, Legal, Support, and Community Join pages
- wire homepage hero into shared status placeholder
- align top sections with scaffold class for consistent layout

## Testing
- `python -m pytest`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68a9d757b024832aadb1af8b0f84e4cf