### PR TITLE
Implement accessible consent banner logic and styles

### DIFF
--- a/coresite/static/coresite/js/consent.js
+++ b/coresite/static/coresite/js/consent.js
@@ -1,0 +1,81 @@
+"use strict";
+
+document.addEventListener('DOMContentLoaded', () => {
+  const banner = document.querySelector('[data-consent-banner]');
+  const body = document.body;
+  if (!banner || !body) return;
+
+  const required = body.dataset.consentRequired === 'true';
+  const granted = body.dataset.consentGranted === 'true';
+  if (!required || granted) return;
+
+  // Accessibility attributes and reveal
+  banner.removeAttribute('hidden');
+  banner.setAttribute('role', 'dialog');
+  banner.setAttribute('aria-modal', 'true');
+  banner.setAttribute('aria-hidden', 'false');
+
+  const focusableSelectors = 'a, button';
+  const focusables = banner.querySelectorAll(focusableSelectors);
+  const firstFocusable = focusables[0];
+  const lastFocusable = focusables[focusables.length - 1];
+  let previousFocus = document.activeElement;
+  if (firstFocusable) firstFocusable.focus();
+
+  function trapFocus(e) {
+    if (!firstFocusable || !lastFocusable) return;
+    if (e.key === 'Tab') {
+      if (e.shiftKey) {
+        if (document.activeElement === firstFocusable) {
+          e.preventDefault();
+          lastFocusable.focus();
+        }
+      } else {
+        if (document.activeElement === lastFocusable) {
+          e.preventDefault();
+          firstFocusable.focus();
+        }
+      }
+    } else if (e.key === 'Escape') {
+      setConsent('rejected');
+    }
+  }
+
+  banner.addEventListener('keydown', trapFocus);
+
+  function hideBanner() {
+    banner.setAttribute('hidden', '');
+    banner.setAttribute('aria-hidden', 'true');
+    banner.removeEventListener('keydown', trapFocus);
+    if (previousFocus) previousFocus.focus();
+  }
+
+  function setConsent(state) {
+    const name = body.dataset.consentCookieName || 'tf_consent';
+    const maxAge = parseInt(body.dataset.consentCookieMaxAge, 10) || 0;
+    const samesite = body.dataset.consentCookieSamesite || 'Lax';
+    const secure = body.dataset.consentCookieSecure === 'true';
+
+    let cookie = `${encodeURIComponent(name)}=${encodeURIComponent(state)}; Max-Age=${maxAge}; Path=/; SameSite=${samesite}`;
+    if (secure) cookie += '; Secure';
+    document.cookie = cookie;
+
+    try {
+      window.localStorage.setItem(name, state);
+    } catch (err) {
+      /* ignore */
+    }
+
+    body.dataset.consentGranted = 'true';
+    hideBanner();
+  }
+
+  banner.querySelectorAll('[data-consent-choice]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      const choice = btn.dataset.consentChoice === 'accept' ? 'accepted' : 'rejected';
+      setConsent(choice);
+    });
+  });
+});
+

--- a/coresite/static/coresite/scss/components/_consent.scss
+++ b/coresite/static/coresite/scss/components/_consent.scss
@@ -1,0 +1,23 @@
+.consent-banner {
+  background-color: c(bg-alt);
+  color: c(text-strong);
+  padding: s(3);
+  font-size: fs(sm-md);
+  box-shadow: sh(md);
+  border-top-left-radius: r(sm);
+  border-top-right-radius: r(sm);
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: z(toast);
+  display: flex;
+  flex-direction: column;
+  gap: s(2);
+
+  &__actions {
+    display: flex;
+    justify-content: center;
+    gap: s(2);
+  }
+}

--- a/coresite/static/coresite/scss/main.scss
+++ b/coresite/static/coresite/scss/main.scss
@@ -21,6 +21,7 @@
 @import 'components/desktop-nav';
 @import 'components/status';
 @import 'components/build-banner';
+@import 'components/consent';
 @import 'components/pager';
 
 // Layout

--- a/coresite/templates/coresite/base.html
+++ b/coresite/templates/coresite/base.html
@@ -46,6 +46,7 @@
 
   {% include 'coresite/partials/global/footer.html' %}
 
+  <script src="{% static 'coresite/js/consent.js' %}?v={{ now|date:'U' }}" defer></script>
   <script src="{% static 'coresite/js/main.js' %}?v={{ now|date:'U' }}" defer></script>
   {% block body_scripts %}{% endblock %}
 </body>


### PR DESCRIPTION
## Summary
- Add client-side consent banner script to manage cookie/localStorage, focus trapping, and ARIA attributes
- Style consent banner using design tokens and include styles in build
- Load consent script in base template

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac65c374c4832aa6a0e47595559015