### PR TITLE
Add knowledge card template

### DIFF
--- a/coresite/templates/coresite/knowledge/_card.html
+++ b/coresite/templates/coresite/knowledge/_card.html
@@ -1,0 +1,19 @@
+{% load thumbnail %}
+<a href="{% url 'knowledge_article' article.category.slug article.slug %}"
+   class="knowledge-card"
+   data-analytics-event="knowledge_article_click"
+   data-analytics-label="{{ article.title }}"
+   data-analytics-url="{% url 'knowledge_article' article.category.slug article.slug %}"
+   style="position:relative;display:block;min-width:16rem;text-decoration:none;color:inherit;border-radius:0.5rem;overflow:hidden;">
+  <div class="knowledge-card__motif motif-grid" aria-hidden="true" style="position:absolute;inset:0;opacity:0.05;"></div>
+  <div class="knowledge-card__inner stack" style="position:relative;gap:0.5rem;">
+    {% if article.image %}
+      {% thumbnail article.image 'hero_mobile' as thumb %}
+        <img src="{{ thumb.url }}" width="{{ thumb.width }}" height="{{ thumb.height }}" alt="{{ article.image.alt|default:article.title }}" style="width:100%;height:auto;display:block;border-radius:0.5rem;" loading="lazy">
+      {% endthumbnail %}
+    {% endif %}
+    <h3>{{ article.title }}</h3>
+    <p>{{ article.blurb }}</p>
+    <p class="knowledge-card__meta" style="font-size:0.875rem;color:var(--color-text-muted,#6c757d);">{{ article.created_at|date:"F j, Y" }} &mdash; {{ article.category.title }}</p>
+  </div>
+</a>

--- a/coresite/templates/coresite/knowledge/category.html
+++ b/coresite/templates/coresite/knowledge/category.html
@@ -12,20 +12,18 @@
   <div class="wrap">
     <h1 id="{{ page_id }}-heading">{{ category.title }}</h1>
     {% include "coresite/partials/global/status_placeholder.html" %}
-    
-    <div class="knowledge__articles">
+    <div class="knowledge__grid" style="display:grid;gap:1.5rem;grid-template-columns:1fr;">
       {% for article in articles %}
-      <article class="knowledge__teaser">
-        <h2>
-          <a href="{% url 'knowledge_article' category.slug article.slug %}"
-             data-analytics-event="knowledge_article_click"
-             data-analytics-label="{{ article.title }}"
-             data-analytics-url="{% url 'knowledge_article' category.slug article.slug %}">{{ article.title }}</a>
-        </h2>
-        <p>{{ article.blurb }}</p>
-      </article>
+        {% include "coresite/knowledge/_card.html" with article=article %}
       {% endfor %}
     </div>
+    <style>
+      @media (min-width: 32rem) {
+        .knowledge__grid {
+          grid-template-columns: repeat(2, minmax(16rem, 1fr));
+        }
+      }
+    </style>
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add knowledge article card partial with thumbnail, meta and grid motif
- show knowledge articles in responsive two-column grid on category pages

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68ade959c9d4832aa4109fd94a82c87f