### PR TITLE
refactor: knowledge hero/filter/featured — tokenized SCSS, static motifs, no inline styles

### DIFF
--- a/coresite/static/coresite/scss/main.scss
+++ b/coresite/static/coresite/scss/main.scss
@@ -47,3 +47,4 @@
   @import "pages/support";
   @import "pages/legal";
   @import "pages/auth";
+  @import "pages/knowledge";

--- a/coresite/static/coresite/scss/pages/_knowledge.scss
+++ b/coresite/static/coresite/scss/pages/_knowledge.scss
@@ -1,0 +1,102 @@
+/* Knowledge page partials */
+
+.kn-hero {
+  --hero-min-h: 30vh;
+  max-height: 30vh;
+  --hero-pad-block: s(6);
+
+  background-image: linear-gradient(
+      to right,
+      rgba(map-get($colors, border), 0.1) 0,
+      rgba(map-get($colors, border), 0.1) bw(sm),
+      transparent bw(sm)
+    ),
+    linear-gradient(
+      to bottom,
+      rgba(map-get($colors, border), 0.1) 0,
+      rgba(map-get($colors, border), 0.1) bw(sm),
+      transparent bw(sm)
+    );
+  background-size: s(6) s(6);
+
+  @include mq(md) { --hero-pad-block: s(7); }
+  @include mq(lg) { --hero-pad-block: s(8); }
+}
+
+.kn-filterbar {
+  position: relative;
+  background-color: c(bg-alt);
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: url('/static/coresite/svg/motifs/motif-node-field-1.svg') center/cover no-repeat;
+    opacity: 0.1;
+    pointer-events: none;
+  }
+}
+
+.kn-filterbar__scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.kn-filterbar__list {
+  list-style: none;
+  display: flex;
+  gap: s(4);
+  margin: 0;
+  padding: s(2) s(4);
+  white-space: nowrap;
+
+  li { flex: 0 0 auto; }
+
+  a {
+    color: c(text);
+    text-decoration: none;
+    letter-spacing: 0.02em;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+
+    &[aria-current="page"] {
+      border-bottom: bw(sm) solid c(blue);
+    }
+  }
+}
+
+@include mq(md) {
+  .kn-filterbar__list { justify-content: center; }
+}
+
+.kn-featured__card {
+  display: flex;
+  flex-direction: column;
+  gap: s(6);
+  align-items: center;
+
+  @include mq(md) {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: s(6);
+    align-items: center;
+  }
+}
+
+.kn-featured__media img {
+  width: 100%;
+  height: auto;
+  border-radius: r(md);
+  box-shadow: sh(card);
+}
+
+.kn-featured__content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: s(4);
+}
+

--- a/coresite/templates/coresite/knowledge/_featured.html
+++ b/coresite/templates/coresite/knowledge/_featured.html
@@ -1,11 +1,11 @@
 {# Render a featured knowledge resource with image, heading, excerpt and CTA #}
-<section class="knowledge-featured" role="region" aria-labelledby="knowledge-featured-heading">
+<section class="kn-featured" role="region" aria-labelledby="knowledge-featured-heading">
   <div class="wrap">
-    <article class="card knowledge-featured__card split" style="width:100%;align-items:center;">
-      <div class="knowledge-featured__media">
-        <img src="{{ featured.image.url }}" alt="{{ featured.image.alt }}" width="{{ featured.image.width }}" height="{{ featured.image.height }}" style="width:100%;height:auto;border-radius:0.5rem;">
+    <article class="card kn-featured__card">
+      <div class="kn-featured__media">
+        <img src="{{ featured.image.url }}" alt="{{ featured.image.alt }}" width="{{ featured.image.width }}" height="{{ featured.image.height }}">
       </div>
-      <div class="knowledge-featured__content stack" style="justify-content:center;">
+      <div class="kn-featured__content stack">
         <h2 id="knowledge-featured-heading">{{ featured.heading }}</h2>
         <p>{{ featured.excerpt }}</p>
         <a href="{{ featured.cta.url }}" class="btn btn--cta" data-analytics-event="knowledge_featured_cta" data-analytics-label="{{ featured.cta.label }}" data-analytics-url="{{ featured.cta.url }}">{{ featured.cta.label }}</a>

--- a/coresite/templates/coresite/knowledge/_filterbar.html
+++ b/coresite/templates/coresite/knowledge/_filterbar.html
@@ -1,41 +1,17 @@
-<nav class="knowledge-filterbar" aria-label="Knowledge filters">
-  <div class="knowledge-filterbar__band" style="position:relative;background:var(--color-bg-alt,#F9FAFB);">
-    <div class="knowledge-filterbar__motif" aria-hidden="true" style="position:absolute;inset:0;pointer-events:none;opacity:0.1;">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" class="motif-node-field" style="width:100%;height:100%;">
-        <circle class="node" cx="20" cy="40" r="4"/>
-        <circle class="node blue" cx="70" cy="20" r="4"/>
-        <circle class="node" cx="140" cy="30" r="4"/>
-        <circle class="node" cx="180" cy="60" r="4"/>
-        <circle class="node blue" cx="50" cy="90" r="4"/>
-        <circle class="node" cx="110" cy="100" r="4"/>
-        <circle class="node" cx="170" cy="120" r="4"/>
-        <circle class="node blue" cx="30" cy="150" r="4"/>
-        <circle class="node" cx="90" cy="160" r="4"/>
-        <circle class="node" cx="150" cy="170" r="4"/>
-        <circle class="node" cx="60" cy="180" r="4"/>
-        <circle class="node" cx="10" cy="110" r="4"/>
-        <line class="link" x1="20" y1="40" x2="70" y2="20"/>
-        <line class="link" x1="70" y1="20" x2="140" y2="30"/>
-        <line class="link" x1="50" y1="90" x2="110" y2="100"/>
-        <line class="link" x1="110" y1="100" x2="170" y2="120"/>
-        <line class="link" x1="30" y1="150" x2="90" y2="160"/>
-        <line class="link" x1="90" y1="160" x2="150" y2="170"/>
-      </svg>
-    </div>
-    <div class="knowledge-filterbar__scroll" style="overflow-x:auto;-webkit-overflow-scrolling:touch;">
-      <ul class="knowledge-filterbar__list" style="display:flex;gap:1rem;list-style:none;margin:0;padding:0.5rem 1rem;white-space:nowrap;font-family:var(--font-family-base,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif);">
-        {% for filter in filters %}
-        <li style="flex:0 0 auto;"><a href="{{ filter.url }}" {% if filter.active %}aria-current="page"{% endif %}>{{ filter.label }}</a></li>
-        {% endfor %}
-      </ul>
-    </div>
-    <div class="knowledge-filterbar__dropdown" hidden>
-      <label for="knowledge-filter" class="visually-hidden">Filter</label>
-      <select id="knowledge-filter" onchange="if(this.value) window.location=this.value" style="font-family:var(--font-family-base,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif);">
-        {% for filter in filters %}
-        <option value="{{ filter.url }}" {% if filter.active %}selected{% endif %}>{{ filter.label }}</option>
-        {% endfor %}
-      </select>
-    </div>
+<nav class="kn-filterbar" aria-label="Knowledge filters">
+  <div class="kn-filterbar__scroll">
+    <ul class="kn-filterbar__list">
+      {% for filter in filters %}
+      <li><a href="{{ filter.url }}" {% if filter.active %}aria-current="page"{% endif %}>{{ filter.label }}</a></li>
+      {% endfor %}
+    </ul>
+  </div>
+  <div class="kn-filterbar__dropdown" hidden>
+    <label for="knowledge-filter" class="visually-hidden">Filter</label>
+    <select id="knowledge-filter" onchange="if(this.value) window.location=this.value">
+      {% for filter in filters %}
+      <option value="{{ filter.url }}" {% if filter.active %}selected{% endif %}>{{ filter.label }}</option>
+      {% endfor %}
+    </select>
   </div>
 </nav>

--- a/coresite/templates/coresite/knowledge/_hero.html
+++ b/coresite/templates/coresite/knowledge/_hero.html
@@ -1,9 +1,8 @@
-<section class="hero knowledge-hero" role="region" aria-label="Knowledge base hero" style="--hero-min-h:30vh;max-height:30vh;">
-  <div class="knowledge-hero__band motif-grid" aria-hidden="true" style="position:absolute;inset:0;opacity:0.1;"></div>
+<section class="hero kn-hero" role="region" aria-label="Knowledge base hero">
   <div class="hero__content">
-    <h1 style="font-family:'IBM Plex Sans', var(--font-family-base, sans-serif);">Welcome to the Knowledge Hub</h1>
+    <h1>Welcome to the Knowledge Hub</h1>
     <p class="hero__sub">Dive into guides, glossary terms, and signals tailored for you.</p>
-    <form class="knowledge-hero__search" role="search" hidden>
+    <form class="kn-hero__search" role="search" hidden>
       <label for="knowledge-search" class="visually-hidden">Search knowledge base</label>
       <input type="search" id="knowledge-search" name="q" placeholder="Search articles">
     </form>


### PR DESCRIPTION
## Summary
- remove inline presentation from Knowledge hero, filter bar, and featured block
- add page-scoped SCSS with token-driven spacing, color, and motifs
- wire new styles into main stylesheet

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

## Files
- coresite/templates/coresite/knowledge/_hero.html
- coresite/templates/coresite/knowledge/_filterbar.html
- coresite/templates/coresite/knowledge/_featured.html
- coresite/static/coresite/scss/pages/_knowledge.scss
- coresite/static/coresite/scss/main.scss

## Acceptance Criteria
- [x] No inline style attributes or `<style>` tags in templates
- [x] No inline SVG motifs; backgrounds reference `/static/coresite/svg/motifs/...`
- [x] All colors, spacing, radii, borders, and shadows are token-based in SCSS
- [x] Hero remains shallow, filter bar accessible with `aria-current`, featured block uses a single gold CTA

------
https://chatgpt.com/codex/tasks/task_e_68adfa5c5f74832a93d8ba6b1eb5b0e8