### PR TITLE
Add accessible contact form with honeypot and success banner

### DIFF
--- a/coresite/forms.py
+++ b/coresite/forms.py
@@ -4,4 +4,12 @@ from django import forms
 class ContactForm(forms.Form):
     name = forms.CharField()
     email = forms.EmailField()
+    subject = forms.CharField()
     message = forms.CharField(widget=forms.Textarea)
+    website = forms.CharField(required=False)
+
+    def clean_website(self):
+        website = self.cleaned_data.get("website")
+        if website:
+            raise forms.ValidationError("Leave empty")
+        return website

--- a/coresite/notifiers.py
+++ b/coresite/notifiers.py
@@ -4,5 +4,13 @@ logger = logging.getLogger(__name__)
 
 
 class ContactNotifier:
-    def send(self, name: str, email: str, message: str) -> None:
-        logger.info({"event": "contact_message", "name": name, "email": email, "message": message})
+    def send(self, name: str, email: str, subject: str, message: str) -> None:
+        logger.info(
+            {
+                "event": "contact_message",
+                "name": name,
+                "email": email,
+                "subject": subject,
+                "message": message,
+            }
+        )

--- a/coresite/templates/coresite/partials/contact/contact-form.html
+++ b/coresite/templates/coresite/partials/contact/contact-form.html
@@ -1,23 +1,37 @@
 <h2 id="contact-form-heading">General inquiries</h2>
 <p>Use this form for non-urgent questions; staff reviews messages each workday [ref:general].</p>
 <p>If the form is unavailable, email <a href="mailto:contact@technofatty.com" data-analytics-event="link.contact.email">contact@technofatty.com</a> for help [ref:general].</p>
+{% if sent %}
+<div class="form-success" role="status" aria-live="polite">
+  <p>Your message has been sent.</p>
+</div>
+{% endif %}
 <form method="post" novalidate>
   {% csrf_token %}
   {{ form.non_field_errors }}
   <p>
-    {{ form.name.label_tag }}
-    {{ form.name }}
-    {{ form.name.errors }}
+    <label for="{{ form.name.id_for_label }}">Name</label>
+    <input type="text" name="{{ form.name.html_name }}" id="{{ form.name.id_for_label }}" value="{{ form.name.value|default_if_none:'' }}" aria-invalid="{{ form.name.errors|yesno:'true,false' }}" aria-describedby="error-name">
+    <span id="error-name" role="alert" aria-live="polite">{% if form.name.errors %}{{ form.name.errors|striptags }}{% endif %}</span>
   </p>
   <p>
-    {{ form.email.label_tag }}
-    {{ form.email }}
-    {{ form.email.errors }}
+    <label for="{{ form.email.id_for_label }}">Email</label>
+    <input type="email" name="{{ form.email.html_name }}" id="{{ form.email.id_for_label }}" value="{{ form.email.value|default_if_none:'' }}" aria-invalid="{{ form.email.errors|yesno:'true,false' }}" aria-describedby="error-email">
+    <span id="error-email" role="alert" aria-live="polite">{% if form.email.errors %}{{ form.email.errors|striptags }}{% endif %}</span>
   </p>
   <p>
-    {{ form.message.label_tag }}
-    {{ form.message }}
-    {{ form.message.errors }}
+    <label for="{{ form.subject.id_for_label }}">Subject</label>
+    <input type="text" name="{{ form.subject.html_name }}" id="{{ form.subject.id_for_label }}" value="{{ form.subject.value|default_if_none:'' }}" aria-invalid="{{ form.subject.errors|yesno:'true,false' }}" aria-describedby="error-subject">
+    <span id="error-subject" role="alert" aria-live="polite">{% if form.subject.errors %}{{ form.subject.errors|striptags }}{% endif %}</span>
+  </p>
+  <p>
+    <label for="{{ form.message.id_for_label }}">Message</label>
+    <textarea name="{{ form.message.html_name }}" id="{{ form.message.id_for_label }}" aria-invalid="{{ form.message.errors|yesno:'true,false' }}" aria-describedby="error-message">{{ form.message.value|default_if_none:'' }}</textarea>
+    <span id="error-message" role="alert" aria-live="polite">{% if form.message.errors %}{{ form.message.errors|striptags }}{% endif %}</span>
+  </p>
+  <p class="visually-hidden">
+    <label for="{{ form.website.id_for_label }}">Website</label>
+    <input type="text" name="{{ form.website.html_name }}" id="{{ form.website.id_for_label }}" value="{{ form.website.value|default_if_none:'' }}" tabindex="-1" autocomplete="off">
   </p>
   <button type="submit">Send</button>
 </form>

--- a/coresite/tests/test_contact.py
+++ b/coresite/tests/test_contact.py
@@ -8,11 +8,19 @@ class ContactViewTests(TestCase):
     @mock.patch("coresite.views.log_newsletter_event")
     @mock.patch("coresite.views.ContactNotifier")
     def test_valid_post_redirects(self, mock_notifier, mock_log):
-        data = {"name": "A", "email": "a@example.com", "message": "Hi"}
+        data = {
+            "name": "A",
+            "email": "a@example.com",
+            "subject": "Hello",
+            "message": "Hi",
+            "website": "",
+        }
         response = self.client.post(reverse("contact"), data)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response["Location"], "/contact/?sent=1")
-        mock_notifier.return_value.send.assert_called_once_with(**data)
+        expected = data.copy()
+        expected.pop("website")
+        mock_notifier.return_value.send.assert_called_once_with(**expected)
         mock_log.assert_called_once_with(mock.ANY, "submitted_success")
 
     def test_invalid_post_rerenders_with_errors_and_focus(self):
@@ -25,3 +33,7 @@ class ContactViewTests(TestCase):
             form.fields["name"].widget.attrs.get("autofocus"),
             "autofocus",
         )
+
+    def test_sent_query_param_renders_success_banner(self):
+        response = self.client.get("/contact/?sent=1")
+        self.assertContains(response, "Your message has been sent.")

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -499,10 +499,12 @@ def legacy_services(request):
 
 def contact(request):
     footer = get_footer_content()
+    sent = request.GET.get("sent") == "1"
     if request.method == "POST":
         form = ContactForm(request.POST)
         if form.is_valid():
-            ContactNotifier().send(**form.cleaned_data)
+            data = {k: v for k, v in form.cleaned_data.items() if k != "website"}
+            ContactNotifier().send(**data)
             log_newsletter_event(request, "submitted_success")
             return redirect("/contact/?sent=1")
         first_error = next(iter(form.errors))
@@ -516,6 +518,7 @@ def contact(request):
             "footer": footer,
             "canonical_url": f"{BASE_CANONICAL}/contact/",
             "form": form,
+            "sent": sent,
         },
     )
 


### PR DESCRIPTION
## Summary
- Replace contact placeholder with form including name, email, subject, message, and hidden website honeypot.
- Add ARIA attributes and success banner for `?sent=1`.
- Extend notifier and view to handle subject and honeypot fields.

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68ac42a19908832a80252cc8740aeca5