### PR TITLE
Refactor knowledge index layout styles

### DIFF
--- a/coresite/static/coresite/scss/pages/_knowledge.scss
+++ b/coresite/static/coresite/scss/pages/_knowledge.scss
@@ -1,5 +1,31 @@
 /* Knowledge page partials */
 
+.knowledge-index {
+  font-family: map-get($font-families, base);
+
+  h1 {
+    font-family: map-get($font-families, base);
+    font-size: fs(xxl);
+  }
+
+  h2 {
+    font-family: map-get($font-families, base);
+    font-size: fs(xl);
+  }
+
+  h3 {
+    font-family: map-get($font-families, base);
+    font-size: fs(lg);
+  }
+}
+
+.knowledge-index > .container {
+  padding-block: map-get($section-pad-y, base);
+
+  @include mq(md) { padding-block: map-get($section-pad-y, md); }
+  @include mq(lg) { padding-block: map-get($section-pad-y, lg); }
+}
+
 .kn-hero {
   --hero-min-h: 30vh;
   max-height: 30vh;
@@ -105,12 +131,9 @@
 
 .knowledge__grid {
   display: grid;
-  gap: s(5);
-  grid-template-columns: 1fr;
-
-  @include mq(sm) {
-    grid-template-columns: repeat(2, minmax(dim(grid-min), 1fr));
-  }
+  gap: s(6);
+  grid-template-columns: repeat(auto-fill, minmax(dim(grid-min), 1fr));
+  margin-top: s(6);
 }
 
 .knowledge-card {

--- a/coresite/templates/coresite/knowledge/index.html
+++ b/coresite/templates/coresite/knowledge/index.html
@@ -11,14 +11,14 @@
 {% endblock %}
 
 {% block content %}
-<div class="knowledge-index" style="font-family:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;">
+<div class="knowledge-index">
   {% include "coresite/knowledge/_hero.html" %}
-  <div class="container" style="padding:s(6) 0;">
+  <div class="container">
     {% include "coresite/knowledge/_filterbar.html" with filters=categories %}
     {% if featured %}
       {% include "coresite/knowledge/_featured.html" %}
     {% endif %}
-    <div class="knowledge-grid" style="display:grid;gap:s(6);grid-template-columns:repeat(auto-fill,minmax(16rem,1fr));margin-top:s(6);">
+    <div class="knowledge__grid">
       {% for article in articles %}
         {% include "coresite/knowledge/_card.html" %}
       {% endfor %}
@@ -29,11 +29,4 @@
     {% endif %}
   </div>
 </div>
-<style>
-  .knowledge-index h1,
-  .knowledge-index h2,
-  .knowledge-index h3 {
-    font-family: 'IBM Plex Sans', var(--font-family-base, sans-serif);
-  }
-</style>
 {% endblock %}


### PR DESCRIPTION
## Summary
- move knowledge index inline styles into SCSS tokens
- style knowledge grid with design tokens and spacing variables
- ensure knowledge page headings inherit font tokens

## Testing
- `pytest` *(fails: Unknown mark and 13 collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aea6433148832a8bb3c3f25377af0e