### PR TITLE
feat: add consent banner and always load analytics

### DIFF
--- a/coresite/context_processors.py
+++ b/coresite/context_processors.py
@@ -1,10 +1,13 @@
 from django.conf import settings
+from django.core import signing
 
 
 def analytics_flags(request):
     """Expose analytics configuration and consent flags."""
 
     consent_granted = getattr(request, "CONSENT_GRANTED", False)
+
+    signer = signing.get_cookie_signer()
 
     return {
         "ANALYTICS_ENABLED": getattr(settings, "ANALYTICS_ENABLED", False),
@@ -27,6 +30,8 @@ def analytics_flags(request):
         "CONSENT_COOKIE_HTTPONLY": getattr(
             settings, "CONSENT_COOKIE_HTTPONLY", True
         ),
+        "CONSENT_ACCEPT_TOKEN": signer.sign("true"),
+        "CONSENT_DECLINE_TOKEN": signer.sign("false"),
     }
 
 

--- a/coresite/templates/coresite/base.html
+++ b/coresite/templates/coresite/base.html
@@ -23,13 +23,15 @@
       data-consent-cookie-max-age="{{ CONSENT_COOKIE_MAX_AGE }}"
       data-consent-cookie-samesite="{{ CONSENT_COOKIE_SAMESITE }}"
       data-consent-cookie-secure="{{ CONSENT_COOKIE_SECURE|yesno:'true,false' }}"
-      data-consent-cookie-httponly="{{ CONSENT_COOKIE_HTTPONLY|yesno:'true,false' }}">
+      data-consent-cookie-httponly="{{ CONSENT_COOKIE_HTTPONLY|yesno:'true,false' }}"
+      data-consent-token-accept="{{ CONSENT_ACCEPT_TOKEN }}"
+      data-consent-token-decline="{{ CONSENT_DECLINE_TOKEN }}">
   <a class="skip-link" href="#main">Skip to content</a>
 
+  {% include 'coresite/partials/consent_banner.html' %}
+
   {% if ANALYTICS_ENABLED %}
-    {% if not CONSENT_REQUIRED or CONSENT_GRANTED %}
-      {% include 'coresite/partials/global/analytics.html' %}
-    {% endif %}
+    {% include 'coresite/partials/global/analytics.html' %}
   {% endif %}
 
   {% include 'coresite/partials/global/build_banner.html' %}

--- a/coresite/templates/coresite/partials/consent_banner.html
+++ b/coresite/templates/coresite/partials/consent_banner.html
@@ -1,0 +1,7 @@
+<div id="consent-banner" class="consent-banner" role="region" aria-label="Cookie consent" hidden data-consent-banner>
+  <p>We use cookies for analytics. You can accept or decline.</p>
+  <div class="consent-banner__actions">
+    <a href="{% url 'consent_accept' %}" data-consent-choice="accept" class="button">Accept</a>
+    <a href="{% url 'consent_decline' %}" data-consent-choice="decline" class="button button--secondary">Decline</a>
+  </div>
+</div>

--- a/coresite/templates/coresite/partials/global/analytics.html
+++ b/coresite/templates/coresite/partials/global/analytics.html
@@ -1,30 +1,28 @@
-{% if not CONSENT_REQUIRED or CONSENT_GRANTED %}
-  {% if ANALYTICS_PROVIDER == 'plausible' and ANALYTICS_SITE_ID %}
-    <script defer data-domain="{{ ANALYTICS_SITE_ID }}" src="https://plausible.io/js/script.js"></script>
-  {% elif ANALYTICS_PROVIDER == 'ga4' and ANALYTICS_SITE_ID %}
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ ANALYTICS_SITE_ID }}"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', '{{ ANALYTICS_SITE_ID }}');
-    </script>
-  {% endif %}
-  {% if ANALYTICS_PROVIDER == 'plausible' or ANALYTICS_PROVIDER == 'ga4' %}
-    <script>
-      (function(){
-        var p=document.body.dataset.analyticsProvider;
-        function send(n,m){m=m||{};if(p==='plausible'&&window.plausible){window.plausible(n,{props:m});}
-          else if(p==='ga4'&&window.gtag){window.gtag('event',n,m);}}
-        var fired={};
-        function meta(el){try{return JSON.parse(el.dataset.analyticsMeta||'{}')}catch(e){return {};}}
-        document.addEventListener('click',function(e){var el=e.target;
-          while(el){var n=el.dataset&&el.dataset.analyticsEvent;if(n){send(n,meta(el));break;}el=el.parentElement;}});
-        document.addEventListener('submit',function(e){var el=e.target,n=el.dataset.analyticsEvent;
-          if(n){if(el.checkValidity&&!el.checkValidity())return;send(n,meta(el));}});
-        document.addEventListener('focusin',function(e){var el=e.target,n=el.dataset.analyticsEvent;
-          if(n&&!fired[n]){fired[n]=1;send(n,meta(el));}});
-      })();
-    </script>
-  {% endif %}
+{% if ANALYTICS_PROVIDER == 'plausible' and ANALYTICS_SITE_ID %}
+  <script defer data-domain="{{ ANALYTICS_SITE_ID }}" src="https://plausible.io/js/script.js"></script>
+{% elif ANALYTICS_PROVIDER == 'ga4' and ANALYTICS_SITE_ID %}
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ ANALYTICS_SITE_ID }}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', '{{ ANALYTICS_SITE_ID }}');
+  </script>
+{% endif %}
+{% if ANALYTICS_PROVIDER == 'plausible' or ANALYTICS_PROVIDER == 'ga4' %}
+  <script>
+    (function(){
+      var p=document.body.dataset.analyticsProvider;
+      function send(n,m){m=m||{};if(p==='plausible'&&window.plausible){window.plausible(n,{props:m});}
+        else if(p==='ga4'&&window.gtag){window.gtag('event',n,m);}}
+      var fired={};
+      function meta(el){try{return JSON.parse(el.dataset.analyticsMeta||'{}')}catch(e){return {};}}
+      document.addEventListener('click',function(e){var el=e.target;
+        while(el){var n=el.dataset&&el.dataset.analyticsEvent;if(n){send(n,meta(el));break;}el=el.parentElement;}});
+      document.addEventListener('submit',function(e){var el=e.target,n=el.dataset.analyticsEvent;
+        if(n){if(el.checkValidity&&!el.checkValidity())return;send(n,meta(el));}});
+      document.addEventListener('focusin',function(e){var el=e.target,n=el.dataset.analyticsEvent;
+        if(n&&!fired[n]){fired[n]=1;send(n,meta(el));}});
+    })();
+  </script>
 {% endif %}

--- a/coresite/tests/test_analytics_flags.py
+++ b/coresite/tests/test_analytics_flags.py
@@ -75,3 +75,11 @@ def test_cookie_settings_exposed(settings):
     assert context['CONSENT_COOKIE_SAMESITE'] == settings.CONSENT_COOKIE_SAMESITE
     assert context['CONSENT_COOKIE_SECURE'] == settings.CONSENT_COOKIE_SECURE
     assert context['CONSENT_COOKIE_HTTPONLY'] == settings.CONSENT_COOKIE_HTTPONLY
+
+
+def test_consent_tokens_exposed(settings):
+    rf = RequestFactory()
+    request = rf.get('/')
+    context = analytics_flags(request)
+    assert signing.loads(context['CONSENT_ACCEPT_TOKEN']) == 'true'
+    assert signing.loads(context['CONSENT_DECLINE_TOKEN']) == 'false'

--- a/docs/global_partials_readme.md
+++ b/docs/global_partials_readme.md
@@ -22,15 +22,20 @@ The `id` matches the heading’s `-heading` suffix. Example usage appears throug
 ### Design tokens
 All styling values come from `_variables.scss`, the single source of truth for SCSS/CSS tokens【F:coresite/static/coresite/scss/abstracts/_variables.scss†L1-L8】.
 
-### Consent-aware analytics
-Analytics is tied to the site's consent banner. Until a user grants tracking permission, the analytics partial outputs nothing and no tracking scripts run【F:coresite/templates/coresite/partials/global/analytics.html†L1-L30】.
+### Analytics and consent
+Analytics scripts run whenever enabled. The consent banner simply records the visitor's preference in a signed cookie【F:coresite/templates/coresite/base.html†L20-L28】.
 
 ## Partial reference
 
+### Consent banner
+* **Path**: `coresite/templates/coresite/partials/consent_banner.html`
+* **Purpose**: Prompts visitors to accept or decline analytics cookies【F:coresite/templates/coresite/partials/consent_banner.html†L1-L8】
+* **Included in**: `base.html` (thus every page)【F:coresite/templates/coresite/base.html†L30-L32】
+
 ### Analytics
 * **Path**: `coresite/templates/coresite/partials/global/analytics.html`
-* **Purpose**: Loads the provider snippet and tiny event dispatcher only after tracking consent is granted【F:coresite/templates/coresite/partials/global/analytics.html†L1-L30】
-* **Included in**: `base.html` (thus every page)【F:coresite/templates/coresite/base.html†L21-L23】
+* **Purpose**: Loads the provider snippet and tiny event dispatcher when analytics is enabled【F:coresite/templates/coresite/partials/global/analytics.html†L1-L27】
+* **Included in**: `base.html` (thus every page)【F:coresite/templates/coresite/base.html†L34-L36】
 
 ### Header and primary navigation
 * **Path**: `coresite/templates/coresite/partials/global/header_nav.html`
@@ -91,7 +96,7 @@ Analytics is tied to the site's consent banner. Until a user grants tracking per
 * **Status**: No global notice partial exists yet; site currently has no mechanism for site-wide alert banners.
 
 ## Inclusion map
-- All templates → analytics
+- All templates → analytics, consent_banner
 - `coresite/templates/coresite/homepage.html` → header_nav, hero, trust, featured_grid, newsletter_block, signals_block, support_block, community_block
 - `coresite/templates/coresite/about.html` → header_nav
 - `coresite/templates/coresite/contact.html` → header_nav


### PR DESCRIPTION
## Summary
- add cookie consent banner partial and include it on every page
- expose signed consent tokens for JavaScript and run analytics regardless of consent
- document consent banner and update analytics partial

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68ac631d764c832ab5d48a50cb14e6ef