### PR TITLE
Add signup activation flow

### DIFF
--- a/coresite/auth_views.py
+++ b/coresite/auth_views.py
@@ -1,0 +1,50 @@
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.contrib.auth.tokens import default_token_generator
+from django.urls import reverse, reverse_lazy
+from django.utils.encoding import force_bytes, force_str
+from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
+from django.views.generic import CreateView, View
+from django.core.mail import send_mail
+from django.shortcuts import render
+
+from .forms import SignUpForm
+
+
+class SignupView(CreateView):
+    form_class = SignUpForm
+    template_name = "registration/signup.html"
+    success_url = reverse_lazy("account_login")
+
+    def form_valid(self, form):
+        user = form.save(commit=False)
+        user.is_active = False
+        user.save()
+        token = default_token_generator.make_token(user)
+        uid = urlsafe_base64_encode(force_bytes(user.pk))
+        activation_link = self.request.build_absolute_uri(
+            reverse("activate", kwargs={"uidb64": uid, "token": token})
+        )
+        send_mail(
+            "Activate your account",
+            f"Activate your account: {activation_link}",
+            getattr(settings, "DEFAULT_FROM_EMAIL", None),
+            [user.email],
+        )
+        return super().form_valid(form)
+
+
+class ActivateView(View):
+    def get(self, request, uidb64, token):
+        try:
+            uid = force_str(urlsafe_base64_decode(uidb64))
+            user = User.objects.get(pk=uid)
+        except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+            user = None
+        if user is not None and default_token_generator.check_token(user, token):
+            user.is_active = True
+            user.save()
+            status = 200
+        else:
+            status = 400
+        return render(request, "registration/activation_complete.html", status=status)

--- a/coresite/forms.py
+++ b/coresite/forms.py
@@ -1,5 +1,7 @@
 from django import forms
 from django.core.exceptions import ValidationError
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.models import User
 
 
 class ContactForm(forms.Form):
@@ -14,3 +16,11 @@ class ContactForm(forms.Form):
         if website:
             raise ValidationError("Leave empty")
         return website
+
+
+class SignUpForm(UserCreationForm):
+    email = forms.EmailField(required=True)
+
+    class Meta:
+        model = User
+        fields = ("username", "email", "password1", "password2")

--- a/coresite/templates/registration/activation_complete.html
+++ b/coresite/templates/registration/activation_complete.html
@@ -1,0 +1,5 @@
+{% extends "coresite/base.html" %}
+{% block content %}
+<h1>Activation complete</h1>
+<p>Your account has been activated. You can now <a href="{% url 'account_login' %}">log in</a>.</p>
+{% endblock %}

--- a/coresite/templates/registration/signup.html
+++ b/coresite/templates/registration/signup.html
@@ -1,6 +1,7 @@
 {% extends "coresite/base.html" %}
 {% block content %}
 <h1>Sign up</h1>
+<p>Fill out the form below. An activation link will be sent to your email.</p>
 <form method="post">
   {% csrf_token %}
   {{ form.as_p }}

--- a/technofatty_com/urls.py
+++ b/technofatty_com/urls.py
@@ -12,7 +12,7 @@ from django.contrib.auth import views as auth_views
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic import TemplateView
 from coresite import views as core_views
-from .views import SignupView
+from coresite.auth_views import SignupView, ActivateView
 
 
 class AccountHomeView(LoginRequiredMixin, TemplateView):
@@ -54,6 +54,7 @@ urlpatterns = [
     path('robots.txt', core_views.robots_txt, name="robots_txt"),
     path('sitemap.xml', core_views.sitemap_xml, name="sitemap_xml"),
     path('signup/', SignupView.as_view(), name='signup'),
+    path('activate/<uidb64>/<token>/', ActivateView.as_view(), name='activate'),
     path('logout/', auth_views.LogoutView.as_view(), name='logout'),
     path('account/', include(account_patterns)),
 ]

--- a/technofatty_com/views.py
+++ b/technofatty_com/views.py
@@ -1,9 +1,0 @@
-from django.contrib.auth.forms import UserCreationForm
-from django.urls import reverse_lazy
-from django.views.generic import CreateView
-
-
-class SignupView(CreateView):
-    form_class = UserCreationForm
-    template_name = "registration/signup.html"
-    success_url = reverse_lazy("account_login")


### PR DESCRIPTION
## Summary
- add SignUpForm and activation views
- create activation completion template and update signup page
- wire up signup and activation URLs

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7b79efc4832a867ff824b17b4afb