### PR TITLE
Add JSON-LD structured data for blog pages

### DIFF
--- a/coresite/templates/coresite/blog.html
+++ b/coresite/templates/coresite/blog.html
@@ -20,19 +20,32 @@
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
+  "@graph": [
     {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "Home",
-      "item": "https://technofatty.com/"
+      "@type": "CollectionPage",
+      "@id": "{{ canonical_url }}#webpage",
+      "url": "{{ canonical_url }}",
+      "name": "{{ page_title|escapejs }}",
+      "isPartOf": {
+        "@type": "WebSite",
+        "@id": "https://technofatty.com/#website"
+      },
+      "inLanguage": "en"
     },
     {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "Placeholder",
-      "item": "https://technofatty.com/placeholder"
+      "@type": "BreadcrumbList",
+      "@id": "{{ canonical_url }}#breadcrumb",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://technofatty.com/"},
+        {"@type": "ListItem", "position": 2, "name": "{{ page_title|escapejs }}", "item": "{{ canonical_url }}"}
+      ]
+    },
+    {
+      "@type": "ItemList",
+      "@id": "{{ canonical_url }}#list",
+      "itemListElement": [
+        {% for post in page_posts %}{"@type": "ListItem", "position": {{ forloop.counter }}, "url": "https://technofatty.com/blog/{{ post.slug }}/"}{% if not forloop.last %},{% endif %}{% endfor %}
+      ]
     }
   ]
 }

--- a/coresite/templates/coresite/blog_detail.html
+++ b/coresite/templates/coresite/blog_detail.html
@@ -12,44 +12,43 @@
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
-  "@type": "BlogPosting",
-  "headline": "{{ post.title|escapejs }}",
-  "url": "{{ canonical_url }}",
-  "mainEntityOfPage": "{{ canonical_url }}",
-  "datePublished": "{{ post.date|date:'c' }}",
-  "dateModified": "{{ post.date|date:'c' }}",
-  "author": {
-    "@type": "Organization",
-    "name": "Technofatty"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Technofatty"
-  },
-  "description": "{{ post.excerpt|default:'A blog post on Technofatty.'|escapejs }}",
-  "breadcrumb": {
-    "@type": "BreadcrumbList",
-    "itemListElement": [
-      {
-        "@type": "ListItem",
-        "position": 1,
-        "name": "Home",
-        "item": "{{ request.scheme }}://{{ request.get_host }}{% url 'home' %}"
+  "@graph": [
+    {
+      "@type": "BlogPosting",
+      "@id": "{{ canonical_url }}#article",
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "{{ canonical_url }}#webpage"
       },
-      {
-        "@type": "ListItem",
-        "position": 2,
-        "name": "Blog",
-        "item": "{{ request.scheme }}://{{ request.get_host }}{% url 'blog' %}"
+      "headline": "{{ post.title|escapejs }}",
+      "url": "{{ canonical_url }}",
+      "datePublished": "{{ post.date|date:'c' }}",
+      "dateModified": "{{ post.updated|default:post.date|date:'c' }}",
+      "author": {
+        "@type": "Organization",
+        "@id": "https://technofatty.com/#organization",
+        "name": "Technofatty",
+        "url": "https://technofatty.com/"
       },
-      {
-        "@type": "ListItem",
-        "position": 3,
-        "name": "{{ post.title|escapejs }}",
-        "item": "{{ canonical_url }}"
-      }
-    ]
-  }
+      "publisher": {
+        "@type": "Organization",
+        "@id": "https://technofatty.com/#organization",
+        "name": "Technofatty",
+        "url": "https://technofatty.com/"
+      },
+      "description": "{{ post.excerpt|default:'A blog post on Technofatty.'|escapejs }}",
+      "inLanguage": "en"
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "{{ canonical_url }}#breadcrumb",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://technofatty.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://technofatty.com/blog/"},
+        {"@type": "ListItem", "position": 3, "name": "{{ post.title|escapejs }}", "item": "{{ canonical_url }}"}
+      ]
+    }
+  ]
 }
 </script>
 {% endblock %}

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -383,6 +383,7 @@ def blog(request):
         "page_title": "Blog",
         "featured_post": featured_post,
         "posts": remaining_posts,
+        "page_posts": page_posts,
         "categories": [
             {"slug": slug, "title": title} for slug, title in sorted(categories)
         ],


### PR DESCRIPTION
## Summary
- replace placeholder breadcrumb JSON-LD on the blog index with a full CollectionPage, BreadcrumbList and ItemList graph
- emit complete BlogPosting and BreadcrumbList structured data on blog posts with stable IDs and language
- expose `page_posts` list in blog view to power ItemList schema

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae93f00e8832abb715d0196896bfd