### PR TITLE
Register ContactEvent in admin for inspection

### DIFF
--- a/coresite/admin.py
+++ b/coresite/admin.py
@@ -6,6 +6,7 @@ from .models import (
     KnowledgeCategory,
     KnowledgeArticle,
     BlogPost,
+    ContactEvent,
 )
 
 @admin.register(SiteSettings)
@@ -57,3 +58,12 @@ class BlogPostAdmin(admin.ModelAdmin):
     list_filter = ("status",)
     prepopulated_fields = {"slug": ("title",)}
     date_hierarchy = "published_at"
+
+
+@admin.register(ContactEvent)
+class ContactEventAdmin(admin.ModelAdmin):
+    list_display = ("timestamp", "event_type", "ip_hash")
+    list_filter = ("event_type",)
+    search_fields = ("event_type", "ip_hash")
+    readonly_fields = ("timestamp", "event_type", "meta", "ip_hash")
+    ordering = ("-timestamp",)

--- a/coresite/models.py
+++ b/coresite/models.py
@@ -157,6 +157,13 @@ def set_knowledge_article_slug(sender, instance, **kwargs):
 
 
 class ContactEvent(models.Model):
+    """Record a contact-related event.
+
+    This minimal model provides an audit trail for contact interactions
+    while keeping the data model simple so that persisting events to an
+    external provider in the future would be straightforward.
+    """
+
     event_type = models.CharField(max_length=100)
     meta = models.JSONField(default=dict, blank=True)
     ip_hash = models.CharField(max_length=64, blank=True)


### PR DESCRIPTION
## Summary
- document ContactEvent model as a lightweight audit trail designed for future external providers
- expose ContactEvent in Django admin for review

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ac540083f4832a821e86d2b75b9b64