### PR TITLE
Use tokens for knowledge index headings

### DIFF
--- a/coresite/static/coresite/scss/pages/_knowledge.scss
+++ b/coresite/static/coresite/scss/pages/_knowledge.scss
@@ -1,21 +1,19 @@
 /* Knowledge page partials */
 
 .knowledge-index {
-  font-family: map-get($font-families, base);
-
   h1 {
-    font-family: map-get($font-families, base);
-    font-size: fs(xxl);
+    font-size: map-get($font-sizes, xxl);
+    line-height: map-get($line-heights, base);
   }
 
   h2 {
-    font-family: map-get($font-families, base);
-    font-size: fs(xl);
+    font-size: map-get($font-sizes, xl);
+    line-height: map-get($line-heights, base);
   }
 
   h3 {
-    font-family: map-get($font-families, base);
-    font-size: fs(lg);
+    font-size: map-get($font-sizes, lg);
+    line-height: map-get($line-heights, base);
   }
 }
 


### PR DESCRIPTION
## Summary
- Switch knowledge index heading styles to design tokens for font size and line height
- Remove bespoke font overrides so headings inherit from global variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68aeacee85bc832a9f50404373da70b3