### PR TITLE
Knowledge hub page uses scaffold body layout

### DIFF
--- a/coresite/templates/coresite/knowledge/hub.html
+++ b/coresite/templates/coresite/knowledge/hub.html
@@ -5,8 +5,8 @@
   <div class="wrap">
     <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
     {% include "coresite/partials/global/status_placeholder.html" %}
-    
-    <p>Welcome to the Knowledge hub. Explore categories to learn more.</p>
+    <div class="scaffold__body">
+      <p>Welcome to the Knowledge hub. Explore categories to learn more.</p>
       <ul class="knowledge__categories">
         {% for category in categories %}
         <li>
@@ -23,6 +23,7 @@
         {% endfor %}
       </ul>
     </div>
-  </section>
+  </div>
+</section>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Wrap Knowledge landing content in `.scaffold__body`
- Place shared status placeholder directly after the H1

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a9e99d72c4832a80e8dece992bd1f1