### PR TITLE
Centralize navigation links in templates

### DIFF
--- a/coresite/templates/coresite/partials/signals_block.html
+++ b/coresite/templates/coresite/partials/signals_block.html
@@ -10,21 +10,21 @@
       {% for card in signals.cards %}
         <article id="signal-{{ card.slug }}" class="signals__card" data-card="{{ card.slug }}">
           {% if card.kicker %}<p class="signals__kicker">{{ card.kicker }}</p>{% endif %}
-          {% if card.title %}<h3 class="signals__title"><a href="/knowledge/signals/#signal-{{ card.slug }}"
+          {% if card.title %}<h3 class="signals__title"><a href="{% url 'knowledge_signals' %}#signal-{{ card.slug }}"
               data-analytics-event="signals_card_click"
               data-analytics-section="signals"
               data-analytics-label="{{ card.title }}"
-              data-analytics-url="/knowledge/signals/#signal-{{ card.slug }}">{{ card.title }}</a></h3>{% endif %}
+              data-analytics-url="{% url 'knowledge_signals' %}#signal-{{ card.slug }}">{{ card.title }}</a></h3>{% endif %}
           {% if card.problem %}<p class="signals__text"><span class="signals__label">Problem:</span> {{ card.problem }}</p>{% endif %}
           {% if card.approach %}<p class="signals__text"><span class="signals__label">Approach:</span> {{ card.approach }}</p>{% endif %}
           {% if card.evidence %}<p class="signals__text"><span class="signals__label">Evidence:</span> {{ card.evidence }}</p>{% endif %}
           {% if card.cta_text %}
             <a class="btn btn--primary signals__cta"
-               href="/knowledge/signals/#signal-{{ card.slug }}"
+               href="{% url 'knowledge_signals' %}#signal-{{ card.slug }}"
                data-analytics-event="signals_card_cta_click"
                data-analytics-section="signals"
                data-analytics-label="{{ card.cta_text }}"
-               data-analytics-url="/knowledge/signals/#signal-{{ card.slug }}">{{ card.cta_text }}</a>
+               data-analytics-url="{% url 'knowledge_signals' %}#signal-{{ card.slug }}">{{ card.cta_text }}</a>
           {% endif %}
         </article>
       {% endfor %}

--- a/coresite/templates/coresite/partials/trust.html
+++ b/coresite/templates/coresite/partials/trust.html
@@ -75,6 +75,6 @@
 <section class="cta-band" aria-labelledby="cta-context">
   <div class="container">
     <p id="cta-context">See how we've helped businesses like yours transform their operations.</p>
-    <a href="/case-studies/" class="btn btn-secondary" aria-describedby="cta-context" data-analytics-event="cta.trust.case_studies">See How It Works</a>
+    <a href="{% url 'case_studies_landing' %}" class="btn btn-secondary" aria-describedby="cta-context" data-analytics-event="cta.trust.case_studies">See How It Works</a>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Replace hard-coded case study CTA with Django URL tag
- Use `knowledge_signals` URL tag in signals block links

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aad87d70f0832a97aea44c6ae18ce0