### PR TITLE
Add minimal RSS feed for blog

### DIFF
--- a/coresite/static/coresite/scss/main.css
+++ b/coresite/static/coresite/scss/main.css
@@ -9696,6 +9696,23 @@ img {
 /* ===============================
    Blog page layout
    =============================== */
+.scaffold__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.rss-link {
+  font-size: 0.875rem;
+  color: #555555;
+  text-decoration: none;
+  margin-left: 0.5rem;
+}
+.rss-link:hover,
+.rss-link:focus {
+  text-decoration: underline;
+}
 .blog-layout {
   display: flex;
   flex-direction: column;

--- a/coresite/static/coresite/scss/pages/_blog.scss
+++ b/coresite/static/coresite/scss/pages/_blog.scss
@@ -2,6 +2,25 @@
    Blog page layout
    =============================== */
 
+.scaffold__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: s(3);
+}
+
+.rss-link {
+  font-size: fs(sm);
+  color: c(text-muted);
+  text-decoration: none;
+  margin-left: s(2);
+
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+  }
+}
+
 .blog-layout {
   display: flex;
   flex-direction: column;

--- a/coresite/templates/coresite/blog.html
+++ b/coresite/templates/coresite/blog.html
@@ -4,9 +4,11 @@
 <main id="main" role="main">
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
-      <h1 id="{{ page_id }}-heading"><a href="{% url 'blog' %}">{{ page_title }}</a></h1>
-        <a href="{% url 'blog_rss' %}">RSS</a>
-        <div class="scaffold__body">
+      <div class="scaffold__header">
+        <h1 id="{{ page_id }}-heading"><a href="{% url 'blog' %}">{{ page_title }}</a></h1>
+        <a class="rss-link" href="{% url 'blog_rss' %}">RSS</a>
+      </div>
+      <div class="scaffold__body">
           {% include "coresite/partials/global/status_placeholder.html" %}
           <p>Latest news and insights from Technofatty.</p>
           <div class="blog-layout">

--- a/coresite/tests.py
+++ b/coresite/tests.py
@@ -1,3 +1,13 @@
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+
+class BlogRssTests(TestCase):
+    def test_rss_feed_endpoint(self):
+        response = self.client.get(reverse("blog_rss"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response["Content-Type"], "application/rss+xml; charset=utf-8"
+        )
+        self.assertIn(b"<rss", response.content)
+        self.assertIn(b"<channel>", response.content)


### PR DESCRIPTION
## Summary
- expose `/blog/rss/` endpoint emitting RSS 2.0 feed with recent posts
- add small “RSS” link beside Blog heading
- style blog RSS link using design tokens and add basic test

## Testing
- ⚠️ `python3 manage.py test` *(missing Django dependency: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a9db0913a8832a873f58ae3921321e