### PR TITLE
feat: offset hash anchors under sticky header

### DIFF
--- a/coresite/static/coresite/scss/abstracts/_variables.scss
+++ b/coresite/static/coresite/scss/abstracts/_variables.scss
@@ -158,6 +158,7 @@ $dur: 200ms;
   --dur-fast: #{$dur-fast};
   --dur: #{$dur};
   --header-h: calc(#{$header-h-mobile} + env(safe-area-inset-top, 0px));
+  --scroll-offset: var(--header-h);
 }
 
 @media (min-width: map-get($bp, md)) {

--- a/coresite/static/coresite/scss/base/_utilities.scss
+++ b/coresite/static/coresite/scss/base/_utilities.scss
@@ -1,6 +1,5 @@
-html { scroll-padding-top: var(--header-h); }
-h1, h2, h3, [id] { scroll-margin-top: var(--header-h); }
-body:not(.is-home) main { padding-top: var(--header-h); }
+html { scroll-padding-top: var(--scroll-offset); }
+body:not(.is-home) main { padding-top: var(--scroll-offset); }
 
 .container { @include container; }
 .container-wide {

--- a/coresite/static/coresite/scss/main.scss
+++ b/coresite/static/coresite/scss/main.scss
@@ -35,6 +35,7 @@
 @import "sections/footer";
 
   // Pages
+  @import "pages/infra";
   @import "pages/home";
   @import "pages/blog";
   @import "pages/about";

--- a/coresite/static/coresite/scss/pages/_infra.scss
+++ b/coresite/static/coresite/scss/pages/_infra.scss
@@ -1,0 +1,29 @@
+/* Infrastructure styles for page-level anchor offsets */
+
+h1[id],
+h2[id],
+h3[id],
+h4[id],
+h5[id],
+h6[id],
+[id^="section-"],
+.anchor-target,
+.section-title {
+  scroll-margin-top: var(--scroll-offset);
+}
+
+/* Exclude homepage hero */
+.is-home .hero {
+  h1[id],
+  h2[id],
+  h3[id],
+  h4[id],
+  h5[id],
+  h6[id],
+  [id^="section-"],
+  .anchor-target,
+  .section-title {
+    scroll-margin-top: 0;
+  }
+}
+


### PR DESCRIPTION
## Summary
- define global `--scroll-offset` tied to header height
- apply consistent scroll margin to hash-targetable headings and anchors
- exclude homepage hero while keeping content offset below sticky header

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9fffcd000832a8fec5a90646808ed