### PR TITLE
Add canonical @id fields to structured data

### DIFF
--- a/coresite/templates/coresite/about.html
+++ b/coresite/templates/coresite/about.html
@@ -16,10 +16,12 @@
     {
       "@context": "https://schema.org",
       "@type": "AboutPage",
-      "url": "https://technofatty.com/about/",
+      "@id": "{{ canonical_url }}#webpage",
+      "url": "{{ canonical_url }}",
       "name": "About – Technofatty",
       "publisher": {
         "@type": "Organization",
+        "@id": "https://technofatty.com/#organization",
         "name": "Technofatty",
         "url": "https://technofatty.com/"
       }

--- a/coresite/templates/coresite/case_studies/landing.html
+++ b/coresite/templates/coresite/case_studies/landing.html
@@ -12,6 +12,7 @@
 {
   "@context": "https://schema.org",
   "@type": "BreadcrumbList",
+  "@id": "{{ canonical_url }}#breadcrumb",
   "itemListElement": [
     {
       "@type": "ListItem",
@@ -22,8 +23,8 @@
     {
       "@type": "ListItem",
       "position": 2,
-      "name": "Placeholder",
-      "item": "https://technofatty.com/placeholder"
+      "name": "{{ page_title|escapejs }}",
+      "item": "{{ canonical_url }}"
     }
   ]
 }

--- a/coresite/templates/coresite/contact.html
+++ b/coresite/templates/coresite/contact.html
@@ -16,10 +16,12 @@
     {
       "@context": "https://schema.org",
       "@type": "ContactPage",
-      "url": "https://technofatty.com/contact/",
+      "@id": "{{ canonical_url }}#webpage",
+      "url": "{{ canonical_url }}",
       "name": "Contact – Technofatty",
       "publisher": {
         "@type": "Organization",
+        "@id": "https://technofatty.com/#organization",
         "name": "Technofatty",
         "url": "https://technofatty.com/"
       }

--- a/coresite/templates/coresite/legal.html
+++ b/coresite/templates/coresite/legal.html
@@ -16,10 +16,12 @@
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "url": "https://technofatty.com/legal/",
+      "@id": "{{ canonical_url }}#webpage",
+      "url": "{{ canonical_url }}",
       "name": "Legal – Technofatty",
       "publisher": {
         "@type": "Organization",
+        "@id": "https://technofatty.com/#organization",
         "name": "Technofatty",
         "url": "https://technofatty.com/"
       }

--- a/coresite/templates/coresite/support.html
+++ b/coresite/templates/coresite/support.html
@@ -15,11 +15,13 @@
 <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "WebPage",
-      "url": "https://technofatty.com/support/",
+      "@type": "FAQPage",
+      "@id": "{{ canonical_url }}#webpage",
+      "url": "{{ canonical_url }}",
       "name": "Support – Technofatty",
       "publisher": {
         "@type": "Organization",
+        "@id": "https://technofatty.com/#organization",
         "name": "Technofatty",
         "url": "https://technofatty.com/"
       }

--- a/coresite/tests/test_schema_ids.py
+++ b/coresite/tests/test_schema_ids.py
@@ -1,0 +1,45 @@
+import json
+import re
+import pytest
+from django.utils import timezone
+
+from coresite.models import BlogPost, StatusChoices
+
+
+def _extract_jsonld(html: str):
+    match = re.search(r'<script type="application/ld\+json">(.*?)</script>', html, re.DOTALL)
+    assert match, "No JSON-LD script found"
+    return json.loads(match.group(1))
+
+
+def test_blog_post_schema_ids(client, db):
+    BlogPost.objects.create(
+        title="Test Post",
+        slug="test-post",
+        status=StatusChoices.PUBLISHED,
+        published_at=timezone.now(),
+    )
+    resp = client.get("/blog/test-post/")
+    assert resp.status_code == 200
+    data = _extract_jsonld(resp.content.decode())
+    graph = data["@graph"]
+    article = next(item for item in graph if item.get("@type") == "BlogPosting")
+    assert article["@id"] == "https://technofatty.com/blog/test-post/#article"
+    breadcrumb = next(item for item in graph if item.get("@type") == "BreadcrumbList")
+    assert breadcrumb["@id"] == "https://technofatty.com/blog/test-post/#breadcrumb"
+
+
+def test_case_studies_breadcrumb_id(client):
+    resp = client.get("/case-studies/")
+    assert resp.status_code == 200
+    data = _extract_jsonld(resp.content.decode())
+    assert data["@id"] == "https://technofatty.com/case-studies/#breadcrumb"
+
+
+def test_support_faqpage_id(client):
+    resp = client.get("/support/")
+    assert resp.status_code == 200
+    data = _extract_jsonld(resp.content.decode())
+    assert data["@id"] == "https://technofatty.com/support/#webpage"
+    assert data["@type"] == "FAQPage"
+


### PR DESCRIPTION
## Summary
- include canonical `@id` fields in about, contact, legal, support, and case study structured data
- add tests checking JSON-LD `@id` values for blog posts, case studies, and support FAQ page

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest coresite/tests/test_schema_ids.py::test_blog_post_schema_ids -q` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68acb0c7ea74832a89aa2bda09f4f091