### PR TITLE
Harden session cookies and add remember-me support

### DIFF
--- a/coresite/auth_views.py
+++ b/coresite/auth_views.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
+from django.contrib.auth.views import LoginView as DjangoLoginView
 from django.urls import reverse, reverse_lazy
 from django.utils.encoding import force_bytes, force_str
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
@@ -31,6 +32,20 @@ class SignupView(CreateView):
             getattr(settings, "DEFAULT_FROM_EMAIL", None),
             [user.email],
         )
+        return super().form_valid(form)
+
+
+class LoginView(DjangoLoginView):
+    """Extend session lifetime when "remember me" is checked."""
+
+    def form_valid(self, form):
+        remember_me = self.request.POST.get("remember_me")
+        if remember_me:
+            self.request.session.set_expiry(
+                getattr(settings, "REMEMBER_ME_SESSION_AGE", 60 * 60 * 24 * 14)
+            )
+        else:
+            self.request.session.set_expiry(settings.SESSION_COOKIE_AGE)
         return super().form_valid(form)
 
 

--- a/technofatty_com/settings.py
+++ b/technofatty_com/settings.py
@@ -206,6 +206,14 @@ CSRF_TRUSTED_ORIGINS = [
     "https://www.technofatty.com",
 ]
 
+# Secure cookies and sane defaults
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SAMESITE = "Lax"
+CSRF_COOKIE_SAMESITE = "Lax"
+SESSION_COOKIE_AGE = 60 * 60 * 24  # 24 hours
+REMEMBER_ME_SESSION_AGE = 60 * 60 * 24 * 14  # 14 days
+
 # -------------------------------------------------
 # Auto field
 # -------------------------------------------------

--- a/technofatty_com/urls.py
+++ b/technofatty_com/urls.py
@@ -12,7 +12,7 @@ from django.contrib.auth import views as auth_views
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic import TemplateView
 from coresite import views as core_views
-from coresite.auth_views import SignupView, ActivateView
+from coresite.auth_views import SignupView, ActivateView, LoginView
 
 
 class AccountHomeView(LoginRequiredMixin, TemplateView):
@@ -22,7 +22,7 @@ class AccountHomeView(LoginRequiredMixin, TemplateView):
 
 account_patterns = [
     path("", AccountHomeView.as_view(), name="account"),
-    path("login/", auth_views.LoginView.as_view(), name="account_login"),
+    path("login/", LoginView.as_view(), name="account_login"),
     path(
         "password_reset/",
         auth_views.PasswordResetView.as_view(


### PR DESCRIPTION
## Summary
- Secure session and CSRF cookies with secure and SameSite flags
- Default session expires in 24h and extends to 14 days when "remember me" is used
- Custom login view applies session age override based on checkbox

## Testing
- `DB_ENGINE=sqlite pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ac90c1076c832a9e4f83e5ea740b15