### PR TITLE
Ignore var outbox directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ htmlcov/
 
 # Generated CSS
 coresite/static/coresite/scss/*.css
+
+# Ignore var outbox
+var/outbox/


### PR DESCRIPTION
## Summary
- ignore `var/outbox/` directory in git

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1 (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_e_68ac4a69dd34832ab5393b9a14496691