### PR TITLE
Add ISO 8601 helper and partials

### DIFF
--- a/tests/test_to_iso8601.py
+++ b/tests/test_to_iso8601.py
@@ -1,0 +1,51 @@
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from utils.dates import to_iso8601
+from utils.partials import article_partial, case_study_partial
+
+
+def test_to_iso8601_formats_aware_datetime():
+    dt = datetime(2024, 5, 1, 10, 0, tzinfo=timezone.utc)
+    assert to_iso8601(dt) == "2024-05-01T10:00:00+00:00"
+
+
+def test_to_iso8601_raises_for_naive_datetime():
+    dt = datetime(2024, 5, 1, 10, 0)
+    with pytest.raises(ValueError):
+        to_iso8601(dt)
+
+
+def test_article_partial_uses_iso_format():
+    pub = datetime(2024, 5, 1, 10, 0, tzinfo=timezone.utc)
+    mod = datetime(2024, 5, 2, 12, 0, tzinfo=timezone.utc)
+    data = article_partial(
+        "https://example.com/blog/my-post",
+        pub,
+        modified=mod,
+        author={"@type": "Person", "name": "Alice"},
+    )
+    assert data["datePublished"] == "2024-05-01T10:00:00+00:00"
+    assert data["dateModified"] == "2024-05-02T12:00:00+00:00"
+
+
+def test_case_study_partial_requires_aware_datetime():
+    pub = datetime(2024, 3, 15, 9, 30, tzinfo=timezone.utc)
+    publisher = {"@type": "Organization", "name": "Example Co", "url": "https://example.com"}
+    data = case_study_partial(
+        "https://example.com/case-studies/acme",
+        pub,
+        publisher,
+    )
+    assert data["datePublished"] == "2024-03-15T09:30:00+00:00"
+    with pytest.raises(ValueError):
+        case_study_partial(
+            "https://example.com/case-studies/acme",
+            datetime(2024, 3, 15, 9, 30),
+            publisher,
+        )

--- a/utils/dates.py
+++ b/utils/dates.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+
+def to_iso8601(dt: datetime) -> str:
+    """Return ISO-8601 string for a timezone-aware datetime.
+
+    Raises:
+        ValueError: If ``dt`` is naive (lacks timezone info).
+    """
+    if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
+        raise ValueError("datetime must be timezone-aware")
+    return dt.isoformat()

--- a/utils/partials.py
+++ b/utils/partials.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from .dates import to_iso8601
+
+
+def article_partial(
+    url: str,
+    published: datetime,
+    *,
+    modified: datetime | None = None,
+    author: dict | None = None,
+) -> dict:
+    """Return JSON-LD data for an article.
+
+    Parameters
+    ----------
+    url:
+        Canonical URL of the article.
+    published:
+        Publication datetime (timezone-aware).
+    modified:
+        Last modification datetime. Defaults to ``published``.
+    author:
+        Optional author dictionary to include.
+    """
+    data: dict = {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "url": url,
+        "datePublished": to_iso8601(published),
+        "dateModified": to_iso8601(modified or published),
+    }
+    if author:
+        data["author"] = author
+    return data
+
+
+def case_study_partial(url: str, published: datetime, publisher: dict) -> dict:
+    """Return JSON-LD data for a case study article."""
+    return {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "url": url,
+        "datePublished": to_iso8601(published),
+        "publisher": publisher,
+    }


### PR DESCRIPTION
## Summary
- add `to_iso8601` utility ensuring datetime timezone-awareness
- provide Article and CaseStudy JSON-LD partial builders using the helper
- test ISO formatting and naive datetime errors

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68acd54bf1b4832a8a1057ec90e0597f