### PR TITLE
Add featured knowledge card template

### DIFF
--- a/coresite/templates/coresite/knowledge/_featured.html
+++ b/coresite/templates/coresite/knowledge/_featured.html
@@ -1,0 +1,15 @@
+{# Render a featured knowledge resource with image, heading, excerpt and CTA #}
+<section class="knowledge-featured" role="region" aria-labelledby="knowledge-featured-heading">
+  <div class="wrap">
+    <article class="card knowledge-featured__card split" style="width:100%;align-items:center;">
+      <div class="knowledge-featured__media">
+        <img src="{{ featured.image.url }}" alt="{{ featured.image.alt }}" width="{{ featured.image.width }}" height="{{ featured.image.height }}" style="width:100%;height:auto;border-radius:0.5rem;">
+      </div>
+      <div class="knowledge-featured__content stack" style="justify-content:center;">
+        <h2 id="knowledge-featured-heading">{{ featured.heading }}</h2>
+        <p>{{ featured.excerpt }}</p>
+        <a href="{{ featured.cta.url }}" class="btn btn--cta" data-analytics-event="knowledge_featured_cta" data-analytics-label="{{ featured.cta.label }}" data-analytics-url="{{ featured.cta.url }}">{{ featured.cta.label }}</a>
+      </div>
+    </article>
+  </div>
+</section>

--- a/docs/structured-data.md
+++ b/docs/structured-data.md
@@ -82,6 +82,11 @@ This document lists required and optional context dictionary keys for each templ
 - Required: resources (list of {title, blurb, url})
 - Optional: None
 
+<a id="knowledge-featured"></a>
+### knowledge/_featured.html
+- Required: featured.image.url, featured.heading, featured.excerpt, featured.cta.url, featured.cta.label
+- Optional: featured.image.alt, featured.image.width, featured.image.height
+
 <a id="global-analytics"></a>
 ### global/analytics.html
 - Required: ANALYTICS_PROVIDER, ANALYTICS_SITE_ID


### PR DESCRIPTION
## Summary
- add knowledge featured card partial with image, heading, excerpt and CTA
- document context keys for new featured knowledge partial

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68ade876dcac832ab143591ec97f8a15