### PR TITLE
Use motif token and helper for knowledge CTA strip

### DIFF
--- a/coresite/static/coresite/scss/pages/_knowledge.scss
+++ b/coresite/static/coresite/scss/pages/_knowledge.scss
@@ -201,7 +201,7 @@
 /* CTA strip */
 
 @mixin motif-bg($name) {
-  background: url('/static/coresite/img/motifs/#{$name}.svg') center/cover no-repeat;
+  background: url('/static/coresite/svg/motifs/#{$name}.svg') center/cover no-repeat;
 }
 
 .knowledge-cta-strip__band {

--- a/coresite/static/coresite/scss/pages/_knowledge.scss
+++ b/coresite/static/coresite/scss/pages/_knowledge.scss
@@ -200,6 +200,10 @@
 
 /* CTA strip */
 
+@mixin motif-bg($name) {
+  background: url('/static/coresite/img/motifs/#{$name}.svg') center/cover no-repeat;
+}
+
 .knowledge-cta-strip__band {
   position: relative;
   background: c(bg-alt);
@@ -209,7 +213,7 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: url('/static/coresite/svg/motifs/motif-waveform-1.svg') center/cover no-repeat;
+  @include motif-bg('motif-waveform-1');
   opacity: map-get($opacities, low);
 }
 

--- a/coresite/templates/coresite/knowledge/_cta_strip.html
+++ b/coresite/templates/coresite/knowledge/_cta_strip.html
@@ -1,7 +1,7 @@
 {% load static %}
 <section class="knowledge-cta-strip" role="region" aria-label="More insights">
   <div class="knowledge-cta-strip__band">
-    <div class="knowledge-cta-strip__motif" aria-hidden="true"></div>
+    <div class="knowledge-cta-strip__motif motif-waveform" data-motif="waveform-1" aria-hidden="true"></div>
     <div class="wrap">
       <div class="knowledge-cta-strip__inner">
         <p class="knowledge-cta-strip__text">Want more insights?</p>


### PR DESCRIPTION
## Summary
- add motif token and data attribute for CTA strip motif
- use mixin motif-bg to load motif asset from img/motifs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68aeadf2b2e8832aad49eb6689052677