### PR TITLE
Add account password management views and templates

### DIFF
--- a/coresite/templates/registration/password_change_form.html
+++ b/coresite/templates/registration/password_change_form.html
@@ -1,0 +1,10 @@
+{% extends "coresite/base.html" %}
+{% block content %}
+<h1>Change password</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Change password</button>
+</form>
+{% endblock %}
+

--- a/coresite/templates/registration/password_reset_complete.html
+++ b/coresite/templates/registration/password_reset_complete.html
@@ -1,0 +1,6 @@
+{% extends "coresite/base.html" %}
+{% block content %}
+<h1>Password reset complete</h1>
+<p>Your password has been set. You may now <a href="{% url 'account_login' %}">log in</a>.</p>
+{% endblock %}
+

--- a/coresite/templates/registration/password_reset_confirm.html
+++ b/coresite/templates/registration/password_reset_confirm.html
@@ -1,0 +1,10 @@
+{% extends "coresite/base.html" %}
+{% block content %}
+<h1>Set new password</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Change password</button>
+</form>
+{% endblock %}
+

--- a/coresite/templates/registration/password_reset_done.html
+++ b/coresite/templates/registration/password_reset_done.html
@@ -1,0 +1,6 @@
+{% extends "coresite/base.html" %}
+{% block content %}
+<h1>Password reset sent</h1>
+<p>Check your email for instructions to reset your password.</p>
+{% endblock %}
+

--- a/coresite/templates/registration/password_reset_form.html
+++ b/coresite/templates/registration/password_reset_form.html
@@ -1,0 +1,10 @@
+{% extends "coresite/base.html" %}
+{% block content %}
+<h1>Password reset</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Reset password</button>
+ </form>
+{% endblock %}
+

--- a/technofatty_com/urls.py
+++ b/technofatty_com/urls.py
@@ -23,23 +23,41 @@ class AccountHomeView(LoginRequiredMixin, TemplateView):
 account_patterns = [
     path("", AccountHomeView.as_view(), name="account"),
     path("login/", auth_views.LoginView.as_view(), name="account_login"),
-    path("password_reset/", auth_views.PasswordResetView.as_view(), name="password_reset"),
+    path(
+        "password_reset/",
+        auth_views.PasswordResetView.as_view(
+            template_name="registration/password_reset_form.html"
+        ),
+        name="password_reset",
+    ),
     path(
         "password_reset/done/",
-        auth_views.PasswordResetDoneView.as_view(),
+        auth_views.PasswordResetDoneView.as_view(
+            template_name="registration/password_reset_done.html"
+        ),
         name="password_reset_done",
     ),
     path(
         "reset/<uidb64>/<token>/",
-        auth_views.PasswordResetConfirmView.as_view(),
+        auth_views.PasswordResetConfirmView.as_view(
+            template_name="registration/password_reset_confirm.html"
+        ),
         name="password_reset_confirm",
     ),
     path(
         "reset/done/",
-        auth_views.PasswordResetCompleteView.as_view(),
+        auth_views.PasswordResetCompleteView.as_view(
+            template_name="registration/password_reset_complete.html"
+        ),
         name="password_reset_complete",
     ),
-    path("password_change/", auth_views.PasswordChangeView.as_view(), name="password_change"),
+    path(
+        "password_change/",
+        auth_views.PasswordChangeView.as_view(
+            template_name="registration/password_change_form.html"
+        ),
+        name="password_change",
+    ),
     path(
         "password_change/done/",
         auth_views.PasswordChangeDoneView.as_view(),


### PR DESCRIPTION
## Summary
- configure password reset and change views under `/account/`
- add password reset and change templates for registration

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68ac7e3da1fc832a8a496cfa4876cfb8