### PR TITLE
Remove nested main wrappers from templates

### DIFF
--- a/coresite/templates/coresite/account.html
+++ b/coresite/templates/coresite/account.html
@@ -1,7 +1,6 @@
 {% extends "coresite/base.html" %}
 
 {% block content %}
-<main id="main" role="main">
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
@@ -11,6 +10,5 @@
       </div>
     </div>
   </section>
-</main>
 {% endblock %}
 

--- a/coresite/templates/coresite/blog.html
+++ b/coresite/templates/coresite/blog.html
@@ -1,7 +1,6 @@
 {% extends "coresite/base.html" %}
 
 {% block content %}
-<main id="main" role="main">
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <div class="scaffold__header">
@@ -58,6 +57,5 @@
         </div>
       </div>
     </section>
-  </main>
   {% endblock %}
 

--- a/coresite/templates/coresite/blog_category.html
+++ b/coresite/templates/coresite/blog_category.html
@@ -1,6 +1,5 @@
 {% extends "coresite/base.html" %}
 {% block content %}
-<main id="main" role="main">
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
@@ -28,5 +27,4 @@
       </div>
     </div>
   </section>
-</main>
 {% endblock %}

--- a/coresite/templates/coresite/blog_detail.html
+++ b/coresite/templates/coresite/blog_detail.html
@@ -1,6 +1,5 @@
 {% extends "coresite/base.html" %}
 {% block content %}
-<main id="main" role="main">
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
         <div class="scaffold__body">
@@ -18,5 +17,4 @@
         </div>
       </div>
     </section>
-  </main>
   {% endblock %}

--- a/coresite/templates/coresite/blog_rss.html
+++ b/coresite/templates/coresite/blog_rss.html
@@ -1,6 +1,5 @@
 {% extends "coresite/base.html" %}
 {% block content %}
-<main id="main" role="main">
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
@@ -10,5 +9,4 @@
       </div>
     </div>
   </section>
-</main>
 {% endblock %}

--- a/coresite/templates/coresite/blog_tag.html
+++ b/coresite/templates/coresite/blog_tag.html
@@ -1,6 +1,5 @@
 {% extends "coresite/base.html" %}
 {% block content %}
-<main id="main" role="main">
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
@@ -28,5 +27,4 @@
       </div>
     </div>
   </section>
-</main>
 {% endblock %}

--- a/coresite/templates/coresite/case_studies/landing.html
+++ b/coresite/templates/coresite/case_studies/landing.html
@@ -1,7 +1,6 @@
 {% extends "coresite/base.html" %}
 
 {% block content %}
-<main id="main" role="main">
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
@@ -10,5 +9,4 @@
       </div>
     </div>
   </section>
-</main>
 {% endblock %}

--- a/coresite/templates/coresite/community.html
+++ b/coresite/templates/coresite/community.html
@@ -1,7 +1,6 @@
 {% extends "coresite/base.html" %}
 
 {% block content %}
-<main id="main" role="main">
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
@@ -11,6 +10,5 @@
       </div>
     </div>
   </section>
-</main>
 {% endblock %}
 

--- a/coresite/templates/coresite/join.html
+++ b/coresite/templates/coresite/join.html
@@ -1,7 +1,6 @@
 {% extends "coresite/base.html" %}
 
 {% block content %}
-<main id="main" role="main">
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
@@ -10,5 +9,4 @@
         </div>
     </div>
   </section>
-</main>
 {% endblock %}

--- a/coresite/templates/coresite/resources.html
+++ b/coresite/templates/coresite/resources.html
@@ -1,6 +1,5 @@
 {% extends "coresite/base.html" %}
 {% block content %}
-<main id="main" role="main">
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
@@ -9,5 +8,4 @@
         </div>
     </div>
   </section>
-</main>
 {% endblock %}

--- a/coresite/templates/coresite/signup.html
+++ b/coresite/templates/coresite/signup.html
@@ -1,7 +1,6 @@
 {% extends "coresite/base.html" %}
 
 {% block content %}
-<main id="main" role="main">
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
@@ -11,6 +10,5 @@
       </div>
     </div>
   </section>
-</main>
 {% endblock %}
 

--- a/coresite/templates/coresite/tools.html
+++ b/coresite/templates/coresite/tools.html
@@ -1,7 +1,6 @@
 {% extends "coresite/base.html" %}
 
 {% block content %}
-<main id="main" role="main">
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
@@ -11,6 +10,5 @@
       </div>
     </div>
   </section>
-</main>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Drop redundant `<main>` elements so interior pages rely on the base layout's canonical `<main>` for spacing and skip-link targets
- Update blog, community, resources, account, case study landing, join, signup, and related templates to render only the scaffold section

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dd49d434832a840617ccb7b2f7f9