### PR TITLE
Add publish status choices and manager

### DIFF
--- a/coresite/admin.py
+++ b/coresite/admin.py
@@ -1,5 +1,12 @@
 from django.contrib import admin
-from .models import SiteSettings, SiteImage, DevImage
+from .models import (
+    SiteSettings,
+    SiteImage,
+    DevImage,
+    KnowledgeCategory,
+    KnowledgeArticle,
+    BlogPost,
+)
 
 @admin.register(SiteSettings)
 class SiteSettingsAdmin(admin.ModelAdmin):
@@ -28,3 +35,25 @@ class DevImageAdmin(admin.ModelAdmin):
         return ""
     image_tag.allow_tags = True
     image_tag.short_description = 'Preview'
+
+
+@admin.register(KnowledgeCategory)
+class KnowledgeCategoryAdmin(admin.ModelAdmin):
+    list_display = ("title", "status")
+    list_filter = ("status",)
+    prepopulated_fields = {"slug": ("title",)}
+
+
+@admin.register(KnowledgeArticle)
+class KnowledgeArticleAdmin(admin.ModelAdmin):
+    list_display = ("title", "category", "status")
+    list_filter = ("status", "category")
+    prepopulated_fields = {"slug": ("title",)}
+
+
+@admin.register(BlogPost)
+class BlogPostAdmin(admin.ModelAdmin):
+    list_display = ("title", "status", "published_at")
+    list_filter = ("status",)
+    prepopulated_fields = {"slug": ("title",)}
+    date_hierarchy = "published_at"

--- a/coresite/migrations/0005_alter_status_fields.py
+++ b/coresite/migrations/0005_alter_status_fields.py
@@ -1,0 +1,49 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("coresite", "0004_blogpost_knowledgecategory_knowledgearticle"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="knowledgecategory",
+            name="status",
+            field=models.CharField(
+                max_length=20,
+                choices=[
+                    ("draft", "Draft"),
+                    ("review", "Review"),
+                    ("published", "Published"),
+                ],
+                default="draft",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="knowledgearticle",
+            name="status",
+            field=models.CharField(
+                max_length=20,
+                choices=[
+                    ("draft", "Draft"),
+                    ("review", "Review"),
+                    ("published", "Published"),
+                ],
+                default="draft",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="blogpost",
+            name="status",
+            field=models.CharField(
+                max_length=20,
+                choices=[
+                    ("draft", "Draft"),
+                    ("review", "Review"),
+                    ("published", "Published"),
+                ],
+                default="draft",
+            ),
+        ),
+    ]

--- a/coresite/models.py
+++ b/coresite/models.py
@@ -1,5 +1,18 @@
 from django.db import models
 
+
+class StatusChoices(models.TextChoices):
+    DRAFT = "draft", "Draft"
+    REVIEW = "review", "Review"
+    PUBLISHED = "published", "Published"
+
+
+class PublishedManager(models.Manager):
+    """Manager that returns only published items."""
+
+    def get_queryset(self):
+        return super().get_queryset().filter(status=StatusChoices.PUBLISHED)
+
 class SiteSettings(models.Model):
     hero_image = models.ImageField(upload_to='hero/', blank=True, null=True)
     hero_video = models.FileField(upload_to='hero_videos/', blank=True, null=True)  # <-- New field
@@ -36,12 +49,6 @@ class DevImage(models.Model):
         return self.title or f"Image {self.id}"
 
 
-STATUS_CHOICES = [
-    ("draft", "Draft"),
-    ("published", "Published"),
-]
-
-
 class TimestampedModel(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -53,8 +60,15 @@ class TimestampedModel(models.Model):
 class KnowledgeCategory(TimestampedModel):
     title = models.CharField(max_length=200)
     slug = models.SlugField(unique=True)
-    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="draft")
+    status = models.CharField(
+        max_length=20,
+        choices=StatusChoices.choices,
+        default=StatusChoices.DRAFT,
+    )
     description = models.TextField(blank=True)
+
+    objects = models.Manager()
+    published = PublishedManager()
 
     def __str__(self):
         return self.title
@@ -66,9 +80,16 @@ class KnowledgeArticle(TimestampedModel):
     )
     title = models.CharField(max_length=200)
     slug = models.SlugField(unique=True)
-    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="draft")
+    status = models.CharField(
+        max_length=20,
+        choices=StatusChoices.choices,
+        default=StatusChoices.DRAFT,
+    )
     blurb = models.TextField(blank=True)
     content = models.TextField(blank=True)
+
+    objects = models.Manager()
+    published = PublishedManager()
 
     def __str__(self):
         return self.title
@@ -77,13 +98,20 @@ class KnowledgeArticle(TimestampedModel):
 class BlogPost(TimestampedModel):
     title = models.CharField(max_length=200)
     slug = models.SlugField(unique=True)
-    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="draft")
+    status = models.CharField(
+        max_length=20,
+        choices=StatusChoices.choices,
+        default=StatusChoices.DRAFT,
+    )
     excerpt = models.TextField(blank=True)
     content = models.TextField(blank=True)
     published_at = models.DateTimeField(blank=True, null=True)
     category_slug = models.SlugField(max_length=100, blank=True)
     category_title = models.CharField(max_length=100, blank=True)
     tags = models.JSONField(default=list, blank=True)
+
+    objects = models.Manager()
+    published = PublishedManager()
 
     def __str__(self):
         return self.title

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -84,7 +84,7 @@ def signal_detail(request, slug: str):
     )
 def knowledge(request):
     footer = get_footer_content()
-    categories = KnowledgeCategory.objects.filter(status="published")
+    categories = KnowledgeCategory.published.all()
     context = {
         "footer": footer,
         "page_id": "knowledge",
@@ -99,11 +99,9 @@ def knowledge(request):
 def knowledge_category(request, category_slug: str):
     footer = get_footer_content()
     category = get_object_or_404(
-        KnowledgeCategory, slug=category_slug, status="published"
+        KnowledgeCategory.published, slug=category_slug
     )
-    articles = KnowledgeArticle.objects.filter(
-        category=category, status="published"
-    )
+    articles = KnowledgeArticle.published.filter(category=category)
     context = {
         "footer": footer,
         "page_id": f"knowledge-{category_slug}",
@@ -118,13 +116,12 @@ def knowledge_category(request, category_slug: str):
 def knowledge_article(request, category_slug: str, article_slug: str):
     footer = get_footer_content()
     category = get_object_or_404(
-        KnowledgeCategory, slug=category_slug, status="published"
+        KnowledgeCategory.published, slug=category_slug
     )
     article = get_object_or_404(
-        KnowledgeArticle,
+        KnowledgeArticle.published,
         category=category,
         slug=article_slug,
-        status="published",
     )
     context = {
         "footer": footer,
@@ -257,9 +254,7 @@ def blog(request):
         return HttpResponsePermanentRedirect(reverse("blog"))
 
     footer = get_footer_content()
-    posts_qs = BlogPost.objects.filter(status="published").order_by(
-        "-published_at"
-    )
+    posts_qs = BlogPost.published.order_by("-published_at")
     posts = list(posts_qs)
 
     # Basic pagination over in-memory posts to enable proper SEO signals.
@@ -315,7 +310,7 @@ def blog(request):
 
 def blog_post(request, post_slug: str):
     footer = get_footer_content()
-    post = get_object_or_404(BlogPost, slug=post_slug, status="published")
+    post = get_object_or_404(BlogPost.published, slug=post_slug)
     context = {
         "footer": footer,
         "page_id": "post",
@@ -328,8 +323,8 @@ def blog_post(request, post_slug: str):
 
 def blog_category(request, category_slug: str):
     footer = get_footer_content()
-    posts_qs = BlogPost.objects.filter(
-        status="published", category_slug=category_slug
+    posts_qs = BlogPost.published.filter(
+        category_slug=category_slug
     ).order_by("-published_at")
     posts = list(posts_qs)
     category_title = (
@@ -353,7 +348,7 @@ def blog_tag(request, tag_slug: str):
     footer = get_footer_content()
     posts = [
         p
-        for p in BlogPost.objects.filter(status="published")
+        for p in BlogPost.published.all()
         if any(t.get("slug") == tag_slug for t in p.tags)
     ]
     tag_title = tag_slug.replace("-", " ").title()
@@ -377,10 +372,7 @@ def blog_rss(request):
         description="Latest news and insights from Technofatty.",
     )
 
-    posts = (
-        BlogPost.objects.filter(status="published")
-        .order_by("-published_at")[:10]
-    )
+    posts = BlogPost.published.order_by("-published_at")[:10]
     for post in posts:
         pubdate = post.published_at
         if pubdate is None:
@@ -406,10 +398,7 @@ def blog_rss(request):
 
 def sitemap_xml(request):
     urls = list(TOP_LEVEL_URLS)
-    posts = (
-        BlogPost.objects.filter(status="published")
-        .order_by("-published_at")[:10]
-    )
+    posts = BlogPost.published.order_by("-published_at")[:10]
     for post in posts:
         urls.append(
             {


### PR DESCRIPTION
## Summary
- add `StatusChoices` enumeration with `draft`, `review`, `published`
- introduce `PublishedManager` and apply to content models
- expose content status in admin and serve only published items in views

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68ac394af200832ab4e86b94e845dba0