### PR TITLE
style: align knowledge filter bar spacing

### DIFF
--- a/coresite/static/coresite/scss/pages/_knowledge.scss
+++ b/coresite/static/coresite/scss/pages/_knowledge.scss
@@ -65,14 +65,16 @@
 .kn-filterbar__scroll {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
+  padding-inline: s(4);
 }
 
 .kn-filterbar__list {
   list-style: none;
   display: flex;
-  gap: s(4);
+  gap: s(3);
   margin: 0;
-  padding: s(2) s(4);
+  padding-block: s(3);
+  padding-inline: 0;
   white-space: nowrap;
 
   li { flex: 0 0 auto; }
@@ -91,6 +93,12 @@
       border-bottom: bw(sm) solid c(blue);
     }
   }
+}
+
+.kn-filterbar__dropdown {
+  display: flex;
+  gap: s(3);
+  padding: s(3) s(4);
 }
 
 @include mq(md) {


### PR DESCRIPTION
## Summary
- normalize Knowledge filter list gap and padding
- add dropdown styling and equalize horizontal padding for scroll and dropdown containers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `npx --yes sass coresite/static/coresite/scss/pages/_knowledge.scss` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aea9cea7f8832aaeb1ad40a553acd9