### PR TITLE
Validate schema URLs before rendering

### DIFF
--- a/coresite/templatetags/jsonld.py
+++ b/coresite/templatetags/jsonld.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import json
 from django import template
+from django.conf import settings
+
 from utils.jsonld import render_jsonld
+from utils.urls import ensure_absolute
 
 register = template.Library()
 
@@ -16,7 +19,38 @@ class JsonLDNode(template.Node):
         if not raw:
             return ""
         data = json.loads(raw)
+
+        request = context.get("request")
+        base = request.build_absolute_uri("/") if request else getattr(
+            settings, "SITE_BASE_URL", ""
+        )
+
+        if not _absolutize_urls(data, base):
+            return ""
         return render_jsonld(data)
+
+
+def _absolutize_urls(value, base: str) -> bool:
+    """Ensure all ``url`` fields within ``value`` are absolute.
+
+    The ``value`` structure is modified in-place. ``True`` is returned when all
+    URLs could be converted to absolute form, otherwise ``False``.
+    """
+    if isinstance(value, dict):
+        for key, val in value.items():
+            if key == "url" and isinstance(val, str):
+                absolute = ensure_absolute(val, base)
+                if absolute is None:
+                    return False
+                value[key] = absolute
+            else:
+                if not _absolutize_urls(val, base):
+                    return False
+    elif isinstance(value, list):
+        for item in value:
+            if not _absolutize_urls(item, base):
+                return False
+    return True
 
 
 @register.tag(name="jsonld")

--- a/tests/test_jsonld_tag_urls.py
+++ b/tests/test_jsonld_tag_urls.py
@@ -1,0 +1,58 @@
+import json
+import re
+import pathlib
+import sys
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+
+def _render(template_str: str, base: str | None = None) -> str:
+    django = pytest.importorskip("django")
+    from django.conf import settings
+    from django.template import Context, Template
+
+    if not settings.configured:
+        settings.configure(
+            TEMPLATES=[{"BACKEND": "django.template.backends.django.DjangoTemplates"}]
+        )
+        django.setup()
+
+    if base is not None:
+        settings.SITE_BASE_URL = base
+    elif hasattr(settings, "SITE_BASE_URL"):
+        delattr(settings, "SITE_BASE_URL")
+
+    template = Template(template_str)
+    return template.render(Context({}))
+
+
+def _extract_json(html: str) -> dict:
+    match = re.search(r'<script type="application/ld\+json">(.*?)</script>', html, re.DOTALL)
+    assert match, "No JSON-LD script found"
+    return json.loads(match.group(1))
+
+
+def test_relative_urls_become_absolute():
+    html = _render(
+        """
+        {% load jsonld %}
+        {% jsonld %}{"@type": "Thing", "url": "/foo", "image": {"url": "/img.png"}, "sameAs": [{"url": "/bar"}]}{% endjsonld %}
+        """,
+        base="https://example.com",
+    )
+    data = _extract_json(html)
+    assert data["url"] == "https://example.com/foo"
+    assert data["image"]["url"] == "https://example.com/img.png"
+    assert data["sameAs"][0]["url"] == "https://example.com/bar"
+
+
+def test_invalid_relative_url_skips_output():
+    html = _render(
+        """
+        {% load jsonld %}
+        {% jsonld %}{"@type": "Thing", "url": "/foo"}{% endjsonld %}
+        """,
+        base=None,
+    )
+    assert html.strip() == ""

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,29 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from utils.urls import ensure_absolute
+
+
+def test_ensure_absolute_returns_input_if_already_absolute():
+    url = "https://example.com/path"
+    assert ensure_absolute(url, "https://base.com") == url
+
+
+def test_ensure_absolute_joins_relative_with_base():
+    assert (
+        ensure_absolute("/foo", "https://example.com")
+        == "https://example.com/foo"
+    )
+
+
+def test_ensure_absolute_returns_none_without_base():
+    assert ensure_absolute("/foo", "") is None
+
+
+def test_ensure_absolute_handles_protocol_relative():
+    assert (
+        ensure_absolute("//example.com/foo", "https://base.com")
+        == "https://example.com/foo"
+    )

--- a/utils/urls.py
+++ b/utils/urls.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from urllib.parse import urlparse, urljoin
+
+
+def ensure_absolute(url: str, base: str) -> str | None:
+    """Return an absolute URL or ``None`` if one cannot be formed.
+
+    ``url`` may already be absolute, in which case it is returned unchanged.
+    Relative URLs are resolved against ``base``. If ``url`` cannot be
+    resolved to an absolute URL (for example when ``base`` is empty or the
+    resulting URL still lacks a scheme/netloc), ``None`` is returned.
+    """
+    if not url:
+        return None
+
+    parsed = urlparse(url)
+    if parsed.scheme and parsed.netloc:
+        return url
+
+    if not base:
+        return None
+
+    absolute = urljoin(base, url)
+    parsed_absolute = urlparse(absolute)
+    if parsed_absolute.scheme and parsed_absolute.netloc:
+        return absolute
+    return None


### PR DESCRIPTION
## Summary
- ensure URLs are absolute with new `ensure_absolute` utility
- validate and normalize `url` fields in JSON-LD schema
- test URL normalisation and JSON-LD tag behaviour

## Testing
- `pytest tests/test_urls.py tests/test_jsonld_tag_urls.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68acd15587a8832aa04ad3695d6ba2a2