### PR TITLE
Document consent banner and analytics consent

### DIFF
--- a/docs/global_partials_readme.md
+++ b/docs/global_partials_readme.md
@@ -23,13 +23,13 @@ The `id` matches the heading’s `-heading` suffix. Example usage appears throug
 All styling values come from `_variables.scss`, the single source of truth for SCSS/CSS tokens【F:coresite/static/coresite/scss/abstracts/_variables.scss†L1-L8】.
 
 ### Analytics and consent
-Analytics scripts run whenever enabled. The consent banner simply records the visitor's preference in a signed cookie【F:coresite/templates/coresite/base.html†L20-L28】.
+Analytics runs only when allowed by consent rules. The visitor's choice is stored in the `tf_consent` cookie and exposed to templates as `CONSENT_GRANTED`【F:coresite/context_processors.py†L8-L18】. `ANALYTICS_ENABLED` evaluates to true only when analytics is configured and either consent isn't required or `CONSENT_GRANTED` is true, so the analytics partial renders only under those conditions【F:coresite/templates/coresite/base.html†L30-L36】.
 
 ## Partial reference
 
 ### Consent banner
 * **Path**: `coresite/templates/coresite/partials/consent_banner.html`
-* **Purpose**: Prompts visitors to accept or decline analytics cookies【F:coresite/templates/coresite/partials/consent_banner.html†L1-L8】
+* **Purpose**: Prompts visitors to accept or decline analytics cookies and sets the `tf_consent` cookie accordingly【F:coresite/templates/coresite/partials/consent_banner.html†L1-L8】
 * **Included in**: `base.html` (thus every page)【F:coresite/templates/coresite/base.html†L30-L32】
 
 ### Analytics
@@ -96,7 +96,7 @@ Analytics scripts run whenever enabled. The consent banner simply records the vi
 * **Status**: No global notice partial exists yet; site currently has no mechanism for site-wide alert banners.
 
 ## Inclusion map
-- All templates → analytics, consent_banner
+- All templates → consent_banner, analytics (when enabled)
 - `coresite/templates/coresite/homepage.html` → header_nav, hero, trust, featured_grid, newsletter_block, signals_block, support_block, community_block
 - `coresite/templates/coresite/about.html` → header_nav
 - `coresite/templates/coresite/contact.html` → header_nav


### PR DESCRIPTION
## Summary
- explain tf_consent cookie and CONSENT_GRANTED flag in the global partials guide
- note that analytics runs only when consent rules allow
- clarify inclusion map for conditional analytics

## Testing
- `pytest` *(fails: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1: Cannot connect to proxy. Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6a064830832abdb8b5fa23b1e522