### PR TITLE
Add knowledge hero partial

### DIFF
--- a/coresite/templates/coresite/knowledge/_hero.html
+++ b/coresite/templates/coresite/knowledge/_hero.html
@@ -1,0 +1,11 @@
+<section class="hero knowledge-hero" role="region" aria-label="Knowledge base hero" style="--hero-min-h:30vh;max-height:30vh;">
+  <div class="knowledge-hero__band motif-grid" aria-hidden="true" style="position:absolute;inset:0;opacity:0.1;"></div>
+  <div class="hero__content">
+    <h1 style="font-family:'IBM Plex Sans', var(--font-family-base, sans-serif);">Welcome to the Knowledge Hub</h1>
+    <p class="hero__sub">Dive into guides, glossary terms, and signals tailored for you.</p>
+    <form class="knowledge-hero__search" role="search" hidden>
+      <label for="knowledge-search" class="visually-hidden">Search knowledge base</label>
+      <input type="search" id="knowledge-search" name="q" placeholder="Search articles">
+    </form>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add knowledge section hero template with grid motif background
- include Plex Sans heading, supporting copy, and optional search field

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ade5aa1b5c832aa5a943ff2c56cc77