### PR TITLE
Handle contact form submissions

### DIFF
--- a/coresite/forms.py
+++ b/coresite/forms.py
@@ -1,0 +1,7 @@
+from django import forms
+
+
+class ContactForm(forms.Form):
+    name = forms.CharField()
+    email = forms.EmailField()
+    message = forms.CharField(widget=forms.Textarea)

--- a/coresite/notifiers.py
+++ b/coresite/notifiers.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ContactNotifier:
+    def send(self, name: str, email: str, message: str) -> None:
+        logger.info({"event": "contact_message", "name": name, "email": email, "message": message})

--- a/coresite/templates/coresite/partials/contact/contact-form.html
+++ b/coresite/templates/coresite/partials/contact/contact-form.html
@@ -1,3 +1,23 @@
 <h2 id="contact-form-heading">General inquiries</h2>
 <p>Use this form for non-urgent questions; staff reviews messages each workday [ref:general].</p>
 <p>If the form is unavailable, email <a href="mailto:contact@technofatty.com" data-analytics-event="link.contact.email">contact@technofatty.com</a> for help [ref:general].</p>
+<form method="post" novalidate>
+  {% csrf_token %}
+  {{ form.non_field_errors }}
+  <p>
+    {{ form.name.label_tag }}
+    {{ form.name }}
+    {{ form.name.errors }}
+  </p>
+  <p>
+    {{ form.email.label_tag }}
+    {{ form.email }}
+    {{ form.email.errors }}
+  </p>
+  <p>
+    {{ form.message.label_tag }}
+    {{ form.message }}
+    {{ form.message.errors }}
+  </p>
+  <button type="submit">Send</button>
+</form>

--- a/coresite/tests/test_contact.py
+++ b/coresite/tests/test_contact.py
@@ -1,0 +1,27 @@
+from unittest import mock
+
+from django.urls import reverse
+from django.test import TestCase
+
+
+class ContactViewTests(TestCase):
+    @mock.patch("coresite.views.log_newsletter_event")
+    @mock.patch("coresite.views.ContactNotifier")
+    def test_valid_post_redirects(self, mock_notifier, mock_log):
+        data = {"name": "A", "email": "a@example.com", "message": "Hi"}
+        response = self.client.post(reverse("contact"), data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "/contact/?sent=1")
+        mock_notifier.return_value.send.assert_called_once_with(**data)
+        mock_log.assert_called_once_with(mock.ANY, "submitted_success")
+
+    def test_invalid_post_rerenders_with_errors_and_focus(self):
+        response = self.client.post(reverse("contact"), {})
+        self.assertEqual(response.status_code, 200)
+        form = response.context["form"]
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
+        self.assertEqual(
+            form.fields["name"].widget.attrs.get("autofocus"),
+            "autofocus",
+        )


### PR DESCRIPTION
## Summary
- Add `ContactForm` and `ContactNotifier` to process contact messages
- Expand `contact` view to validate form, send notifications, and redirect on success
- Render contact form with errors and autofocus handling for invalid submissions

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68ac401073e4832a9198c33962ec5b14