### PR TITLE
Add breadcrumb position tests

### DIFF
--- a/tests/test_breadcrumbs.py
+++ b/tests/test_breadcrumbs.py
@@ -1,0 +1,55 @@
+import pytest
+
+
+def build_breadcrumbs(pages):
+    """Build a JSON-LD BreadcrumbList from ``pages``.
+
+    Each page is a mapping with ``name`` and ``url`` keys.  The function
+    enumerates the list and assigns sequential ``position`` values starting at
+    1 for each ListItem.
+    """
+    return {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            {
+                "@type": "ListItem",
+                "position": idx + 1,
+                "name": page["name"],
+                "item": page["url"],
+            }
+            for idx, page in enumerate(pages)
+        ],
+    }
+
+
+def assert_sequential_positions(breadcrumbs):
+    items = breadcrumbs["itemListElement"]
+    for idx, item in enumerate(items):
+        assert item["position"] == idx + 1
+
+
+def test_multilevel_breadcrumb_positions():
+    pages = [
+        {"name": "Home", "url": "/"},
+        {"name": "Section", "url": "/section/"},
+        {"name": "Subsection", "url": "/section/sub/"},
+    ]
+    breadcrumbs = build_breadcrumbs(pages)
+    assert_sequential_positions(breadcrumbs)
+
+
+def test_single_item_breadcrumb():
+    pages = [{"name": "Home", "url": "/"}]
+    breadcrumbs = build_breadcrumbs(pages)
+    assert_sequential_positions(breadcrumbs)
+    assert len(breadcrumbs["itemListElement"]) == 1
+
+
+def test_deeply_nested_breadcrumb():
+    pages = [
+        {"name": f"Level {i}", "url": f"/level-{i}/"}
+        for i in range(1, 11)
+    ]
+    breadcrumbs = build_breadcrumbs(pages)
+    assert_sequential_positions(breadcrumbs)
+    assert breadcrumbs["itemListElement"][-1]["position"] == len(pages)


### PR DESCRIPTION
## Summary
- Add utilities to build breadcrumb JSON-LD data for tests
- Cover multi-level, single-item, and deep breadcrumb lists with position assertions

## Testing
- `pytest tests/test_breadcrumbs.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68acd3873c24832a993b5634f6e62c25