### PR TITLE
Refactor knowledge SCSS to use tokens

### DIFF
--- a/coresite/static/coresite/scss/pages/_knowledge.scss
+++ b/coresite/static/coresite/scss/pages/_knowledge.scss
@@ -30,14 +30,14 @@
 
   background-image: linear-gradient(
       to right,
-      rgba(map-get($colors, border), 0.1) 0,
-      rgba(map-get($colors, border), 0.1) bw(sm),
+      rgba(map-get($colors, border), map-get($opacities, low)) 0,
+      rgba(map-get($colors, border), map-get($opacities, low)) bw(sm),
       transparent bw(sm)
     ),
     linear-gradient(
       to bottom,
-      rgba(map-get($colors, border), 0.1) 0,
-      rgba(map-get($colors, border), 0.1) bw(sm),
+      rgba(map-get($colors, border), map-get($opacities, low)) 0,
+      rgba(map-get($colors, border), map-get($opacities, low)) bw(sm),
       transparent bw(sm)
     );
   background-size: s(6) s(6);
@@ -55,7 +55,7 @@
     position: absolute;
     inset: 0;
     background: url('/static/coresite/svg/motifs/motif-node-field-1.svg') center/cover no-repeat;
-    opacity: 0.1;
+    opacity: map-get($opacities, low);
     pointer-events: none;
   }
 }
@@ -80,7 +80,7 @@
   a {
     color: c(text);
     text-decoration: none;
-    letter-spacing: 0.02em;
+    letter-spacing: 0.02em; // design sign-off
 
     &:hover,
     &:focus {


### PR DESCRIPTION
## Summary
- replace hard-coded opacity values in knowledge page styles with design tokens
- note custom letter-spacing that deviates from design tokens

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68aeb70f854c832abebf3b3285a6a064