### PR TITLE
Add JSON-LD schema validation tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = test_*.py validate_*.py

--- a/tests/fixtures/blog_post.html
+++ b/tests/fixtures/blog_post.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Blog Post</title>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "url": "https://example.com/blog/my-post",
+  "datePublished": "2024-05-01T10:00:00+00:00",
+  "dateModified": "2024-05-02T12:00:00+00:00",
+  "author": {
+    "@type": "Person",
+    "name": "Alice",
+    "url": "https://example.com/authors/alice"
+  }
+}
+</script>
+</head>
+<body>
+<p>Sample blog post.</p>
+</body>
+</html>

--- a/tests/fixtures/case_study.html
+++ b/tests/fixtures/case_study.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Case Study</title>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "url": "https://example.com/case-studies/acme",
+  "datePublished": "2024-03-15T09:30:00+00:00",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Example Co",
+    "url": "https://example.com"
+  }
+}
+</script>
+</head>
+<body>
+<p>Case study content.</p>
+</body>
+</html>

--- a/tests/fixtures/faq.html
+++ b/tests/fixtures/faq.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>FAQ</title>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [{
+    "@type": "Question",
+    "name": "What is Example?",
+    "acceptedAnswer": {
+      "@type": "Answer",
+      "text": "An example answer.",
+      "url": "https://example.com/faq#example"
+    }
+  }]
+}
+</script>
+</head>
+<body>
+<p>FAQ content.</p>
+</body>
+</html>

--- a/tests/validate_schema.py
+++ b/tests/validate_schema.py
@@ -1,0 +1,73 @@
+import json
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+from datetime import datetime
+
+FIXTURES = Path(__file__).parent / "fixtures"
+JSON_LD_RE = re.compile(
+    r'<script[^>]+type="application/ld\+json"[^>]*>(.*?)</script>',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _extract_jsonld(html: str):
+    for match in JSON_LD_RE.finditer(html):
+        try:
+            yield json.loads(match.group(1))
+        except json.JSONDecodeError as exc:
+            raise AssertionError(f"Invalid JSON-LD: {exc}") from exc
+
+
+def _looks_like_url(value: str) -> bool:
+    parsed = urlparse(value)
+    return bool(parsed.scheme or parsed.netloc or value.startswith("/"))
+
+
+def _assert_absolute_urls(node):
+    if isinstance(node, dict):
+        for value in node.values():
+            _assert_absolute_urls(value)
+    elif isinstance(node, list):
+        for item in node:
+            _assert_absolute_urls(item)
+    elif isinstance(node, str) and _looks_like_url(node):
+        parsed = urlparse(node)
+        if not (parsed.scheme and parsed.netloc):
+            raise AssertionError(f"URL is not absolute: {node}")
+
+
+def _assert_iso_dates(node):
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if isinstance(value, str) and "date" in key.lower():
+                candidate = value.replace("Z", "+00:00")
+                try:
+                    datetime.fromisoformat(candidate)
+                except ValueError as exc:
+                    raise AssertionError(
+                        f"Invalid ISO-8601 date for '{key}': {value}"
+                    ) from exc
+            _assert_iso_dates(value)
+    elif isinstance(node, list):
+        for item in node:
+            _assert_iso_dates(item)
+
+
+def _validate_file(name: str):
+    html = (FIXTURES / name).read_text()
+    for data in _extract_jsonld(html):
+        _assert_absolute_urls(data)
+        _assert_iso_dates(data)
+
+
+def test_blog_post():
+    _validate_file("blog_post.html")
+
+
+def test_case_study():
+    _validate_file("case_study.html")
+
+
+def test_faq():
+    _validate_file("faq.html")


### PR DESCRIPTION
## Summary
- validate JSON-LD in fixtures ensuring absolute URLs and ISO-8601 dates
- add sample blog, case study, and FAQ fixtures
- configure pytest to run validator

## Testing
- `pytest tests/validate_schema.py`

------
https://chatgpt.com/codex/tasks/task_e_68acca93f7f0832ab862bad5db75c636