### PR TITLE
Add onboarding docs and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,33 @@
 # Technofatty
 
+## Setup
+
+### Requirements
+- Python 3.12
+
+### Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+python manage.py migrate
+python manage.py check
+```
+
+### Run server
+
+```bash
+python manage.py runserver
+```
+
+### Tests
+
+```bash
+pytest
+```
+
 ## Configuration
 
 The application reads configuration from environment variables.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+asgiref==3.8.1
+Django==4.2.23
+django-compressor==4.4
+django-sass-processor==1.4.1
+easy-thumbnails==2.9.1
+libsass==0.23.0
+psycopg2-binary==2.9.9
+pytest==8.4.1
+pytest-django==4.10.0
+rcssmin==1.1.2
+rjsmin==1.2.1
+sqlparse==0.5.1
+tzdata==2024.1


### PR DESCRIPTION
## Summary
- document environment setup and workflow in README
- add pinned Python requirements for Django project

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68ac3563d0d4832aaeca9e7b4cfda88b