### PR TITLE
Add nav wrapper for mobile menu

### DIFF
--- a/coresite/templates/coresite/partials/global/header_nav.html
+++ b/coresite/templates/coresite/partials/global/header_nav.html
@@ -33,8 +33,10 @@
       {% include 'coresite/partials/global/nav_cta.html' %}
       <button class="menu-overlay__close" aria-label="Close menu">&times;</button>
     </div>
-    <ul class="menu-overlay__links">
-      {% include 'coresite/partials/global/nav_links.html' with id_prefix='mobile' %}
-    </ul>
+    <nav aria-label="Mobile">
+      <ul class="menu-overlay__links">
+        {% include 'coresite/partials/global/nav_links.html' with id_prefix='mobile' %}
+      </ul>
+    </nav>
   </div>
 </div>

--- a/docs/global_partials_readme.md
+++ b/docs/global_partials_readme.md
@@ -39,8 +39,8 @@ Analytics is tied to the site's consent banner. Until a user grants tracking per
 
 ### Navigation links
 * **Path**: `coresite/templates/coresite/partials/global/nav_links.html`
-* **Purpose**: List of primary site links used in both desktop and overlay menus【F:coresite/templates/coresite/partials/global/header_nav.html†L7-L12】
-* **Included in**: `header_nav.html`【F:coresite/templates/coresite/partials/global/header_nav.html†L7-L12】
+* **Purpose**: Canonical list of primary site links reused across header, mobile menu, and footer navigation.
+* **Included in**: `header_nav.html`, `includes/footer_links.html`
 
 ### Navigation CTA
 * **Path**: `coresite/templates/coresite/partials/global/nav_cta.html`


### PR DESCRIPTION
## Summary
- Ensure mobile slide-in menu uses a semantic `<nav>` element
- Document canonical usage of global `nav_links.html` in footer and header

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: ProxyError: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68aabe563398832a96d4b37dc29245df