### PR TITLE
refactor: tokenise newsletter status min-height

### DIFF
--- a/coresite/static/coresite/scss/abstracts/_variables.scss
+++ b/coresite/static/coresite/scss/abstracts/_variables.scss
@@ -49,6 +49,7 @@ $dimensions: (
   menu-overlay-min-w: 16rem,
   menu-overlay-max-w: 24rem,
   grid-min: 16rem,
+  newsletter-msg-min-h: s(4), // reserve space for status text
   sr-only-size: 1px,
   focus-ring-width: 3px
 );

--- a/coresite/static/coresite/scss/sections/_newsletter.scss
+++ b/coresite/static/coresite/scss/sections/_newsletter.scss
@@ -67,7 +67,7 @@
         // CTA inherits .btn--cta (gold base, blue hover)
       }
 
-      .form-message { min-height: 1em; }
+      .form-message { min-height: dim(newsletter-msg-min-h); }
     }
 
     &.is-error {


### PR DESCRIPTION
## Summary
- add `$newsletter-msg-min-h` dimension token and consume it for `.form-message`
- replace hard-coded `1em` with design token to keep spacing scale consistent

## Testing
- `npm test` *(fails: Missing script "test")*
- `python manage.py test` *(fails: No module named 'django')*
- `npx sass coresite/static/coresite/scss/main.scss` *(fails: 403 Forbidden from registry)*

### min-height references
- `%form-control-shared` (all breakpoints)
- `.form-message` (all breakpoints)


------
https://chatgpt.com/codex/tasks/task_e_68ac120ad184832aa0561db611a8f752