### PR TITLE
Add legacy redirect mappings and tests

### DIFF
--- a/coresite/tests/test_legacy_redirects.py
+++ b/coresite/tests/test_legacy_redirects.py
@@ -1,0 +1,29 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("/signup/", "https://technofatty.com/#signup"),
+        ("/services/", "https://technofatty.com/about/"),
+        (
+            "/signals/alpha/",
+            "https://technofatty.com/knowledge/signals/#signal-alpha",
+        ),
+        ("/community/join/", "https://technofatty.com/community/"),
+    ],
+)
+@pytest.mark.django_db
+def test_legacy_redirects(client, path, expected):
+    response = client.get(path, follow=False)
+    assert response.status_code == 301
+    assert response["Location"] == expected
+
+
+def test_signup_query_string_preserved(client):
+    response = client.get("/signup/?ref=newsletter", follow=False)
+    assert response.status_code == 301
+    assert (
+        response["Location"]
+        == "https://technofatty.com/?ref=newsletter#signup"
+    )

--- a/coresite/urls.py
+++ b/coresite/urls.py
@@ -1,7 +1,10 @@
 import re
 
 from django.urls import path, re_path
+from django.views.generic import RedirectView
+
 from . import views
+from .views import BASE_CANONICAL
 from .feeds import (
     BlogAtomFeed,
     BlogRSSFeed,
@@ -50,28 +53,42 @@ urlpatterns = [
     path("blog/tag/<slug:tag_slug>/", views.blog_tag, name="blog_tag"),
     path("blog/<slug:post_slug>/", views.blog_post, name="blog_post"),
     path("join/", views.join, name="join"),
-    re_path(
-        re.compile(r"^signup/?$", re.IGNORECASE),
-        views.legacy_signup,
-        name="legacy_signup",
-    ),
     path("about/", views.about, name="about"),
-    re_path(
-        re.compile(r"^services/?$", re.IGNORECASE),
-        views.legacy_services,
-        name="legacy_services",
-    ),
     path("contact/", views.contact, name="contact"),
     path("support/", views.support, name="support"),
     path("legal/", views.legal, name="legal"),
-    re_path(
-        re.compile(r"^signals/(?P<slug>[^/]+)/?$", re.IGNORECASE),
-        views.legacy_signal,
-        name="legacy_signal",
+]
+
+
+legacy_redirects = [
+    (
+        re.compile(r"^signup/?$", re.IGNORECASE),
+        f"{BASE_CANONICAL}/#signup",
+        "legacy_signup",
     ),
-    re_path(
+    (
+        re.compile(r"^services/?$", re.IGNORECASE),
+        f"{BASE_CANONICAL}/about/",
+        "legacy_services",
+    ),
+    (
+        re.compile(r"^signals/(?P<slug>[^/]+)/?$", re.IGNORECASE),
+        f"{BASE_CANONICAL}/knowledge/signals/#signal-%(slug)s",
+        "legacy_signal",
+    ),
+    (
         re.compile(r"^community/join/?$", re.IGNORECASE),
-        views.legacy_community_join,
-        name="legacy_community_join",
+        f"{BASE_CANONICAL}/community/",
+        "legacy_community_join",
     ),
 ]
+
+
+for pattern, target, name in legacy_redirects:
+    urlpatterns.append(
+        re_path(
+            pattern,
+            RedirectView.as_view(url=target, permanent=True, query_string=True),
+            name=name,
+        )
+    )

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -486,14 +486,6 @@ def join(request):
     )
 
 
-def legacy_signup(request):
-    """Legacy /signup/ route. 301 to homepage signup anchor."""
-    base = f"{BASE_CANONICAL}/"
-    qs = request.META.get("QUERY_STRING")
-    url = f"{base}?{qs}#signup" if qs else f"{base}#signup"
-    return HttpResponsePermanentRedirect(url)
-
-
 def about(request):
     footer = get_footer_content()
     return render(
@@ -501,14 +493,6 @@ def about(request):
         "coresite/about.html",
         {"footer": footer, "canonical_url": f"{BASE_CANONICAL}/about/"},
     )
-
-
-def legacy_services(request):
-    """Legacy /services/ route. 301 to About page."""
-    base = f"{BASE_CANONICAL}/about/"
-    qs = request.META.get("QUERY_STRING")
-    url = f"{base}?{qs}" if qs else base
-    return HttpResponsePermanentRedirect(url)
 
 
 def contact(request):
@@ -558,20 +542,3 @@ def legal(request):
         "coresite/legal.html",
         {"footer": footer, "canonical_url": f"{BASE_CANONICAL}/legal/"},
     )
-
-
-def legacy_signal(request, slug: str):
-    """Legacy /signals/<slug>/ route. 301 to knowledge signals pillar."""
-    base = f"{BASE_CANONICAL}/knowledge/signals/"
-    qs = request.META.get("QUERY_STRING")
-    fragment = f"#signal-{slug}"
-    url = f"{base}?{qs}{fragment}" if qs else f"{base}{fragment}"
-    return HttpResponsePermanentRedirect(url)
-
-
-def legacy_community_join(request):
-    """Legacy /community/join/ route. 301 to community hub."""
-    base = f"{BASE_CANONICAL}/community/"
-    qs = request.META.get("QUERY_STRING")
-    url = f"{base}?{qs}" if qs else base
-    return HttpResponsePermanentRedirect(url)

--- a/docs/rollout_checklist.md
+++ b/docs/rollout_checklist.md
@@ -1,0 +1,5 @@
+# Rollout Checklist
+
+- [ ] Run full test suite.
+- [ ] Verify legacy redirects in the staging environment before deploying to production.
+- [ ] Confirm critical pages respond with expected status codes.


### PR DESCRIPTION
## Summary
- Define legacy URL redirects in `coresite/urls.py` using Django's `RedirectView`
- Add tests ensuring legacy paths return a 301 to the canonical location
- Document rollout requirement to verify redirects in staging

## Testing
- `pytest` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68acaddbc5c8832aabe5c34ccdc4fc33