### PR TITLE
Add knowledge filter bar partial

### DIFF
--- a/coresite/templates/coresite/knowledge/_filterbar.html
+++ b/coresite/templates/coresite/knowledge/_filterbar.html
@@ -1,0 +1,41 @@
+<nav class="knowledge-filterbar" aria-label="Knowledge filters">
+  <div class="knowledge-filterbar__band" style="position:relative;background:var(--color-bg-alt,#F9FAFB);">
+    <div class="knowledge-filterbar__motif" aria-hidden="true" style="position:absolute;inset:0;pointer-events:none;opacity:0.1;">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" class="motif-node-field" style="width:100%;height:100%;">
+        <circle class="node" cx="20" cy="40" r="4"/>
+        <circle class="node blue" cx="70" cy="20" r="4"/>
+        <circle class="node" cx="140" cy="30" r="4"/>
+        <circle class="node" cx="180" cy="60" r="4"/>
+        <circle class="node blue" cx="50" cy="90" r="4"/>
+        <circle class="node" cx="110" cy="100" r="4"/>
+        <circle class="node" cx="170" cy="120" r="4"/>
+        <circle class="node blue" cx="30" cy="150" r="4"/>
+        <circle class="node" cx="90" cy="160" r="4"/>
+        <circle class="node" cx="150" cy="170" r="4"/>
+        <circle class="node" cx="60" cy="180" r="4"/>
+        <circle class="node" cx="10" cy="110" r="4"/>
+        <line class="link" x1="20" y1="40" x2="70" y2="20"/>
+        <line class="link" x1="70" y1="20" x2="140" y2="30"/>
+        <line class="link" x1="50" y1="90" x2="110" y2="100"/>
+        <line class="link" x1="110" y1="100" x2="170" y2="120"/>
+        <line class="link" x1="30" y1="150" x2="90" y2="160"/>
+        <line class="link" x1="90" y1="160" x2="150" y2="170"/>
+      </svg>
+    </div>
+    <div class="knowledge-filterbar__scroll" style="overflow-x:auto;-webkit-overflow-scrolling:touch;">
+      <ul class="knowledge-filterbar__list" style="display:flex;gap:1rem;list-style:none;margin:0;padding:0.5rem 1rem;white-space:nowrap;font-family:var(--font-family-base,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif);">
+        {% for filter in filters %}
+        <li style="flex:0 0 auto;"><a href="{{ filter.url }}" {% if filter.active %}aria-current="page"{% endif %}>{{ filter.label }}</a></li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="knowledge-filterbar__dropdown" hidden>
+      <label for="knowledge-filter" class="visually-hidden">Filter</label>
+      <select id="knowledge-filter" onchange="if(this.value) window.location=this.value" style="font-family:var(--font-family-base,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif);">
+        {% for filter in filters %}
+        <option value="{{ filter.url }}" {% if filter.active %}selected{% endif %}>{{ filter.label }}</option>
+        {% endfor %}
+      </select>
+    </div>
+  </div>
+</nav>


### PR DESCRIPTION
## Summary
- add knowledge filter bar partial with bg-alt band and node-field accent
- include horizontally scrollable plain-text links with dropdown fallback

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ade6e4b030832aa718d457f08dd50f