### PR TITLE
Add success banner and status region to contact form

### DIFF
--- a/coresite/templates/coresite/contact.html
+++ b/coresite/templates/coresite/contact.html
@@ -36,6 +36,11 @@
 
 <section id="contact-form" class="section" role="region" aria-labelledby="contact-form-heading">
   <div class="wrap">
+    {% if sent %}
+    <div class="form-success" role="status" aria-live="polite">
+      <p>Your message has been sent.</p>
+    </div>
+    {% endif %}
     {% include "coresite/partials/contact/contact-form.html" %}
   </div>
 </section>
@@ -63,5 +68,21 @@
     {% include "coresite/partials/contact/contact-cta.html" %}
   </div>
 </section>
+{% endblock %}
+
+{% block body_scripts %}
+  {{ block.super }}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const firstInvalid = document.querySelector("[aria-invalid='true']");
+      if (firstInvalid) {
+        firstInvalid.focus();
+        const status = document.getElementById('form-status');
+        if (status) {
+          status.textContent = 'Please correct the errors below.';
+        }
+      }
+    });
+  </script>
 {% endblock %}
 

--- a/coresite/templates/coresite/partials/contact/contact-form.html
+++ b/coresite/templates/coresite/partials/contact/contact-form.html
@@ -1,14 +1,9 @@
 <h2 id="contact-form-heading">General inquiries</h2>
 <p>Use this form for non-urgent questions; staff reviews messages each workday [ref:general].</p>
 <p>If the form is unavailable, email <a href="mailto:contact@technofatty.com" data-analytics-event="link.contact.email">contact@technofatty.com</a> for help [ref:general].</p>
-{% if sent %}
-<div class="form-success" role="status" aria-live="polite">
-  <p>Your message has been sent.</p>
-</div>
-{% endif %}
+<div id="form-status" role="status" aria-live="polite">{{ form.non_field_errors }}</div>
 <form method="post" novalidate>
   {% csrf_token %}
-  {{ form.non_field_errors }}
   <p>
     <label for="{{ form.name.id_for_label }}">Name</label>
     <input type="text" name="{{ form.name.html_name }}" id="{{ form.name.id_for_label }}" value="{{ form.name.value|default_if_none:'' }}" aria-invalid="{{ form.name.errors|yesno:'true,false' }}" aria-describedby="error-name">

--- a/coresite/tests/test_contact.py
+++ b/coresite/tests/test_contact.py
@@ -37,6 +37,11 @@ class ContactViewTests(TestCase):
             form.fields["name"].widget.attrs.get("autofocus"),
             "autofocus",
         )
+        self.assertContains(
+            response,
+            '<div id="form-status" role="status" aria-live="polite">',
+            html=False,
+        )
 
     def test_sent_query_param_renders_success_banner(self):
         response = self.client.get("/contact/?sent=1")


### PR DESCRIPTION
## Summary
- show a success banner on the contact page when `sent` query param is present
- expose an `aria-live` status region and focus the first invalid field on form errors
- test ensures status region renders on error

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest coresite/tests/test_contact.py` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68ac4df3a8d4832ab894aad78a7cd476