### PR TITLE
Implement lightweight no-results handling on Knowledge pages

### DIFF
--- a/coresite/static/coresite/scss/pages/_knowledge.scss
+++ b/coresite/static/coresite/scss/pages/_knowledge.scss
@@ -245,7 +245,7 @@
 
 /* Footer separator */
 
-.knowledge-index + footer {
+main + footer {
   border-top: 1px solid c(border);
 }
 

--- a/coresite/static/coresite/scss/pages/_knowledge.scss
+++ b/coresite/static/coresite/scss/pages/_knowledge.scss
@@ -233,22 +233,14 @@
   margin: 0;
 }
 
-/* Empty state */
+/* No results */
 
-.knowledge-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: s(4);
+.kn-no-results {
   padding-block: map-get($section-pad-y, base);
+  text-align: center;
 
   @include mq(md) { padding-block: map-get($section-pad-y, md); }
   @include mq(lg) { padding-block: map-get($section-pad-y, lg); }
-}
-
-.knowledge-empty__text {
-  margin: 0;
-  text-align: center;
 }
 
 /* Footer separator */

--- a/coresite/templates/coresite/knowledge/_no_results.html
+++ b/coresite/templates/coresite/knowledge/_no_results.html
@@ -1,4 +1,4 @@
-<div class="kn-no-results">
+<div class="kn-no-results" role="status" aria-live="polite">
   <p>No articles found for your selection. <a href="{% url 'knowledge' %}">Back to all articles</a>.</p>
-  <p><a href="{% url 'newsletter_subscribe' %}">Want updates? Subscribe here.</a></p>
+  <p><a href="/#signup">Want updates? Subscribe here.</a></p>
 </div>

--- a/coresite/templates/coresite/knowledge/_no_results.html
+++ b/coresite/templates/coresite/knowledge/_no_results.html
@@ -1,0 +1,4 @@
+<div class="kn-no-results">
+  <p>No articles found for your selection. <a href="{% url 'knowledge' %}">Back to all articles</a>.</p>
+  <p><a href="{% url 'newsletter_subscribe' %}">Want updates? Subscribe here.</a></p>
+</div>

--- a/coresite/templates/coresite/knowledge/category.html
+++ b/coresite/templates/coresite/knowledge/category.html
@@ -12,11 +12,15 @@
   <div class="wrap">
     <h1 id="{{ page_id }}-heading">{{ category.title }}</h1>
     {% include "coresite/partials/global/status_placeholder.html" %}
+    {% if articles %}
     <div class="knowledge-grid">
       {% for article in articles %}
         {% include "coresite/knowledge/_card.html" with article=article %}
       {% endfor %}
     </div>
+    {% else %}
+      {% include "coresite/knowledge/_no_results.html" %}
+    {% endif %}
   </div>
 </section>
 {% endblock %}

--- a/coresite/templates/coresite/knowledge/index.html
+++ b/coresite/templates/coresite/knowledge/index.html
@@ -29,10 +29,7 @@
         {% include "coresite/knowledge/_cta_strip.html" %}
       {% endif %}
     {% else %}
-      <section class="knowledge-empty">
-        <p class="knowledge-empty__text">No articles yet. Subscribe to our newsletter for updates.</p>
-        <a href="#" class="btn btn--cta">Get the newsletter</a>
-      </section>
+      <p>No articles published yet.</p>
     {% endif %}
   </div>
 </div>

--- a/coresite/templates/coresite/knowledge/index.html
+++ b/coresite/templates/coresite/knowledge/index.html
@@ -14,7 +14,9 @@
 <div class="knowledge-index">
   {% include "coresite/knowledge/_hero.html" %}
   <div class="container">
-    {% include "coresite/knowledge/_filterbar.html" with filters=categories %}
+    {% if has_filters %}
+      {% include "coresite/knowledge/_filterbar.html" with filters=categories %}
+    {% endif %}
     {% if featured %}
       {% include "coresite/knowledge/_featured.html" %}
     {% endif %}

--- a/coresite/tests/test_knowledge_index.py
+++ b/coresite/tests/test_knowledge_index.py
@@ -24,6 +24,7 @@ def test_knowledge_index_renders_featured_and_pagination(client):
     assert "Article 5" in content
     assert f"/knowledge/{category.slug}/" in content
     assert "?page=2" in content
+    assert "kn-filterbar" in content
 
 
 @pytest.mark.django_db
@@ -53,6 +54,7 @@ def test_knowledge_index_empty_state(client):
     content = response.content.decode()
     assert "No articles published yet." in content
     assert "knowledge-grid" not in content
+    assert "kn-filterbar" not in content
 
 
 @pytest.mark.django_db

--- a/coresite/tests/test_knowledge_index.py
+++ b/coresite/tests/test_knowledge_index.py
@@ -51,5 +51,17 @@ def test_knowledge_index_empty_state(client):
     response = client.get(reverse("knowledge"))
     assert response.status_code == 200
     content = response.content.decode()
-    assert "knowledge-empty" in content
+    assert "No articles published yet." in content
+    assert "knowledge-grid" not in content
+
+
+@pytest.mark.django_db
+def test_knowledge_category_no_results(client):
+    category = KnowledgeCategory.objects.create(
+        title="General", slug="general", status=StatusChoices.PUBLISHED
+    )
+    response = client.get(reverse("knowledge_category", args=[category.slug]))
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "No articles found for your selection." in content
     assert "knowledge-grid" not in content

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -171,6 +171,7 @@ def knowledge(request):
                 "active": False,
             }
         )
+    has_filters = len(categories) > 1
 
     prev_page = absolute_page_url(page_number - 1) if page_obj.has_previous() else None
     next_page = absolute_page_url(page_number + 1) if page_obj.has_next() else None
@@ -181,6 +182,7 @@ def knowledge(request):
         "page_id": "knowledge",
         "page_title": "Knowledge",
         "categories": categories,
+        "has_filters": has_filters,
         "featured": featured_article,
         "articles": remaining_articles,
         "page_obj": page_obj,


### PR DESCRIPTION
## Summary
- add reusable `kn-no-results` component with link back to All articles and optional newsletter CTA
- simplify empty state on Knowledge index to a plain message
- show `kn-no-results` when a category has no articles and remove old `knowledge-empty` styles

## Testing
- `pytest` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68aecbef5ba8832aaff8735cd98004d6