### PR TITLE
Add JSON-LD structured data for blog pages

### DIFF
--- a/coresite/templates/coresite/blog.html
+++ b/coresite/templates/coresite/blog.html
@@ -6,7 +6,7 @@
   "@context": "https://schema.org",
   "@type": "CollectionPage",
   "name": "Blog",
-  "url": "{{ request.scheme }}://{{ request.get_host }}{% url 'blog' %}",
+  "url": "{{ canonical_url }}",
   "breadcrumb": {
     "@type": "BreadcrumbList",
     "itemListElement": [
@@ -20,7 +20,7 @@
         "@type": "ListItem",
         "position": 2,
         "name": "Blog",
-        "item": "{{ request.scheme }}://{{ request.get_host }}{% url 'blog' %}"
+        "item": "{{ canonical_url }}"
       }
     ]
   }

--- a/coresite/templates/coresite/blog_detail.html
+++ b/coresite/templates/coresite/blog_detail.html
@@ -6,17 +6,19 @@
   "@context": "https://schema.org",
   "@type": "BlogPosting",
   "headline": "{{ post.title|escapejs }}",
-  "url": "{{ request.scheme }}://{{ request.get_host }}{% url 'blog_post' post.slug %}",
-  "datePublished": "{{ post.date|date:'Y-m-d' }}",
-  "dateModified": "{{ post.date|date:'Y-m-d' }}",
+  "url": "{{ canonical_url }}",
+  "mainEntityOfPage": "{{ canonical_url }}",
+  "datePublished": "{{ post.date|date:'c' }}",
+  "dateModified": "{{ post.date|date:'c' }}",
   "author": {
-    "@type": "Person",
+    "@type": "Organization",
     "name": "Technofatty"
   },
   "publisher": {
     "@type": "Organization",
     "name": "Technofatty"
   },
+  "description": "{{ post.excerpt|default:'A blog post on Technofatty.'|escapejs }}",
   "breadcrumb": {
     "@type": "BreadcrumbList",
     "itemListElement": [
@@ -36,7 +38,7 @@
         "@type": "ListItem",
         "position": 3,
         "name": "{{ post.title|escapejs }}",
-        "item": "{{ request.scheme }}://{{ request.get_host }}{% url 'blog_post' post.slug %}"
+        "item": "{{ canonical_url }}"
       }
     ]
   }


### PR DESCRIPTION
## Summary
- add JSON-LD CollectionPage and breadcrumb to blog index using canonical URLs
- add JSON-LD BlogPosting with dates, organization author/publisher, description, and breadcrumb to post detail

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a9f6a36d14832a963cb8e2bf6c2f9b