### PR TITLE
Fetch knowledge page data and add tests

### DIFF
--- a/coresite/templates/coresite/knowledge/index.html
+++ b/coresite/templates/coresite/knowledge/index.html
@@ -14,7 +14,7 @@
 <div class="knowledge-index" style="font-family:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;">
   {% include "coresite/knowledge/_hero.html" %}
   <div class="container" style="padding:s(6) 0;">
-    {% include "coresite/knowledge/_filterbar.html" %}
+    {% include "coresite/knowledge/_filterbar.html" with filters=categories %}
     {% if featured %}
       {% include "coresite/knowledge/_featured.html" %}
     {% endif %}
@@ -23,7 +23,7 @@
         {% include "coresite/knowledge/_card.html" %}
       {% endfor %}
     </div>
-    {% include "coresite/knowledge/_pagination.html" %}
+    {% include "coresite/knowledge/_pagination.html" with page_obj=page_obj %}
     {% if show_cta_strip %}
       {% include "coresite/knowledge/_cta_strip.html" %}
     {% endif %}

--- a/coresite/tests/test_knowledge_index.py
+++ b/coresite/tests/test_knowledge_index.py
@@ -1,0 +1,46 @@
+import pytest
+from django.urls import reverse
+
+from coresite.models import KnowledgeCategory, KnowledgeArticle, StatusChoices
+
+
+@pytest.mark.django_db
+def test_knowledge_index_renders_featured_and_pagination(client):
+    category = KnowledgeCategory.objects.create(
+        title="General", slug="general", status=StatusChoices.PUBLISHED
+    )
+    for i in range(7):
+        KnowledgeArticle.objects.create(
+            category=category,
+            title=f"Article {i}",
+            slug=f"article-{i}",
+            status=StatusChoices.PUBLISHED,
+            blurb="blurb",
+        )
+    response = client.get(reverse("knowledge"))
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Article 6" in content
+    assert "Article 5" in content
+    assert f"/knowledge/{category.slug}/" in content
+    assert "?page=2" in content
+
+
+@pytest.mark.django_db
+def test_knowledge_index_second_page_has_no_featured(client):
+    category = KnowledgeCategory.objects.create(
+        title="General", slug="general", status=StatusChoices.PUBLISHED
+    )
+    for i in range(7):
+        KnowledgeArticle.objects.create(
+            category=category,
+            title=f"Article {i}",
+            slug=f"article-{i}",
+            status=StatusChoices.PUBLISHED,
+            blurb="blurb",
+        )
+    response = client.get(reverse("knowledge") + "?page=2")
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "knowledge-featured" not in content
+    assert "Article 0" in content


### PR DESCRIPTION
## Summary
- build knowledge page data with featured article, category filters, and pagination links
- wire new context into template
- test knowledge index rendering and pagination navigation

## Testing
- `pytest coresite/tests/test_knowledge_index.py -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68adf50ff52c832aa9092ef1781b8373