### PR TITLE
Add ordered navigation links

### DIFF
--- a/coresite/context_processors.py
+++ b/coresite/context_processors.py
@@ -2,6 +2,82 @@ from django.conf import settings
 from django.core import signing
 
 
+NAV_LINKS = [
+    {
+        "label": "Knowledge",
+        "url": "knowledge",
+        "locations": ["header", "footer"],
+        "order": 1,
+    },
+    {
+        "label": "Tools",
+        "url": "tools",
+        "locations": ["header", "footer"],
+        "order": 2,
+    },
+    {
+        "label": "Case Studies",
+        "url": "case_studies_landing",
+        "locations": ["header", "footer"],
+        "order": 3,
+    },
+    {
+        "label": "Community",
+        "url": "community",
+        "locations": ["header", "footer"],
+        "order": 4,
+        "requires_auth": True,
+        "alt_url": "join",
+        "sr_id": "community-locked",
+        "sr_text": "Available after you join.",
+    },
+    {
+        "label": "Blog",
+        "url": "blog",
+        "locations": ["header", "footer"],
+        "order": 5,
+    },
+    {
+        "label": "Account",
+        "url": "account",
+        "locations": ["footer"],
+        "order": 6,
+        "requires_auth": True,
+    },
+    {
+        "label": "Join Free",
+        "url": "join",
+        "locations": ["footer"],
+        "order": 7,
+        "requires_anon": True,
+    },
+    {
+        "label": "About",
+        "url": "about",
+        "locations": ["footer"],
+        "order": 8,
+    },
+    {
+        "label": "Contact",
+        "url": "contact",
+        "locations": ["footer"],
+        "order": 9,
+    },
+    {
+        "label": "Support",
+        "url": "support",
+        "locations": ["footer"],
+        "order": 10,
+    },
+    {
+        "label": "Legal",
+        "url": "legal",
+        "locations": ["footer"],
+        "order": 11,
+    },
+]
+
+
 def analytics_flags(request):
     """Expose analytics configuration and consent flags."""
 
@@ -42,3 +118,7 @@ def build_metadata(request):
         'build_datetime': getattr(settings, 'BUILD_DATETIME', ''),
         'show_build_banner': getattr(settings, 'SHOW_BUILD_BANNER', False),
     }
+
+
+def nav_links(request):
+    return {"nav_links": NAV_LINKS}

--- a/coresite/templates/coresite/partials/global/nav_links.html
+++ b/coresite/templates/coresite/partials/global/nav_links.html
@@ -1,39 +1,30 @@
 {% with prefix=id_prefix|default:'nav' %}
-  {% if location|default:'header' == 'footer' %}
-    <li><a href="{% url 'knowledge' %}" data-analytics-event="nav_link_click" data-analytics-label="Knowledge" data-analytics-url="{% url 'knowledge' %}">Knowledge</a></li>
-    <li><a href="{% url 'tools' %}" data-analytics-event="nav_link_click" data-analytics-label="Tools" data-analytics-url="{% url 'tools' %}">Tools</a></li>
-    <li><a href="{% url 'case_studies_landing' %}" data-analytics-event="nav_link_click" data-analytics-label="Case Studies" data-analytics-url="{% url 'case_studies_landing' %}">Case Studies</a></li>
-    <li>
-      {% if user.is_authenticated %}
-        <a href="{% url 'community' %}" data-analytics-event="nav_link_click" data-analytics-label="Community" data-analytics-url="{% url 'community' %}">Community</a>
-      {% else %}
-        <a href="{% url 'join' %}" aria-describedby="{{ prefix }}-community-locked" data-analytics-event="nav_link_click" data-analytics-label="Community" data-analytics-url="{% url 'join' %}">Community</a>
-        <span id="{{ prefix }}-community-locked" class="sr-only">Available after you join.</span>
+  {% with loc=location|default:'header' %}
+    {% for link in nav_links|dictsort:"order" %}
+      {% if loc in link.locations %}
+        {% if link.requires_auth and not user.is_authenticated %}
+          {% if link.alt_url %}
+            <li>
+              <a href="{% url link.alt_url %}"
+                 aria-describedby="{{ prefix }}-{{ link.sr_id }}"
+                 data-analytics-event="nav_link_click"
+                 data-analytics-label="{{ link.label }}"
+                 data-analytics-url="{% url link.alt_url %}">{{ link.label }}</a>
+              {% if link.sr_text %}<span id="{{ prefix }}-{{ link.sr_id }}" class="sr-only">{{ link.sr_text }}</span>{% endif %}
+            </li>
+          {% endif %}
+        {% elif link.requires_anon and user.is_authenticated %}
+          {# Skip links meant only for anonymous users #}
+        {% else %}
+          <li>
+            <a href="{% url link.url %}"
+               data-analytics-event="nav_link_click"
+               data-analytics-label="{{ link.label }}"
+               data-analytics-url="{% url link.url %}">{{ link.label }}</a>
+          </li>
+        {% endif %}
       {% endif %}
-    </li>
-    <li><a href="{% url 'blog' %}" data-analytics-event="nav_link_click" data-analytics-label="Blog" data-analytics-url="{% url 'blog' %}">Blog</a></li>
-    {% if user.is_authenticated %}
-      <li><a href="{% url 'account' %}" data-analytics-event="nav_link_click" data-analytics-label="Account" data-analytics-url="{% url 'account' %}">Account</a></li>
-    {% else %}
-      <li><a href="{% url 'join' %}" data-analytics-event="nav_link_click" data-analytics-label="Join Free" data-analytics-url="{% url 'join' %}">Join Free</a></li>
-    {% endif %}
-    <li><a href="{% url 'about' %}" data-analytics-event="nav_link_click" data-analytics-label="About" data-analytics-url="{% url 'about' %}">About</a></li>
-    <li><a href="{% url 'contact' %}" data-analytics-event="nav_link_click" data-analytics-label="Contact" data-analytics-url="{% url 'contact' %}">Contact</a></li>
-    <li><a href="{% url 'support' %}" data-analytics-event="nav_link_click" data-analytics-label="Support" data-analytics-url="{% url 'support' %}">Support</a></li>
-    <li><a href="{% url 'legal' %}" data-analytics-event="nav_link_click" data-analytics-label="Legal" data-analytics-url="{% url 'legal' %}">Legal</a></li>
-  {% else %}
-    <li><a href="{% url 'knowledge' %}" data-analytics-event="nav_link_click" data-analytics-label="Knowledge" data-analytics-url="{% url 'knowledge' %}">Knowledge</a></li>
-    <li><a href="{% url 'tools' %}" data-analytics-event="nav_link_click" data-analytics-label="Tools" data-analytics-url="{% url 'tools' %}">Tools</a></li>
-    <li><a href="{% url 'case_studies_landing' %}" data-analytics-event="nav_link_click" data-analytics-label="Case Studies" data-analytics-url="{% url 'case_studies_landing' %}">Case Studies</a></li>
-    <li>
-      {% if user.is_authenticated %}
-        <a href="{% url 'community' %}" data-analytics-event="nav_link_click" data-analytics-label="Community" data-analytics-url="{% url 'community' %}">Community</a>
-      {% else %}
-        <a href="{% url 'join' %}" aria-describedby="{{ prefix }}-community-locked" data-analytics-event="nav_link_click" data-analytics-label="Community" data-analytics-url="{% url 'join' %}">Community</a>
-        <span id="{{ prefix }}-community-locked" class="sr-only">Available after you join.</span>
-      {% endif %}
-    </li>
-    <li><a href="{% url 'blog' %}" data-analytics-event="nav_link_click" data-analytics-label="Blog" data-analytics-url="{% url 'blog' %}">Blog</a></li>
-  {% endif %}
+    {% endfor %}
+  {% endwith %}
 {% endwith %}
 

--- a/technofatty_com/settings.py
+++ b/technofatty_com/settings.py
@@ -114,6 +114,7 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "coresite.context_processors.analytics_flags",
                 "coresite.context_processors.build_metadata",
+                "coresite.context_processors.nav_links",
             ],
         },
     },


### PR DESCRIPTION
## Summary
- define NAV_LINKS with explicit order and expose via context processor
- sort navigation links in template
- register navigation context processor in settings

## Testing
- `pytest` *(fails: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9f52f0e0832a90151a8b3121f7bf