### PR TITLE
Add knowledge index page and update view

### DIFF
--- a/coresite/templates/coresite/knowledge/index.html
+++ b/coresite/templates/coresite/knowledge/index.html
@@ -1,0 +1,39 @@
+{% extends "coresite/base.html" %}
+
+{% block meta %}
+  {% with meta_description="Guides and insights from Technofatty." %}
+    {% include "coresite/partials/seo/meta_head.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block structured_data %}
+  {{ block.super }}
+{% endblock %}
+
+{% block content %}
+<div class="knowledge-index" style="font-family:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;">
+  {% include "coresite/knowledge/_hero.html" %}
+  <div class="container" style="padding:s(6) 0;">
+    {% include "coresite/knowledge/_filterbar.html" %}
+    {% if featured %}
+      {% include "coresite/knowledge/_featured.html" %}
+    {% endif %}
+    <div class="knowledge-grid" style="display:grid;gap:s(6);grid-template-columns:repeat(auto-fill,minmax(16rem,1fr));margin-top:s(6);">
+      {% for article in articles %}
+        {% include "coresite/knowledge/_card.html" %}
+      {% endfor %}
+    </div>
+    {% include "coresite/knowledge/_pagination.html" %}
+    {% if show_cta_strip %}
+      {% include "coresite/knowledge/_cta_strip.html" %}
+    {% endif %}
+  </div>
+</div>
+<style>
+  .knowledge-index h1,
+  .knowledge-index h2,
+  .knowledge-index h3 {
+    font-family: 'IBM Plex Sans', var(--font-family-base, sans-serif);
+  }
+</style>
+{% endblock %}


### PR DESCRIPTION
## Summary
- build new knowledge index template that composes hero, filterbar, featured, cards, pagination, and CTA strip
- style knowledge hub with container-max layout, spacing scale, and Plex Sans headings
- replace hub view to serve new index with pagination and category filters

## Testing
- `pytest` *(fails: Unknown pytest mark and 12 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68adf3c3cbcc832a8c2f1e5f3239b13b