### PR TITLE
feat: add token-driven motif assets

### DIFF
--- a/coresite/static/coresite/scss/components/_motifs.scss
+++ b/coresite/static/coresite/scss/components/_motifs.scss
@@ -1,0 +1,35 @@
+// Motif styles
+
+// Grid background
+.motif-grid {
+  background-image: linear-gradient(to right, c(border) 0, c(border) bw(sm), transparent bw(sm)),
+                    linear-gradient(to bottom, c(border) 0, c(border) bw(sm), transparent bw(sm));
+  background-size: s(6) s(6);
+}
+
+.motif-grid--mid {
+  background-image: linear-gradient(to right, c(mid) 0, c(mid) bw(sm), transparent bw(sm)),
+                    linear-gradient(to bottom, c(mid) 0, c(mid) bw(sm), transparent bw(sm));
+}
+
+// Node-field motifs
+.motif-node-field .node {
+  fill: c(mid);
+}
+.motif-node-field .node.blue {
+  fill: c(blue);
+}
+.motif-node-field .link {
+  stroke: c(border);
+  stroke-width: bw(sm);
+}
+
+// Waveform motifs
+.motif-waveform .wave {
+  fill: none;
+  stroke: c(blue);
+  stroke-width: bw(sm);
+}
+.motif-waveform.gray .wave {
+  stroke: c(gray-light);
+}

--- a/coresite/static/coresite/scss/main.scss
+++ b/coresite/static/coresite/scss/main.scss
@@ -23,6 +23,7 @@
 @import 'components/build-banner';
 @import 'components/consent';
 @import 'components/pager';
+@import 'components/motifs';
 
 // Layout
 @import "layout/grid";

--- a/coresite/static/coresite/svg/motifs/motif-node-field-1.svg
+++ b/coresite/static/coresite/svg/motifs/motif-node-field-1.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" class="motif-node-field">
+  <circle class="node" cx="20" cy="40" r="4"/>
+  <circle class="node blue" cx="70" cy="20" r="4"/>
+  <circle class="node" cx="140" cy="30" r="4"/>
+  <circle class="node" cx="180" cy="60" r="4"/>
+  <circle class="node blue" cx="50" cy="90" r="4"/>
+  <circle class="node" cx="110" cy="100" r="4"/>
+  <circle class="node" cx="170" cy="120" r="4"/>
+  <circle class="node blue" cx="30" cy="150" r="4"/>
+  <circle class="node" cx="90" cy="160" r="4"/>
+  <circle class="node" cx="150" cy="170" r="4"/>
+  <circle class="node" cx="60" cy="180" r="4"/>
+  <circle class="node" cx="10" cy="110" r="4"/>
+  <line class="link" x1="20" y1="40" x2="70" y2="20"/>
+  <line class="link" x1="70" y1="20" x2="140" y2="30"/>
+  <line class="link" x1="50" y1="90" x2="110" y2="100"/>
+  <line class="link" x1="110" y1="100" x2="170" y2="120"/>
+  <line class="link" x1="30" y1="150" x2="90" y2="160"/>
+  <line class="link" x1="90" y1="160" x2="150" y2="170"/>
+</svg>

--- a/coresite/static/coresite/svg/motifs/motif-node-field-2.svg
+++ b/coresite/static/coresite/svg/motifs/motif-node-field-2.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" class="motif-node-field">
+  <circle class="node" cx="40" cy="30" r="4"/>
+  <circle class="node" cx="100" cy="20" r="4"/>
+  <circle class="node blue" cx="160" cy="40" r="4"/>
+  <circle class="node" cx="30" cy="80" r="4"/>
+  <circle class="node blue" cx="90" cy="90" r="4"/>
+  <circle class="node" cx="150" cy="100" r="4"/>
+  <circle class="node" cx="60" cy="140" r="4"/>
+  <circle class="node blue" cx="120" cy="150" r="4"/>
+  <circle class="node" cx="180" cy="160" r="4"/>
+  <circle class="node" cx="20" cy="170" r="4"/>
+  <line class="link" x1="40" y1="30" x2="100" y2="20"/>
+  <line class="link" x1="100" y1="20" x2="160" y2="40"/>
+  <line class="link" x1="30" y1="80" x2="90" y2="90"/>
+  <line class="link" x1="90" y1="90" x2="150" y2="100"/>
+  <line class="link" x1="60" y1="140" x2="120" y2="150"/>
+  <line class="link" x1="120" y1="150" x2="180" y2="160"/>
+</svg>

--- a/coresite/static/coresite/svg/motifs/motif-node-field-3.svg
+++ b/coresite/static/coresite/svg/motifs/motif-node-field-3.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" class="motif-node-field">
+  <circle class="node" cx="20" cy="20" r="4"/>
+  <circle class="node" cx="60" cy="15" r="4"/>
+  <circle class="node blue" cx="100" cy="25" r="4"/>
+  <circle class="node" cx="150" cy="40" r="4"/>
+  <circle class="node" cx="180" cy="70" r="4"/>
+  <circle class="node" cx="40" cy="60" r="4"/>
+  <circle class="node blue" cx="80" cy="70" r="4"/>
+  <circle class="node" cx="120" cy="80" r="4"/>
+  <circle class="node" cx="160" cy="90" r="4"/>
+  <circle class="node blue" cx="30" cy="110" r="4"/>
+  <circle class="node" cx="90" cy="120" r="4"/>
+  <circle class="node" cx="140" cy="130" r="4"/>
+  <circle class="node" cx="180" cy="140" r="4"/>
+  <circle class="node" cx="50" cy="150" r="4"/>
+  <circle class="node blue" cx="100" cy="160" r="4"/>
+  <circle class="node" cx="150" cy="170" r="4"/>
+  <circle class="node" cx="20" cy="180" r="4"/>
+  <circle class="node" cx="80" cy="180" r="4"/>
+  <circle class="node" cx="130" cy="180" r="4"/>
+  <line class="link" x1="20" y1="20" x2="60" y2="15"/>
+  <line class="link" x1="60" y1="15" x2="100" y2="25"/>
+  <line class="link" x1="40" y1="60" x2="80" y2="70"/>
+  <line class="link" x1="80" y1="70" x2="120" y2="80"/>
+  <line class="link" x1="120" y1="80" x2="160" y2="90"/>
+  <line class="link" x1="30" y1="110" x2="90" y2="120"/>
+  <line class="link" x1="90" y1="120" x2="140" y2="130"/>
+  <line class="link" x1="140" y1="130" x2="180" y2="140"/>
+  <line class="link" x1="50" y1="150" x2="100" y2="160"/>
+  <line class="link" x1="100" y1="160" x2="150" y2="170"/>
+  <line class="link" x1="20" y1="180" x2="80" y2="180"/>
+  <line class="link" x1="80" y1="180" x2="130" y2="180"/>
+</svg>

--- a/coresite/static/coresite/svg/motifs/motif-waveform-1.svg
+++ b/coresite/static/coresite/svg/motifs/motif-waveform-1.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 40" class="motif-waveform">
+  <path class="wave" d="M0 20 C20 0 40 40 60 20 S100 0 120 20 S160 40 180 20 S200 0 220 20"/>
+</svg>

--- a/coresite/static/coresite/svg/motifs/motif-waveform-2.svg
+++ b/coresite/static/coresite/svg/motifs/motif-waveform-2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 50" class="motif-waveform gray">
+  <path class="wave" d="M0 25 C25 5 50 45 75 25 S125 5 150 25 S175 45 200 25"/>
+  <path class="wave" d="M0 35 C25 15 50 55 75 35 S125 15 150 35 S175 55 200 35"/>
+</svg>


### PR DESCRIPTION
## Summary
- add SCSS motif utilities with token-based grid, node-field and waveform styles
- add node-field and waveform SVG assets for accent motifs

## Testing
- `npx svgo coresite/static/coresite/svg/motifs/motif-node-field-1.svg coresite/static/coresite/svg/motifs/motif-node-field-2.svg coresite/static/coresite/svg/motifs/motif-node-field-3.svg coresite/static/coresite/svg/motifs/motif-waveform-1.svg coresite/static/coresite/svg/motifs/motif-waveform-2.svg` (fails: 403 Forbidden)
- `pip install django` (fails: 403 Forbidden)
- `pytest` (fails: ModuleNotFoundError: No module named 'django')

------
https://chatgpt.com/codex/tasks/task_e_68ad9c2421e4832a9efab99d133e504c