### PR TITLE
Add signup and auth URL configurations

### DIFF
--- a/coresite/templates/registration/signup.html
+++ b/coresite/templates/registration/signup.html
@@ -1,0 +1,9 @@
+{% extends "coresite/base.html" %}
+{% block content %}
+<h1>Sign up</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Sign up</button>
+</form>
+{% endblock %}

--- a/technofatty_com/settings.py
+++ b/technofatty_com/settings.py
@@ -119,6 +119,14 @@ TEMPLATES = [
     },
 ]
 
+# -------------------------------------------------
+# Authentication redirects
+# -------------------------------------------------
+LOGIN_URL = "account_login"
+LOGIN_REDIRECT_URL = "account"
+LOGOUT_REDIRECT_URL = "home"
+
+
 WSGI_APPLICATION = "technofatty_com.wsgi.application"
 
 # -------------------------------------------------

--- a/technofatty_com/urls.py
+++ b/technofatty_com/urls.py
@@ -12,11 +12,40 @@ from django.contrib.auth import views as auth_views
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic import TemplateView
 from coresite import views as core_views
+from .views import SignupView
 
 
 class AccountHomeView(LoginRequiredMixin, TemplateView):
     template_name = "coresite/account/account_home.html"
     login_url = reverse_lazy("account_login")
+
+
+account_patterns = [
+    path("", AccountHomeView.as_view(), name="account"),
+    path("login/", auth_views.LoginView.as_view(), name="account_login"),
+    path("password_reset/", auth_views.PasswordResetView.as_view(), name="password_reset"),
+    path(
+        "password_reset/done/",
+        auth_views.PasswordResetDoneView.as_view(),
+        name="password_reset_done",
+    ),
+    path(
+        "reset/<uidb64>/<token>/",
+        auth_views.PasswordResetConfirmView.as_view(),
+        name="password_reset_confirm",
+    ),
+    path(
+        "reset/done/",
+        auth_views.PasswordResetCompleteView.as_view(),
+        name="password_reset_complete",
+    ),
+    path("password_change/", auth_views.PasswordChangeView.as_view(), name="password_change"),
+    path(
+        "password_change/done/",
+        auth_views.PasswordChangeDoneView.as_view(),
+        name="password_change_done",
+    ),
+]
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -24,9 +53,9 @@ urlpatterns = [
     path('newsletter/', include('newsletter.urls')),
     path('robots.txt', core_views.robots_txt, name="robots_txt"),
     path('sitemap.xml', core_views.sitemap_xml, name="sitemap_xml"),
-    path('account/login/', auth_views.LoginView.as_view(), name='account_login'),
-    path('account/logout/', auth_views.LogoutView.as_view(), name='account_logout'),
-    path('account/', AccountHomeView.as_view(), name='account'),
+    path('signup/', SignupView.as_view(), name='signup'),
+    path('logout/', auth_views.LogoutView.as_view(), name='logout'),
+    path('account/', include(account_patterns)),
 ]
 
 if settings.DEBUG:

--- a/technofatty_com/views.py
+++ b/technofatty_com/views.py
@@ -1,0 +1,9 @@
+from django.contrib.auth.forms import UserCreationForm
+from django.urls import reverse_lazy
+from django.views.generic import CreateView
+
+
+class SignupView(CreateView):
+    form_class = UserCreationForm
+    template_name = "registration/signup.html"
+    success_url = reverse_lazy("account_login")


### PR DESCRIPTION
## Summary
- add custom SignupView and registration template
- route `/signup/`, `/logout/`, and `/account/` auth views
- configure login, logout, and redirect URLs

## Testing
- `DB_ENGINE=sqlite pytest` *(fails: No module named 'django')*
- `pip install -r requirements.txt` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7992cb40832a87d5feaebfbc730d