### PR TITLE
Add structured data hooks and blog JSON-LD stubs

### DIFF
--- a/coresite/templates/coresite/base.html
+++ b/coresite/templates/coresite/base.html
@@ -10,6 +10,7 @@
   {% if canonical_url %}<link rel="canonical" href="{{ canonical_url }}" />{% endif %}
   <link rel="stylesheet" href="{% sass_src 'coresite/scss/main.scss' %}">
   {% block head_extras %}{% endblock %}
+  {% block structured_data %}{% endblock %}
 </head>
 
 <body {% block body_class %}{% endblock %}

--- a/coresite/templates/coresite/blog.html
+++ b/coresite/templates/coresite/blog.html
@@ -1,5 +1,33 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "Blog",
+  "url": "{{ request.scheme }}://{{ request.get_host }}{% url 'blog' %}",
+  "breadcrumb": {
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Home",
+        "item": "{{ request.scheme }}://{{ request.get_host }}{% url 'home' %}"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "Blog",
+        "item": "{{ request.scheme }}://{{ request.get_host }}{% url 'blog' %}"
+      }
+    ]
+  }
+}
+</script>
+{% endblock %}
+
 {% block content %}
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">

--- a/coresite/templates/coresite/blog_detail.html
+++ b/coresite/templates/coresite/blog_detail.html
@@ -1,4 +1,49 @@
 {% extends "coresite/base.html" %}
+
+{% block structured_data %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "{{ post.title|escapejs }}",
+  "url": "{{ request.scheme }}://{{ request.get_host }}{% url 'blog_post' post.slug %}",
+  "datePublished": "{{ post.date|date:'Y-m-d' }}",
+  "dateModified": "{{ post.date|date:'Y-m-d' }}",
+  "author": {
+    "@type": "Person",
+    "name": "Technofatty"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Technofatty"
+  },
+  "breadcrumb": {
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Home",
+        "item": "{{ request.scheme }}://{{ request.get_host }}{% url 'home' %}"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "Blog",
+        "item": "{{ request.scheme }}://{{ request.get_host }}{% url 'blog' %}"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "{{ post.title|escapejs }}",
+        "item": "{{ request.scheme }}://{{ request.get_host }}{% url 'blog_post' post.slug %}"
+      }
+    ]
+  }
+}
+</script>
+{% endblock %}
+
 {% block content %}
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">


### PR DESCRIPTION
## Summary
- add `structured_data` block to `base.html`
- provide JSON-LD for blog index and blog detail pages

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f1d22ba4832ab8bd997fe137f8dd