### PR TITLE
Add configurable email backend setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,12 @@ ANALYTICS_ENABLED=false
 ANALYTICS_PROVIDER=plausible
 ANALYTICS_SITE_ID=
 CONSENT_REQUIRED=true
+
+# Email backend: 'file' writes emails to disk, 'smtp' sends them via SMTP
+TF_EMAIL_BACKEND=file
+# EMAIL_FILE_PATH=var/outbox
+# EMAIL_HOST=smtp.example.com
+# EMAIL_PORT=587
+# EMAIL_HOST_USER=
+# EMAIL_HOST_PASSWORD=
+# EMAIL_USE_TLS=true

--- a/README.md
+++ b/README.md
@@ -53,5 +53,6 @@ Required variables:
 - `ANALYTICS_PROVIDER`
 - `ANALYTICS_SITE_ID`
 - `CONSENT_REQUIRED`
+- `TF_EMAIL_BACKEND`
 
 See `.env.example` for placeholder values.

--- a/technofatty_com/settings.py
+++ b/technofatty_com/settings.py
@@ -214,10 +214,23 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # -------------------------------------------------
 # Email
 # -------------------------------------------------
-EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
-EMAIL_FILE_PATH = os.environ.get(
-    "EMAIL_FILE_PATH", os.path.join(BASE_DIR, "var", "outbox")
-)
+# Email
+# -------------------------------------------------
+TF_EMAIL_BACKEND = os.environ.get("TF_EMAIL_BACKEND", "file").lower()
+
+if TF_EMAIL_BACKEND == "smtp":
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    EMAIL_HOST = os.environ.get("EMAIL_HOST", "localhost")
+    EMAIL_PORT = int(os.environ.get("EMAIL_PORT", "25"))
+    EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
+    EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
+    EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "false").lower() == "true"
+    EMAIL_USE_SSL = os.environ.get("EMAIL_USE_SSL", "false").lower() == "true"
+else:
+    EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
+    EMAIL_FILE_PATH = os.environ.get(
+        "EMAIL_FILE_PATH", os.path.join(BASE_DIR, "var", "outbox")
+    )
 
 DEFAULT_FROM_EMAIL = "no-reply@technofatty.com"
 


### PR DESCRIPTION
## Summary
- Add TF_EMAIL_BACKEND env switch to choose file or SMTP
- Wire email backend settings based on TF_EMAIL_BACKEND
- Document new setting in example env and README

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref due to proxy issues)*
- `DB_ENGINE=sqlite python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68ac81cc4d54832a9e8e0b9f6d49211e