### PR TITLE
Enhance knowledge card rendering and blurb generation

### DIFF
--- a/coresite/models.py
+++ b/coresite/models.py
@@ -166,8 +166,8 @@ class KnowledgeArticle(TimestampedModel):
             qs = self.__class__.objects.exclude(pk=self.pk)
             self.slug = _generate_unique_slug(self.title, qs)
         if not self.blurb and self.content:
-            snippet = self.content.strip()
-            self.blurb = snippet[:160]
+            snippet = self.content.strip().split("\n\n", 1)[0]
+            self.blurb = snippet
         if self.content:
             words = len(self.content.split())
             self.reading_time = max(1, math.ceil(words / 200)) if words else None

--- a/coresite/static/coresite/scss/pages/_knowledge.scss
+++ b/coresite/static/coresite/scss/pages/_knowledge.scss
@@ -174,6 +174,23 @@
   border-radius: r(sm);
 }
 
+.knowledge-card__title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.knowledge-card__blurb {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+
+  @include mq(md) {
+    -webkit-line-clamp: 3;
+  }
+}
+
 .knowledge-card__meta {
   font-size: fs(sm);
   color: c(text-muted);

--- a/coresite/templates/coresite/knowledge/_card.html
+++ b/coresite/templates/coresite/knowledge/_card.html
@@ -6,16 +6,16 @@
    data-analytics-url="{% url 'knowledge_article' article.category.slug article.slug %}">
   <div class="knowledge-card__motif motif-grid" aria-hidden="true"></div>
   <div class="knowledge-card__inner">
-    {% if article.image %}
+    {% if article.image and article.image_alt %}
       <img class="knowledge-card__image"
            src="{{ article.image|thumbnail_url:'hero_mobile' }}"
-           alt="{{ article.image.alt|default_if_none:article.title }}"
+           alt="{{ article.image_alt }}"
            loading="lazy" decoding="async">
     {% else %}
       <div class="knowledge-card__image knowledge-card__image--placeholder" aria-hidden="true"></div>
     {% endif %}
     <h3 class="knowledge-card__title">{{ article.title }}</h3>
     <p class="knowledge-card__blurb">{{ article.blurb }}</p>
-    <p class="knowledge-card__meta">{{ article.created_at|date:"F j, Y" }} &mdash; {{ article.category.title }}</p>
+    <p class="knowledge-card__meta">{{ article.published_at|date:"F j, Y" }} &mdash; {{ article.category.title }}</p>
   </div>
 </a>

--- a/coresite/tests/test_knowledge_card.py
+++ b/coresite/tests/test_knowledge_card.py
@@ -1,0 +1,41 @@
+import pytest
+from django.template.loader import render_to_string
+from django.utils import timezone
+from django.utils.formats import date_format
+
+from coresite.models import KnowledgeCategory, KnowledgeArticle, StatusChoices
+
+
+@pytest.mark.django_db
+def test_card_meta_and_placeholder_rendering():
+    category = KnowledgeCategory.objects.create(
+        title="General", slug="general", status=StatusChoices.PUBLISHED
+    )
+    article = KnowledgeArticle.objects.create(
+        category=category,
+        title="Sample",
+        slug="sample",
+        status=StatusChoices.PUBLISHED,
+        published_at=timezone.now(),
+        content="First paragraph."
+    )
+    html = render_to_string("coresite/knowledge/_card.html", {"article": article})
+    assert "knowledge-card__image--placeholder" in html
+    assert category.title in html
+    assert date_format(article.published_at, "F j, Y") in html
+
+
+@pytest.mark.django_db
+def test_blurb_auto_generation_from_first_paragraph():
+    category = KnowledgeCategory.objects.create(
+        title="General", slug="general", status=StatusChoices.PUBLISHED
+    )
+    content = "First paragraph.\n\nSecond paragraph."
+    article = KnowledgeArticle.objects.create(
+        category=category,
+        title="Auto",
+        slug="auto",
+        status=StatusChoices.DRAFT,
+        content=content,
+    )
+    assert article.blurb == "First paragraph."


### PR DESCRIPTION
## Summary
- Clamp knowledge card title and blurb with responsive line limits and show published date and category
- Require alt text for card images and fall back to placeholder when missing
- Auto-generate article blurb from the first paragraph when absent

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_68af06cdc7f8832a9d92ed95106ef895