### PR TITLE
Fix invalid template tag in knowledge card

### DIFF
--- a/coresite/templates/coresite/knowledge/_card.html
+++ b/coresite/templates/coresite/knowledge/_card.html
@@ -10,7 +10,6 @@
     {% if article.image %}
       {% thumbnail article.image 'hero_mobile' as thumb %}
         <img src="{{ thumb.url }}" width="{{ thumb.width }}" height="{{ thumb.height }}" alt="{{ article.image.alt|default:article.title }}" style="width:100%;height:auto;display:block;border-radius:0.5rem;" loading="lazy">
-      {% endthumbnail %}
     {% endif %}
     <h3>{{ article.title }}</h3>
     <p>{{ article.blurb }}</p>


### PR DESCRIPTION
## Summary
- fix invalid `endthumbnail` tag in knowledge card template

## Testing
- `python manage.py compilescss` *(fails: No module named 'django')*
- `pytest` *(fails: 12 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68adeb0cd59c832a95b1e358e7328107