### PR TITLE
Expand KnowledgeArticle model with taxonomy, media, and SEO fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,46 +5,44 @@ __pycache__/
 *.pyd
 *.sqlite3
 
-# Django
+# Django / project artifacts
 db.sqlite3
-/staticfiles/
+static_collected/
+staticfiles/
 media/
 *.log
 
-# Virtual environment
+# Virtual environments
+.venv/
 venv/
 env/
-.venv/
 technofatty_env/
 
 # Node
 node_modules/
-npm-debug.log
-yarn-error.log
+npm-debug.log*
+yarn-error.log*
 package-lock.json
 
-# SCSS cache
+# SCSS cache / generated CSS in source tree
 .sass-cache/
+coresite/static/coresite/scss/*.css
 
-# OS / IDE files
+# Editor / OS
 .DS_Store
 Thumbs.db
 .vscode/
 .idea/
 
-# Env files
+# Env / secrets
 .env
 *.env
 
-# Coverage / Test
+# Tests / coverage
 htmlcov/
 .tox/
 .coverage
 .pytest_cache/
 
-# Generated CSS
-coresite/static/coresite/scss/*.css
-
-# Ignore var outbox contents but keep directory
-var/outbox/*
-!var/outbox/.gitkeep
+# Local runtime data (never commit)
+var/

--- a/coresite/admin.py
+++ b/coresite/admin.py
@@ -5,6 +5,7 @@ from .models import (
     DevImage,
     KnowledgeCategory,
     KnowledgeArticle,
+    KnowledgeTag,
     BlogPost,
     ContactEvent,
 )
@@ -50,6 +51,11 @@ class KnowledgeArticleAdmin(admin.ModelAdmin):
     list_display = ("title", "category", "status")
     list_filter = ("status", "category")
     prepopulated_fields = {"slug": ("title",)}
+
+
+@admin.register(KnowledgeTag)
+class KnowledgeTagAdmin(admin.ModelAdmin):
+    prepopulated_fields = {"slug": ("name",)}
 
 
 @admin.register(BlogPost)

--- a/coresite/feeds.py
+++ b/coresite/feeds.py
@@ -43,7 +43,7 @@ class KnowledgeRSSFeed(Feed):
 
     def items(self):
         return (
-            KnowledgeArticle.published.select_related("category").order_by("-created_at")[:10]
+            KnowledgeArticle.published.select_related("category").order_by("-published_at")[:10]
         )
 
     def item_title(self, item):
@@ -56,7 +56,10 @@ class KnowledgeRSSFeed(Feed):
         return reverse("knowledge_article", args=[item.category.slug, item.slug])
 
     def item_pubdate(self, item):
-        return item.created_at
+        pubdate = item.published_at or timezone.now()
+        if timezone.is_naive(pubdate):
+            pubdate = timezone.make_aware(pubdate, timezone.utc)
+        return pubdate
 
 
 class KnowledgeAtomFeed(KnowledgeRSSFeed):
@@ -79,7 +82,7 @@ def blog_json_feed(request):
 
 def knowledge_json_feed(request):
     articles = (
-        KnowledgeArticle.published.select_related("category").order_by("-created_at")[:10]
+        KnowledgeArticle.published.select_related("category").order_by("-published_at")[:10]
     )
     items = [
         {

--- a/coresite/migrations/0008_knowledgearticle_expansion.py
+++ b/coresite/migrations/0008_knowledgearticle_expansion.py
@@ -1,0 +1,167 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("coresite", "0007_contactevent"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="KnowledgeTag",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("name", models.CharField(max_length=100)),
+                ("slug", models.SlugField(unique=True)),
+            ],
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="subtype",
+            field=models.CharField(blank=True, choices=[
+                ("guide", "Guide"),
+                ("glossary", "Glossary"),
+                ("signal", "Signal"),
+                ("quick_win", "Quick Win"),
+            ], max_length=20),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="published_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="author",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="knowledge_articles",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="reading_time",
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="attribution",
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="tags",
+            field=models.ManyToManyField(blank=True, related_name="articles", to="coresite.knowledgetag"),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="image",
+            field=models.ImageField(blank=True, null=True, upload_to="knowledge/"),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="image_alt",
+            field=models.CharField(default="", max_length=255),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="motif",
+            field=models.CharField(blank=True, max_length=100),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="meta_title",
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="meta_description",
+            field=models.TextField(blank=True),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="canonical_url",
+            field=models.URLField(blank=True),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="og_title",
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="og_description",
+            field=models.TextField(blank=True),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="og_image_url",
+            field=models.URLField(blank=True),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="twitter_title",
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="twitter_description",
+            field=models.TextField(blank=True),
+        ),
+        migrations.AddField(
+            model_name="knowledgearticle",
+            name="twitter_image_url",
+            field=models.URLField(blank=True),
+        ),
+        migrations.AlterField(
+            model_name="knowledgearticle",
+            name="slug",
+            field=models.SlugField(blank=True),
+        ),
+        migrations.AlterField(
+            model_name="knowledgearticle",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("draft", "Draft"),
+                    ("published", "Published"),
+                    ("archived", "Archived"),
+                ],
+                default="draft",
+                max_length=20,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="knowledgecategory",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("draft", "Draft"),
+                    ("published", "Published"),
+                    ("archived", "Archived"),
+                ],
+                default="draft",
+                max_length=20,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="blogpost",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("draft", "Draft"),
+                    ("published", "Published"),
+                    ("archived", "Archived"),
+                ],
+                default="draft",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/coresite/migrations/0009_publish_semantics_and_indexes.py
+++ b/coresite/migrations/0009_publish_semantics_and_indexes.py
@@ -1,0 +1,68 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("coresite", "0008_knowledgearticle_expansion"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="knowledgearticle",
+            name="unique_article_slug_per_category",
+        ),
+        migrations.AlterField(
+            model_name="knowledgearticle",
+            name="slug",
+            field=models.SlugField(
+                blank=True,
+                unique=True,
+                help_text="Unique across all knowledge articles for future routing flexibility",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="knowledgearticle",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("draft", "Draft"),
+                    ("published", "Published"),
+                    ("archived", "Archived"),
+                ],
+                default="draft",
+                max_length=20,
+                db_index=True,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="knowledgearticle",
+            name="published_at",
+            field=models.DateTimeField(blank=True, null=True, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name="knowledgearticle",
+            name="image_alt",
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AddIndex(
+            model_name="knowledgearticle",
+            index=models.Index(
+                fields=["status", "published_at"],
+                name="knowledgearticle_status_published_at_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="knowledgearticle",
+            index=models.Index(
+                fields=["category", "status", "published_at"],
+                name="knowledgearticle_category_status_published_at_idx",
+            ),
+        ),
+        migrations.RunSQL(
+            sql="CREATE INDEX IF NOT EXISTS coresite_knowledgearticle_tags_tag_id_idx ON coresite_knowledgearticle_tags (knowledgetag_id);",
+            reverse_sql="DROP INDEX IF EXISTS coresite_knowledgearticle_tags_tag_id_idx;",
+        ),
+        migrations.RunSQL(
+            sql="CREATE INDEX IF NOT EXISTS coresite_knowledgearticle_tags_article_id_idx ON coresite_knowledgearticle_tags (knowledgearticle_id);",
+            reverse_sql="DROP INDEX IF EXISTS coresite_knowledgearticle_tags_article_id_idx;",
+        ),
+    ]

--- a/coresite/migrations/0009_publish_semantics_and_indexes.py
+++ b/coresite/migrations/0009_publish_semantics_and_indexes.py
@@ -47,14 +47,14 @@ class Migration(migrations.Migration):
             model_name="knowledgearticle",
             index=models.Index(
                 fields=["status", "published_at"],
-                name="knowledgearticle_status_published_at_idx",
+                name="knart_status_pub_idx",
             ),
         ),
         migrations.AddIndex(
             model_name="knowledgearticle",
             index=models.Index(
                 fields=["category", "status", "published_at"],
-                name="knowledgearticle_category_status_published_at_idx",
+                name="knart_cat_status_pub_idx",
             ),
         ),
         migrations.RunSQL(

--- a/coresite/models.py
+++ b/coresite/models.py
@@ -184,8 +184,8 @@ class KnowledgeArticle(TimestampedModel):
 
     class Meta:
         indexes = [
-            models.Index(fields=["status", "published_at"], name="knowledgearticle_status_published_at_idx"),
-            models.Index(fields=["category", "status", "published_at"], name="knowledgearticle_category_status_published_at_idx"),
+            models.Index(fields=["status", "published_at"], name="knart_status_pub_idx"),
+            models.Index(fields=["category", "status", "published_at"], name="knart_cat_status_pub_idx"),
         ]
 
 

--- a/coresite/tests/test_feeds.py
+++ b/coresite/tests/test_feeds.py
@@ -62,6 +62,7 @@ def test_knowledge_rss_feed(client):
         title="Art",
         slug="art",
         status=StatusChoices.PUBLISHED,
+        published_at=timezone.now(),
     )
     response = client.get(reverse("knowledge_rss"))
     assert response.status_code == 200
@@ -80,6 +81,7 @@ def test_knowledge_atom_feed(client):
         title="AtomArt",
         slug="atomart",
         status=StatusChoices.PUBLISHED,
+        published_at=timezone.now(),
     )
     response = client.get(reverse("knowledge_atom"))
     assert response.status_code == 200
@@ -98,6 +100,7 @@ def test_knowledge_json_feed(client):
         title="JsonArt",
         slug="jsonart",
         status=StatusChoices.PUBLISHED,
+        published_at=timezone.now(),
     )
     response = client.get(reverse("knowledge_json"))
     assert response.status_code == 200

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -130,7 +130,7 @@ def knowledge(request):
         )
 
     articles_qs = (
-        KnowledgeArticle.published.select_related("category").order_by("-created_at")
+        KnowledgeArticle.published.select_related("category").order_by("-published_at")
     )
     paginator = Paginator(articles_qs, 6)
     try:


### PR DESCRIPTION
## Summary
- enforce global slug uniqueness and publish date semantics for KnowledgeArticle
- add alt-text validation and automatic reading-time/slug generation on save
- index publish fields and tag joins for faster queries

## Testing
- `python manage.py makemigrations --check` *(fails: No module named 'django')*
- `pytest -q` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68aed7ce373c832a80d7140a5dbec4a1