### PR TITLE
Add consent middleware and expose consent flag

### DIFF
--- a/coresite/context_processors.py
+++ b/coresite/context_processors.py
@@ -1,17 +1,10 @@
 from django.conf import settings
-from django.core.signing import BadSignature
 
 
 def analytics_flags(request):
     """Expose analytics configuration and consent flags."""
 
-    consent_granted = False
-    try:
-        consent_granted = (
-            request.get_signed_cookie(settings.CONSENT_COOKIE_NAME) == "true"
-        )
-    except (KeyError, BadSignature):
-        consent_granted = False
+    consent_granted = getattr(request, "CONSENT_GRANTED", False)
 
     return {
         "ANALYTICS_ENABLED": getattr(settings, "ANALYTICS_ENABLED", False),

--- a/coresite/middleware.py
+++ b/coresite/middleware.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+from django.core.signing import BadSignature
+
+
+class ConsentMiddleware:
+    """Attach CONSENT_GRANTED flag to each request."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        consent_granted = False
+        try:
+            consent_granted = (
+                request.get_signed_cookie(settings.CONSENT_COOKIE_NAME) == "true"
+            )
+        except (KeyError, BadSignature):
+            consent_granted = False
+        request.CONSENT_GRANTED = consent_granted
+        response = self.get_response(request)
+        return response

--- a/coresite/tests/test_analytics_flags.py
+++ b/coresite/tests/test_analytics_flags.py
@@ -1,15 +1,24 @@
 import pytest
+from django.http import HttpResponse
 from django.test import RequestFactory
 from django.core import signing
 from django.urls import reverse
 
 from coresite.context_processors import analytics_flags
+from coresite.middleware import ConsentMiddleware
+
+
+def _apply_middleware(request):
+    middleware = ConsentMiddleware(lambda req: HttpResponse("OK"))
+    middleware(request)
 
 
 def test_consent_not_granted_without_cookie():
     rf = RequestFactory()
     request = rf.get('/')
+    _apply_middleware(request)
     context = analytics_flags(request)
+    assert request.CONSENT_GRANTED is False
     assert context['CONSENT_GRANTED'] is False
 
 
@@ -17,7 +26,9 @@ def test_consent_granted_with_valid_cookie(settings):
     rf = RequestFactory()
     request = rf.get('/')
     request.COOKIES[settings.CONSENT_COOKIE_NAME] = signing.dumps('true')
+    _apply_middleware(request)
     context = analytics_flags(request)
+    assert request.CONSENT_GRANTED is True
     assert context['CONSENT_GRANTED'] is True
 
 
@@ -25,7 +36,9 @@ def test_consent_not_granted_with_invalid_cookie(settings):
     rf = RequestFactory()
     request = rf.get('/')
     request.COOKIES[settings.CONSENT_COOKIE_NAME] = 'true'  # unsigned value
+    _apply_middleware(request)
     context = analytics_flags(request)
+    assert request.CONSENT_GRANTED is False
     assert context['CONSENT_GRANTED'] is False
 
 

--- a/technofatty_com/settings.py
+++ b/technofatty_com/settings.py
@@ -93,6 +93,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "coresite.middleware.ConsentMiddleware",
 ]
 
 ROOT_URLCONF = "technofatty_com.urls"


### PR DESCRIPTION
## Summary
- Add `ConsentMiddleware` to verify signed consent cookie and store result on the request
- Expose request consent flag to templates via updated `analytics_flags` context processor
- Register middleware and extend tests to exercise new consent handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5d9594b4832a85a1e30a91d2850b