### PR TITLE
Align Knowledge hero rhythm with homepage

### DIFF
--- a/coresite/static/coresite/scss/pages/_knowledge.scss
+++ b/coresite/static/coresite/scss/pages/_knowledge.scss
@@ -27,9 +27,8 @@
 }
 
 .kn-hero {
-  --hero-min-h: 30vh;
-  max-height: 30vh;
-  --hero-pad-block: s(6);
+  min-height: calc(dim(hero-min-h) - var(--header-h));
+  padding-block: map-get($section-pad-y, base);
 
   background-image: linear-gradient(
       to right,
@@ -45,8 +44,8 @@
     );
   background-size: s(6) s(6);
 
-  @include mq(md) { --hero-pad-block: s(7); }
-  @include mq(lg) { --hero-pad-block: s(8); }
+  @include mq(md) { padding-block: map-get($section-pad-y, md); }
+  @include mq(lg) { padding-block: map-get($section-pad-y, lg); }
 }
 
 .kn-filterbar {


### PR DESCRIPTION
## Summary
- replace Knowledge hero viewport height rules with token-based min-height
- use section padding tokens for hero spacing

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68aea8089050832aa379222df5fef77f