### PR TITLE
Add structured data blocks across templates

### DIFF
--- a/coresite/templates/404.html
+++ b/coresite/templates/404.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block title %}Page not found{% endblock %}
 
 {% block content %}

--- a/coresite/templates/410.html
+++ b/coresite/templates/410.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block title %}Page gone{% endblock %}
 
 {% block content %}

--- a/coresite/templates/500.html
+++ b/coresite/templates/500.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block title %}Server error{% endblock %}
 
 {% block content %}

--- a/coresite/templates/coresite/about.html
+++ b/coresite/templates/coresite/about.html
@@ -16,6 +16,22 @@
   <meta name="twitter:url" content="https://technofatty.com/about/">
 {% endblock %}
 
+{% block structured_data %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "AboutPage",
+      "url": "https://technofatty.com/about/",
+      "name": "About – Technofatty",
+      "publisher": {
+        "@type": "Organization",
+        "name": "Technofatty",
+        "url": "https://technofatty.com/"
+      }
+    }
+  </script>
+{% endblock %}
+
 {% block content %}
 <section id="about-hero" class="section section--scaffold" role="region" aria-labelledby="about-hero-heading">
   <div class="wrap">
@@ -58,21 +74,5 @@
     {% include "coresite/partials/about/about-cta.html" %}
   </div>
 </section>
-{% endblock %}
-
-{% block body_scripts %}
-  <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "AboutPage",
-      "url": "https://technofatty.com/about/",
-      "name": "About – Technofatty",
-      "publisher": {
-        "@type": "Organization",
-        "name": "Technofatty",
-        "url": "https://technofatty.com/"
-      }
-    }
-  </script>
 {% endblock %}
 

--- a/coresite/templates/coresite/account.html
+++ b/coresite/templates/coresite/account.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block content %}
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">

--- a/coresite/templates/coresite/base.html
+++ b/coresite/templates/coresite/base.html
@@ -7,12 +7,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="{% sass_src 'coresite/scss/main.scss' %}">
   {% block head_extras %}{% endblock %}
-  {% block structured_data %}{% endblock %}
   {% block meta %}
     <title>Technofatty</title>
     <meta name="description" content="Tech resources and community.">
     {% if canonical_url %}<link rel="canonical" href="{{ canonical_url }}" />{% endif %}
   {% endblock %}
+  {% block structured_data %}{% endblock %}
 </head>
 
 <body {% block body_class %}{% endblock %}

--- a/coresite/templates/coresite/blog_category.html
+++ b/coresite/templates/coresite/blog_category.html
@@ -1,4 +1,6 @@
 {% extends "coresite/base.html" %}
+
+{% block structured_data %}{% endblock %}
 {% block content %}
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">

--- a/coresite/templates/coresite/blog_rss.html
+++ b/coresite/templates/coresite/blog_rss.html
@@ -1,4 +1,6 @@
 {% extends "coresite/base.html" %}
+
+{% block structured_data %}{% endblock %}
 {% block content %}
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">

--- a/coresite/templates/coresite/blog_tag.html
+++ b/coresite/templates/coresite/blog_tag.html
@@ -1,4 +1,6 @@
 {% extends "coresite/base.html" %}
+
+{% block structured_data %}{% endblock %}
 {% block content %}
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">

--- a/coresite/templates/coresite/case_studies/detail.html
+++ b/coresite/templates/coresite/case_studies/detail.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block meta %}
   <title>{{ page_title }} | Technofatty</title>
   <meta name="description" content="Case study details from Technofatty.">

--- a/coresite/templates/coresite/community.html
+++ b/coresite/templates/coresite/community.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block content %}
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">

--- a/coresite/templates/coresite/community_join.html
+++ b/coresite/templates/coresite/community_join.html
@@ -1,5 +1,6 @@
 {% extends "coresite/base.html" %}
 {% load static %}
+{% block structured_data %}{% endblock %}
 {% block title %}Join the Technofatty Community{% endblock %}
 {% block meta_description %}Join the Technofatty community for updates, tools, and early access while we’re building.{% endblock %}
 

--- a/coresite/templates/coresite/contact.html
+++ b/coresite/templates/coresite/contact.html
@@ -16,6 +16,22 @@
   <meta name="twitter:url" content="https://technofatty.com/contact/">
 {% endblock %}
 
+{% block structured_data %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ContactPage",
+      "url": "https://technofatty.com/contact/",
+      "name": "Contact – Technofatty",
+      "publisher": {
+        "@type": "Organization",
+        "name": "Technofatty",
+        "url": "https://technofatty.com/"
+      }
+    }
+  </script>
+{% endblock %}
+
 {% block content %}
 <section id="contact-intro" class="section section--scaffold" role="region" aria-labelledby="contact-intro-heading">
   <div class="wrap">
@@ -52,20 +68,5 @@
     {% include "coresite/partials/contact/contact-cta.html" %}
   </div>
 </section>
-{% endblock %}
-{% block body_scripts %}
-  <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "ContactPage",
-      "url": "https://technofatty.com/contact/",
-      "name": "Contact – Technofatty",
-      "publisher": {
-        "@type": "Organization",
-        "name": "Technofatty",
-        "url": "https://technofatty.com/"
-      }
-    }
-  </script>
 {% endblock %}
 

--- a/coresite/templates/coresite/homepage.html
+++ b/coresite/templates/coresite/homepage.html
@@ -1,5 +1,6 @@
 {% extends "coresite/base.html" %}
 {% load static %}
+{% block structured_data %}{% endblock %}
 {% block body_class %}class="is-home"{% endblock %}
 {% block title %}Technofatty Front Page{% endblock %}
 {% block meta_description %}Modern tech resources—fast, accessible, and community-driven.{% endblock %}

--- a/coresite/templates/coresite/join.html
+++ b/coresite/templates/coresite/join.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block content %}
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">

--- a/coresite/templates/coresite/knowledge/article.html
+++ b/coresite/templates/coresite/knowledge/article.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block content %}
 <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
   <div class="wrap">

--- a/coresite/templates/coresite/knowledge/category.html
+++ b/coresite/templates/coresite/knowledge/category.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block content %}
 <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
   <div class="wrap">

--- a/coresite/templates/coresite/knowledge/glossary.html
+++ b/coresite/templates/coresite/knowledge/glossary.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block content %}
 <h1>Glossary</h1>
 {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/coresite/knowledge/guides.html
+++ b/coresite/templates/coresite/knowledge/guides.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block content %}
 <h1>Guides</h1>
 {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/coresite/knowledge/quick_wins.html
+++ b/coresite/templates/coresite/knowledge/quick_wins.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block content %}
 <h1>Quick Wins</h1>
 {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/coresite/knowledge/signals.html
+++ b/coresite/templates/coresite/knowledge/signals.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block content %}
 <h1>Signals</h1>
 {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/coresite/legal.html
+++ b/coresite/templates/coresite/legal.html
@@ -16,6 +16,22 @@
   <meta name="twitter:url" content="https://technofatty.com/legal/">
 {% endblock %}
 
+{% block structured_data %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      "url": "https://technofatty.com/legal/",
+      "name": "Legal – Technofatty",
+      "publisher": {
+        "@type": "Organization",
+        "name": "Technofatty",
+        "url": "https://technofatty.com/"
+      }
+    }
+  </script>
+{% endblock %}
+
 {% block content %}
 <section id="legal-intro" class="section section--scaffold" role="region" aria-labelledby="legal-intro-heading">
   <div class="wrap">
@@ -64,20 +80,4 @@
     {% include "coresite/partials/legal/legal-contact.html" %}
   </div>
 </section>
-{% endblock %}
-
-{% block body_scripts %}
-  <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "url": "https://technofatty.com/legal/",
-      "name": "Legal – Technofatty",
-      "publisher": {
-        "@type": "Organization",
-        "name": "Technofatty",
-        "url": "https://technofatty.com/"
-      }
-    }
-  </script>
 {% endblock %}

--- a/coresite/templates/coresite/resources.html
+++ b/coresite/templates/coresite/resources.html
@@ -1,4 +1,6 @@
 {% extends "coresite/base.html" %}
+
+{% block structured_data %}{% endblock %}
 {% block content %}
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">

--- a/coresite/templates/coresite/services.html
+++ b/coresite/templates/coresite/services.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block title %}Services{% endblock %}
 
 {% block content %}

--- a/coresite/templates/coresite/signal_placeholder.html
+++ b/coresite/templates/coresite/signal_placeholder.html
@@ -1,4 +1,5 @@
 {% extends "coresite/base.html" %}
+{% block structured_data %}{% endblock %}
 {% block title %}Signal: {{ slug|title }}{% endblock %}
 {% block content %}
 <section class="section" role="region" aria-labelledby="signal-placeholder-heading">

--- a/coresite/templates/coresite/signup.html
+++ b/coresite/templates/coresite/signup.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block content %}
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">

--- a/coresite/templates/coresite/support.html
+++ b/coresite/templates/coresite/support.html
@@ -16,6 +16,22 @@
   <meta name="twitter:url" content="https://technofatty.com/support/">
 {% endblock %}
 
+{% block structured_data %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      "url": "https://technofatty.com/support/",
+      "name": "Support – Technofatty",
+      "publisher": {
+        "@type": "Organization",
+        "name": "Technofatty",
+        "url": "https://technofatty.com/"
+      }
+    }
+  </script>
+{% endblock %}
+
 {% block content %}
 <section id="support-intro" class="section section--scaffold" role="region" aria-labelledby="support-intro-heading">
   <div class="wrap">
@@ -70,21 +86,5 @@
     {% include "coresite/partials/support/support-contact.html" %}
   </div>
 </section>
-{% endblock %}
-
-{% block body_scripts %}
-  <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "url": "https://technofatty.com/support/",
-      "name": "Support – Technofatty",
-      "publisher": {
-        "@type": "Organization",
-        "name": "Technofatty",
-        "url": "https://technofatty.com/"
-      }
-    }
-  </script>
 {% endblock %}
 

--- a/coresite/templates/coresite/tools.html
+++ b/coresite/templates/coresite/tools.html
@@ -1,5 +1,7 @@
 {% extends "coresite/base.html" %}
 
+{% block structured_data %}{% endblock %}
+
 {% block content %}
   <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">


### PR DESCRIPTION
## Summary
- Move structured data block after meta sections in base template
- Provide empty `{% block structured_data %}` in every template, including error pages
- Shift existing JSON-LD snippets into structured data blocks

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68aab51a70d0832a8c0bed5e581b7d3c