### PR TITLE
feat: scaffold overrideable meta blocks

### DIFF
--- a/coresite/templates/coresite/base.html
+++ b/coresite/templates/coresite/base.html
@@ -4,13 +4,15 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>{% block title %}Technofatty{% endblock %}</title>
-  <meta name="description" content="{% block meta_description %}Tech resources and community.{% endblock %}">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  {% if canonical_url %}<link rel="canonical" href="{{ canonical_url }}" />{% endif %}
   <link rel="stylesheet" href="{% sass_src 'coresite/scss/main.scss' %}">
   {% block head_extras %}{% endblock %}
   {% block structured_data %}{% endblock %}
+  {% block meta %}
+    <title>Technofatty</title>
+    <meta name="description" content="Tech resources and community.">
+    {% if canonical_url %}<link rel="canonical" href="{{ canonical_url }}" />{% endif %}
+  {% endblock %}
 </head>
 
 <body {% block body_class %}{% endblock %}

--- a/coresite/templates/coresite/blog.html
+++ b/coresite/templates/coresite/blog.html
@@ -1,5 +1,20 @@
 {% extends "coresite/base.html" %}
 
+{% block meta %}
+  <title>{{ page_title }} | Technofatty</title>
+  <meta name="description" content="Latest news and insights from Technofatty.">
+  <link rel="canonical" href="{{ canonical_url }}">
+  <meta property="og:title" content="{{ page_title }} | Technofatty">
+  <meta property="og:description" content="Latest news and insights from Technofatty.">
+  <meta property="og:url" content="{{ canonical_url }}">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Technofatty">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ page_title }} | Technofatty">
+  <meta name="twitter:description" content="Latest news and insights from Technofatty.">
+  <meta name="twitter:url" content="{{ canonical_url }}">
+{% endblock %}
+
 {% block structured_data %}
 <script type="application/ld+json">
 {

--- a/coresite/templates/coresite/blog_detail.html
+++ b/coresite/templates/coresite/blog_detail.html
@@ -1,5 +1,22 @@
 {% extends "coresite/base.html" %}
 
+{% block meta %}
+  <title>{{ post.title }} | Technofatty</title>
+  <meta name="description" content="{{ post.excerpt|default:'A blog post on Technofatty.' }}">
+  <link rel="canonical" href="{{ canonical_url }}">
+  <meta property="og:title" content="{{ post.title }} | Technofatty">
+  <meta property="og:description" content="{{ post.excerpt|default:'A blog post on Technofatty.' }}">
+  <meta property="og:url" content="{{ canonical_url }}">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="Technofatty">
+  {% if post.date %}<meta property="article:published_time" content="{{ post.date|date:'c' }}">{% endif %}
+  {% if post.updated %}<meta property="article:modified_time" content="{{ post.updated|date:'c' }}">{% endif %}
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ post.title }} | Technofatty">
+  <meta name="twitter:description" content="{{ post.excerpt|default:'A blog post on Technofatty.' }}">
+  <meta name="twitter:url" content="{{ canonical_url }}">
+{% endblock %}
+
 {% block structured_data %}
 <script type="application/ld+json">
 {

--- a/coresite/templates/coresite/case_studies/detail.html
+++ b/coresite/templates/coresite/case_studies/detail.html
@@ -1,5 +1,20 @@
 {% extends "coresite/base.html" %}
 
+{% block meta %}
+  <title>{{ page_title }} | Technofatty</title>
+  <meta name="description" content="Case study details from Technofatty.">
+  <link rel="canonical" href="{{ canonical_url }}">
+  <meta property="og:title" content="{{ page_title }} | Technofatty">
+  <meta property="og:description" content="Case study details from Technofatty.">
+  <meta property="og:url" content="{{ canonical_url }}">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="Technofatty">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ page_title }} | Technofatty">
+  <meta name="twitter:description" content="Case study details from Technofatty.">
+  <meta name="twitter:url" content="{{ canonical_url }}">
+{% endblock %}
+
 {% block content %}
 <h1>Case Study Title</h1>
 {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/coresite/case_studies/landing.html
+++ b/coresite/templates/coresite/case_studies/landing.html
@@ -1,5 +1,20 @@
 {% extends "coresite/base.html" %}
 
+{% block meta %}
+  <title>{{ page_title }} | Technofatty</title>
+  <meta name="description" content="Client success stories from Technofatty.">
+  <link rel="canonical" href="{{ canonical_url }}">
+  <meta property="og:title" content="{{ page_title }} | Technofatty">
+  <meta property="og:description" content="Client success stories from Technofatty.">
+  <meta property="og:url" content="{{ canonical_url }}">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Technofatty">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ page_title }} | Technofatty">
+  <meta name="twitter:description" content="Client success stories from Technofatty.">
+  <meta name="twitter:url" content="{{ canonical_url }}">
+{% endblock %}
+
 {% block structured_data %}
 <script type="application/ld+json">
 {

--- a/coresite/templates/coresite/knowledge/hub.html
+++ b/coresite/templates/coresite/knowledge/hub.html
@@ -1,5 +1,20 @@
 {% extends "coresite/base.html" %}
 
+{% block meta %}
+  <title>{{ page_title }} | Technofatty</title>
+  <meta name="description" content="Guides and insights from Technofatty.">
+  <link rel="canonical" href="{{ canonical_url }}">
+  <meta property="og:title" content="{{ page_title }} | Technofatty">
+  <meta property="og:description" content="Guides and insights from Technofatty.">
+  <meta property="og:url" content="{{ canonical_url }}">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Technofatty">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ page_title }} | Technofatty">
+  <meta name="twitter:description" content="Guides and insights from Technofatty.">
+  <meta name="twitter:url" content="{{ canonical_url }}">
+{% endblock %}
+
 {% block structured_data %}
 <script type="application/ld+json">
 {


### PR DESCRIPTION
## Summary
- add `{% block meta %}` with default tags in base template
- provide page-specific meta overrides for blog, case study, and knowledge pages

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fd3f6ee4832aafed58cb1dfea9d1