### PR TITLE
Document partial context keys and add references

### DIFF
--- a/coresite/templates/coresite/partials/about/about-cta.html
+++ b/coresite/templates/coresite/partials/about/about-cta.html
@@ -1,2 +1,3 @@
+{# See docs/structured-data.md#about-about-cta for context keys #}
 <h2 id="about-cta-heading">Stay connected</h2>
 <p>Join our waitlist to follow Technofatty's progress and be first to try new tools [ref:cta].</p>

--- a/coresite/templates/coresite/partials/about/about-hero.html
+++ b/coresite/templates/coresite/partials/about/about-hero.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#about-about-hero for context keys #}
 <h1 class="visually-hidden" id="about-page-heading">About</h1>
 <div class="scaffold__body">
   {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/coresite/partials/about/about-milestones.html
+++ b/coresite/templates/coresite/partials/about/about-milestones.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#about-about-milestones for context keys #}
 <h2 id="about-milestones-heading">Where we are now</h2>
 <p>Technofatty is currently in a private beta with select partner clinics [ref:status].</p>
 <p>Our near-term focus is converting early feedback into a publicly accessible toolkit [ref:focus].</p>

--- a/coresite/templates/coresite/partials/about/about-principles.html
+++ b/coresite/templates/coresite/partials/about/about-principles.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#about-about-principles for context keys #}
 <h2 id="about-principles-heading">Our principles</h2>
 <ul>
   <li>Open data builds trust and accountability [ref:open-data].</li>

--- a/coresite/templates/coresite/partials/about/about-story.html
+++ b/coresite/templates/coresite/partials/about/about-story.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#about-about-story for context keys #}
 <h2 id="about-story-heading">The Technofatty story</h2>
 <p>Technofatty exists to demystify dietary fats, empowering people with clear, actionable guidance [ref:purpose].</p>
 <p>Conflicting advice and opaque labels leave most eaters unsure how fats affect their wellbeing [ref:problem].</p>

--- a/coresite/templates/coresite/partials/about/about-team.html
+++ b/coresite/templates/coresite/partials/about/about-team.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#about-about-team for context keys #}
 <h2 id="about-team-heading">Meet the team</h2>
 <p>Our crew combines clinical dietitians, food technologists, and product engineers [ref:team-roles].</p>
 <p>Together they craft evidence-based tools that respect privacy and adapt to user feedback [ref:team-values].</p>

--- a/coresite/templates/coresite/partials/about/about-trust.html
+++ b/coresite/templates/coresite/partials/about/about-trust.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#about-about-trust for context keys #}
 <h2 id="about-trust-heading">Proof you can trust</h2>
 <ul>
   <li>Annual third-party security audits [ref:pending]</li>

--- a/coresite/templates/coresite/partials/community_block.html
+++ b/coresite/templates/coresite/partials/community_block.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#community_block for context keys #}
 <section class="section section--community" role="region" aria-labelledby="community-heading" data-section="community">
   <div class="wrap">
     {% with level=community.heading_level|default:'h2' %}

--- a/coresite/templates/coresite/partials/consent_banner.html
+++ b/coresite/templates/coresite/partials/consent_banner.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#consent_banner for context keys #}
 <div id="consent-banner" class="consent-banner" role="region" aria-label="Cookie consent" hidden data-consent-banner>
   <p>We use cookies for analytics. You can accept or decline.</p>
   <div class="consent-banner__actions">

--- a/coresite/templates/coresite/partials/contact/contact-cta.html
+++ b/coresite/templates/coresite/partials/contact/contact-cta.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#contact-contact-cta for context keys #}
 <h2 id="contact-cta-heading">Ready to reach out?</h2>
 <p>Use the form to connect; we'll route your message to the right team [ref:cta].</p>
 <ul class="contact-sources">

--- a/coresite/templates/coresite/partials/contact/contact-form.html
+++ b/coresite/templates/coresite/partials/contact/contact-form.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#contact-contact-form for context keys #}
 <h2 id="contact-form-heading">General inquiries</h2>
 <p>Use this form for non-urgent questions; staff reviews messages each workday [ref:general].</p>
 <p>If the form is unavailable, email <a href="mailto:contact@technofatty.com" data-analytics-event="link.contact.email">contact@technofatty.com</a> for help [ref:general].</p>

--- a/coresite/templates/coresite/partials/contact/contact-info.html
+++ b/coresite/templates/coresite/partials/contact/contact-info.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#contact-contact-info for context keys #}
 <h2 id="contact-info-heading">Support</h2>
 <p>Visit our support portal for guides and system status updates [ref:support].</p>
 <p>Need more help? Submit a ticket so technicians can review your case quickly [ref:support].</p>

--- a/coresite/templates/coresite/partials/contact/contact-intro.html
+++ b/coresite/templates/coresite/partials/contact/contact-intro.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#contact-contact-intro for context keys #}
 <h1 class="visually-hidden" id="contact-page-heading">Contact</h1>
 <div class="scaffold__body">
   {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/coresite/partials/contact/contact-social.html
+++ b/coresite/templates/coresite/partials/contact/contact-social.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#contact-contact-social for context keys #}
 <h2 id="contact-social-heading">Legal requests</h2>
 <p>Send formal notices or privacy requests to our legal team for processing [ref:legal].</p>
 <p>Email <a href="mailto:legal@technofatty.com" data-analytics-event="link.legal.email">legal@technofatty.com</a> with your contact details and any supporting documents [ref:legal].</p>

--- a/coresite/templates/coresite/partials/contact/contact-trust.html
+++ b/coresite/templates/coresite/partials/contact/contact-trust.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#contact-contact-trust for context keys #}
 <h2 id="contact-trust-heading">Partnerships &amp; business</h2>
 <p>We consider collaborations that align with our mission and audience [ref:partners].</p>
 <p>Share your proposal with <a href="mailto:partners@technofatty.com">partners@technofatty.com</a>; our bizdev team reviews every submission [ref:partners].</p>

--- a/coresite/templates/coresite/partials/featured_grid.html
+++ b/coresite/templates/coresite/partials/featured_grid.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#featured_grid for context keys #}
 {% load static %}
 
 <section id="featured" class="featured" aria-labelledby="featured-heading">

--- a/coresite/templates/coresite/partials/global/analytics.html
+++ b/coresite/templates/coresite/partials/global/analytics.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#global-analytics for context keys #}
 {% if ANALYTICS_PROVIDER == 'plausible' and ANALYTICS_SITE_ID %}
   <script defer data-domain="{{ ANALYTICS_SITE_ID }}" src="https://plausible.io/js/script.js"></script>
 {% elif ANALYTICS_PROVIDER == 'ga4' and ANALYTICS_SITE_ID %}

--- a/coresite/templates/coresite/partials/global/build_banner.html
+++ b/coresite/templates/coresite/partials/global/build_banner.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#global-build_banner for context keys #}
 <div class="build-banner" role="status" aria-live="polite" aria-label="Build information">
   Branch: {{ build_branch|default:"n/a" }} — {{ build_commit|default:"n/a" }} — {{ build_datetime|default:"n/a" }}
 </div>

--- a/coresite/templates/coresite/partials/global/footer.html
+++ b/coresite/templates/coresite/partials/global/footer.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#global-footer for context keys #}
 {% if footer %}
 <footer class="footer">
   <nav aria-label="Footer">

--- a/coresite/templates/coresite/partials/global/header_nav.html
+++ b/coresite/templates/coresite/partials/global/header_nav.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#global-header_nav for context keys #}
 <header class="site-header {% if request.path == '/' %}hero-mode{% else %}fixed-mode{% endif %}">
   <!-- Desktop Navigation -->
   <nav class="desktop-nav" aria-label="Primary">

--- a/coresite/templates/coresite/partials/global/nav_cta.html
+++ b/coresite/templates/coresite/partials/global/nav_cta.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#global-nav_cta for context keys #}
 {% if user.is_authenticated %}
 <a class="btn btn--cta" href="{% url 'account' %}" data-analytics-event="nav_cta_click" data-analytics-label="Account" data-analytics-url="{% url 'account' %}">Account</a>
 {% else %}

--- a/coresite/templates/coresite/partials/global/nav_links.html
+++ b/coresite/templates/coresite/partials/global/nav_links.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#global-nav_links for context keys #}
 {% load nav_tags %}
 {% with prefix=id_prefix|default:'nav' %}
   {% with loc=location|default:'header' %}

--- a/coresite/templates/coresite/partials/global/notice.html
+++ b/coresite/templates/coresite/partials/global/notice.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#global-notice for context keys #}
 {# Global notice placeholder — intentionally renders nothing #}
 {% comment %}
 Purpose: allow site-wide banners (beta, cookie, downtime) without touching page templates.

--- a/coresite/templates/coresite/partials/global/status_placeholder.html
+++ b/coresite/templates/coresite/partials/global/status_placeholder.html
@@ -1,2 +1,3 @@
+{# See docs/structured-data.md#global-status_placeholder for context keys #}
 <div id="site-status" class="status-placeholder" role="status" aria-live="polite" aria-atomic="true"></div>
 

--- a/coresite/templates/coresite/partials/hero.html
+++ b/coresite/templates/coresite/partials/hero.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#hero for context keys #}
 <section class="hero" role="region" aria-label="{{ site_images.hero1.alt_text|default:'Technofatty hero' }}">
   <div class="hero__bg" aria-hidden="true">
     {% if site_images.hero1 and site_images.hero1.video and site_images.hero1.image %}

--- a/coresite/templates/coresite/partials/legal/legal-accessibility.html
+++ b/coresite/templates/coresite/partials/legal/legal-accessibility.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#legal-legal-accessibility for context keys #}
 <h2 id="legal-accessibility-heading">Accessibility</h2>
 <p>We aim to make the site usable by as many people as possible and
   target conformance with WCAG&nbsp;2.1 Level AA. [ref:accessibility]</p>

--- a/coresite/templates/coresite/partials/legal/legal-compliance.html
+++ b/coresite/templates/coresite/partials/legal/legal-compliance.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#legal-legal-compliance for context keys #}
 <h2 id="legal-compliance-heading">Compliance</h2>
 <p>Technofatty operates under United States law and monitors emerging
   obligations in other jurisdictions. [ref:compliance]</p>

--- a/coresite/templates/coresite/partials/legal/legal-contact.html
+++ b/coresite/templates/coresite/partials/legal/legal-contact.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#legal-legal-contact for context keys #}
 <h2 id="legal-contact-heading">Contact</h2>
 <p>For privacy questions or rights requests, contact our legal team at
   <a href="mailto:legal@technofatty.com" data-analytics-event="link.legal.email">legal@technofatty.com</a>.

--- a/coresite/templates/coresite/partials/legal/legal-cookies.html
+++ b/coresite/templates/coresite/partials/legal/legal-cookies.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#legal-legal-cookies for context keys #}
 <h2 id="legal-cookies-heading">Cookie Policy</h2>
 <p>Technofatty uses essential cookies to maintain site security and
   remember session preferences. [ref:cookies]</p>

--- a/coresite/templates/coresite/partials/legal/legal-intro.html
+++ b/coresite/templates/coresite/partials/legal/legal-intro.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#legal-legal-intro for context keys #}
 <h1 class="visually-hidden" id="legal-page-heading">Legal</h1>
 <div class="scaffold__body">
   {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/coresite/partials/legal/legal-licensing.html
+++ b/coresite/templates/coresite/partials/legal/legal-licensing.html
@@ -1,2 +1,3 @@
+{# See docs/structured-data.md#legal-legal-licensing for context keys #}
 <h2 id="legal-licensing-heading">Licensing &amp; Attributions</h2>
 <p>Third-party attributions placeholder [ref:licensing].</p>

--- a/coresite/templates/coresite/partials/legal/legal-privacy.html
+++ b/coresite/templates/coresite/partials/legal/legal-privacy.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#legal-legal-privacy for context keys #}
 <h2 id="legal-privacy-heading">Privacy Policy</h2>
 <p>We collect only the data needed to operate the site and respond to
   user requests. Personal information is processed according to our

--- a/coresite/templates/coresite/partials/legal/legal-terms.html
+++ b/coresite/templates/coresite/partials/legal/legal-terms.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#legal-legal-terms for context keys #}
 <h2 id="legal-terms-heading">Terms of Service</h2>
 <p>You may access the site to evaluate Technofatty's offerings and
   participate in its community as allowed by these terms.

--- a/coresite/templates/coresite/partials/newsletter_block.html
+++ b/coresite/templates/coresite/partials/newsletter_block.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#newsletter_block for context keys #}
 <!-- TODO: Stakeholder decision: headline_scope (music) -->
 <section id="signup"
          class="newsletter-band"

--- a/coresite/templates/coresite/partials/seo/meta_head.html
+++ b/coresite/templates/coresite/partials/seo/meta_head.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#seo-meta_head for context keys #}
 {% load seo_tags %}
 {% canonical_url canonical_url as resolved_canonical %}
 {% if page_title %}{% with full_title=page_title|add:' | Technofatty' %}

--- a/coresite/templates/coresite/partials/seo/structured_data.html
+++ b/coresite/templates/coresite/partials/seo/structured_data.html
@@ -1,1 +1,2 @@
+{# See docs/structured-data.md#seo-structured_data for context keys #}
 <!-- sd:canonical -->

--- a/coresite/templates/coresite/partials/signals_block.html
+++ b/coresite/templates/coresite/partials/signals_block.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#signals_block for context keys #}
 <section class="section section--signals" role="region" aria-labelledby="signals-heading" data-section="signals">
   <div class="container-wide">
     {% with level=signals.heading_level|default:'h2' %}

--- a/coresite/templates/coresite/partials/support/support-accessibility.html
+++ b/coresite/templates/coresite/partials/support/support-accessibility.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#support-support-accessibility for context keys #}
 <h2 id="support-accessibility-heading">Accessibility support</h2>
 <p>We aim to provide help that works with a variety of assistive
 technologies [ref:a11y].</p>

--- a/coresite/templates/coresite/partials/support/support-account-billing.html
+++ b/coresite/templates/coresite/partials/support/support-account-billing.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#support-support-account-billing for context keys #}
 <h2 id="support-account-billing-heading">Account &amp; billing help</h2>
 <p>Use this area for questions about sign-in, subscriptions, or invoices
 [ref:billing].</p>

--- a/coresite/templates/coresite/partials/support/support-contact.html
+++ b/coresite/templates/coresite/partials/support/support-contact.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#support-support-contact for context keys #}
 <h2 id="support-contact-heading">Contact support / ticket intake</h2>
 <p>Reach us via the in-app help panel or email
 <a href="mailto:support@technofatty.com">support@technofatty.com</a>

--- a/coresite/templates/coresite/partials/support/support-faqs.html
+++ b/coresite/templates/coresite/partials/support/support-faqs.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#support-support-faqs for context keys #}
 <h2 id="support-faqs-heading">Top FAQs</h2>
 <p>Answers to common product questions are collected here [ref:faqs].</p>
 <p>For additional details, see the guides or contact support [ref:faqs].</p>

--- a/coresite/templates/coresite/partials/support/support-guides.html
+++ b/coresite/templates/coresite/partials/support/support-guides.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#support-support-guides for context keys #}
 <h2 id="support-guides-heading">Guides &amp; documentation</h2>
 <p>Step-by-step manuals and references for core features live here
 [ref:docs].</p>

--- a/coresite/templates/coresite/partials/support/support-intro.html
+++ b/coresite/templates/coresite/partials/support/support-intro.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#support-support-intro for context keys #}
 <h1 class="visually-hidden" id="support-page-heading">Support</h1>
 <div class="scaffold__body">
   {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/coresite/partials/support/support-privacy-security.html
+++ b/coresite/templates/coresite/partials/support/support-privacy-security.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#support-support-privacy-security for context keys #}
 <h2 id="support-privacy-security-heading">Data privacy &amp; security</h2>
 <p>Support may request your account email, order numbers, or diagnostic
 logs to investigate issues [ref:privacy].</p>

--- a/coresite/templates/coresite/partials/support/support-status.html
+++ b/coresite/templates/coresite/partials/support/support-status.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#support-support-status for context keys #}
 <h2 id="support-status-heading">System status &amp; updates</h2>
 <p>Live service status is published on a separate status page; link pending
 final approval [ref:status].</p>

--- a/coresite/templates/coresite/partials/support/support-troubleshooting.html
+++ b/coresite/templates/coresite/partials/support/support-troubleshooting.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#support-support-troubleshooting for context keys #}
 <h2 id="support-troubleshooting-heading">Troubleshooting &amp; known issues</h2>
 <p>Use this section to confirm whether a problem stems from configuration,
 outages, or a documented limitation [ref:troubleshooting].</p>

--- a/coresite/templates/coresite/partials/support_block.html
+++ b/coresite/templates/coresite/partials/support_block.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#support_block for context keys #}
 <section class="section section--support" role="region" aria-labelledby="support-heading" data-section="support">
   <div class="wrap">
     {% with level=support.heading_level|default:'h2' %}

--- a/coresite/templates/coresite/partials/trust.html
+++ b/coresite/templates/coresite/partials/trust.html
@@ -1,3 +1,4 @@
+{# See docs/structured-data.md#trust for context keys #}
 {% load static %}
 
 <section class="trust" aria-labelledby="trust-heading">

--- a/docs/global_partials_readme.md
+++ b/docs/global_partials_readme.md
@@ -2,6 +2,8 @@
 
 This page outlines the shared partial templates used across Technofatty. Each entry explains the partial’s purpose, where it lives, and which templates include it.
 
+See [structured-data](structured-data.md) for required context keys.
+
 ## Conventions
 
 ### Single page-level H1

--- a/docs/structured-data.md
+++ b/docs/structured-data.md
@@ -1,0 +1,244 @@
+# Partial context keys
+
+This document lists required and optional context dictionary keys for each template partial.
+
+<a id="about-about-cta"></a>
+### about/about-cta.html
+- Required: None
+- Optional: None
+
+<a id="about-about-hero"></a>
+### about/about-hero.html
+- Required: None
+- Optional: None
+
+<a id="about-about-milestones"></a>
+### about/about-milestones.html
+- Required: None
+- Optional: None
+
+<a id="about-about-principles"></a>
+### about/about-principles.html
+- Required: None
+- Optional: None
+
+<a id="about-about-story"></a>
+### about/about-story.html
+- Required: None
+- Optional: None
+
+<a id="about-about-team"></a>
+### about/about-team.html
+- Required: None
+- Optional: None
+
+<a id="about-about-trust"></a>
+### about/about-trust.html
+- Required: None
+- Optional: None
+
+<a id="community_block"></a>
+### community_block.html
+- Required: community.headline, community.messages.empty
+- Optional: community.heading_level, community.intro, community.primary_cta (url,label), community.secondary_links (slug,url,label,description)
+
+<a id="consent_banner"></a>
+### consent_banner.html
+- Required: None
+- Optional: None
+
+<a id="contact-contact-cta"></a>
+### contact/contact-cta.html
+- Required: None
+- Optional: None
+
+<a id="contact-contact-form"></a>
+### contact/contact-form.html
+- Required: form
+- Optional: None
+
+<a id="contact-contact-info"></a>
+### contact/contact-info.html
+- Required: None
+- Optional: None
+
+<a id="contact-contact-intro"></a>
+### contact/contact-intro.html
+- Required: None
+- Optional: None
+
+<a id="contact-contact-social"></a>
+### contact/contact-social.html
+- Required: None
+- Optional: None
+
+<a id="contact-contact-trust"></a>
+### contact/contact-trust.html
+- Required: None
+- Optional: None
+
+<a id="featured_grid"></a>
+### featured_grid.html
+- Required: resources (list of {title, blurb, url})
+- Optional: None
+
+<a id="global-analytics"></a>
+### global/analytics.html
+- Required: ANALYTICS_PROVIDER, ANALYTICS_SITE_ID
+- Optional: None
+
+<a id="global-build_banner"></a>
+### global/build_banner.html
+- Required: None
+- Optional: build_branch, build_commit, build_datetime
+
+<a id="global-footer"></a>
+### global/footer.html
+- Required: footer (headline, optional heading_level, intro, meta)
+- Optional: footer.heading_level, footer.intro, footer.meta.copyright, footer.meta.made_in, footer.meta.email
+
+<a id="global-header_nav"></a>
+### global/header_nav.html
+- Required: request.path (from context)
+- Optional: None
+
+<a id="global-nav_cta"></a>
+### global/nav_cta.html
+- Required: user.is_authenticated (from context)
+- Optional: None
+
+<a id="global-nav_links"></a>
+### global/nav_links.html
+- Required: nav_links
+- Optional: id_prefix (default "nav"), location (default "header")
+
+<a id="global-notice"></a>
+### global/notice.html
+- Required: None
+- Optional: None
+
+<a id="global-status_placeholder"></a>
+### global/status_placeholder.html
+- Required: None
+- Optional: None
+
+<a id="hero"></a>
+### hero.html
+- Required: site_images.hero1.image or site_images.hero1.video
+- Optional: site_images.hero1.alt_text
+
+<a id="legal-legal-accessibility"></a>
+### legal/legal-accessibility.html
+- Required: None
+- Optional: None
+
+<a id="legal-legal-compliance"></a>
+### legal/legal-compliance.html
+- Required: None
+- Optional: None
+
+<a id="legal-legal-contact"></a>
+### legal/legal-contact.html
+- Required: None
+- Optional: None
+
+<a id="legal-legal-cookies"></a>
+### legal/legal-cookies.html
+- Required: None
+- Optional: None
+
+<a id="legal-legal-intro"></a>
+### legal/legal-intro.html
+- Required: None
+- Optional: None
+
+<a id="legal-legal-licensing"></a>
+### legal/legal-licensing.html
+- Required: None
+- Optional: None
+
+<a id="legal-legal-privacy"></a>
+### legal/legal-privacy.html
+- Required: None
+- Optional: None
+
+<a id="legal-legal-terms"></a>
+### legal/legal-terms.html
+- Required: None
+- Optional: None
+
+<a id="newsletter_block"></a>
+### newsletter_block.html
+- Required: None
+- Optional: messages, APPROVED_CTA
+
+<a id="seo-meta_head"></a>
+### seo/meta_head.html
+- Required: canonical_url
+- Optional: page_title, meta_description, og_type, og_image_url
+
+<a id="seo-structured_data"></a>
+### seo/structured_data.html
+- Required: None
+- Optional: None
+
+<a id="signals_block"></a>
+### signals_block.html
+- Required: signals.headline, signals.cards
+- Optional: signals.heading_level, signals.intro, cards.kicker, cards.title, cards.problem, cards.approach, cards.evidence, cards.cta_text
+
+<a id="support-support-accessibility"></a>
+### support/support-accessibility.html
+- Required: None
+- Optional: None
+
+<a id="support-support-account-billing"></a>
+### support/support-account-billing.html
+- Required: None
+- Optional: None
+
+<a id="support-support-contact"></a>
+### support/support-contact.html
+- Required: None
+- Optional: None
+
+<a id="support-support-faqs"></a>
+### support/support-faqs.html
+- Required: None
+- Optional: None
+
+<a id="support-support-guides"></a>
+### support/support-guides.html
+- Required: None
+- Optional: None
+
+<a id="support-support-intro"></a>
+### support/support-intro.html
+- Required: None
+- Optional: None
+
+<a id="support-support-privacy-security"></a>
+### support/support-privacy-security.html
+- Required: None
+- Optional: None
+
+<a id="support-support-status"></a>
+### support/support-status.html
+- Required: None
+- Optional: None
+
+<a id="support-support-troubleshooting"></a>
+### support/support-troubleshooting.html
+- Required: None
+- Optional: None
+
+<a id="support_block"></a>
+### support_block.html
+- Required: support.headline, support.messages.empty
+- Optional: support.heading_level, support.intro, support.links (slug,url,label,description)
+
+<a id="trust"></a>
+### trust.html
+- Required: None
+- Optional: None
+


### PR DESCRIPTION
## Summary
- Document required and optional context keys for every template partial
- Link partials to the new structured-data reference and mention it in contributor guidelines

## Testing
- `pytest` *(fails: 11 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68acb48d4730832a94a106945a9f605c