### PR TITLE
Add knowledge CTA strip partial

### DIFF
--- a/coresite/templates/coresite/knowledge/_cta_strip.html
+++ b/coresite/templates/coresite/knowledge/_cta_strip.html
@@ -1,0 +1,20 @@
+<section class="knowledge-cta-strip" role="region" aria-label="More insights">
+  <div class="knowledge-cta-strip__band" style="position:relative;background:var(--color-bg-alt,#F9FAFB);">
+    <div class="knowledge-cta-strip__motif" aria-hidden="true" style="position:absolute;inset:0;pointer-events:none;opacity:0.1;">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 40" class="motif-waveform gray" style="width:100%;height:100%;">
+        <path class="wave" d="M0 20 C20 0 40 40 60 20 S100 0 120 20 S160 40 180 20 S200 0 220 20" />
+      </svg>
+    </div>
+    <div class="wrap">
+      <div class="knowledge-cta-strip__inner" style="display:flex;flex-direction:column;align-items:center;gap:1rem;padding:1.5rem 0;">
+        <p class="knowledge-cta-strip__text" style="margin:0;font-family:var(--font-family-base,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif);">Want more insights?</p>
+        <a href="#" class="btn btn--cta">Get the newsletter</a>
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  @media(min-width:768px){
+    .knowledge-cta-strip__inner{flex-direction:row;justify-content:space-between;}
+  }
+</style>


### PR DESCRIPTION
## Summary
- add reusable knowledge CTA strip with waveform motif and gold button

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68adf29c9ffc832abfe4432c54a23475