### PR TITLE
Use tokens for knowledge styles and require image alt text

### DIFF
--- a/coresite/static/coresite/scss/pages/_knowledge.scss
+++ b/coresite/static/coresite/scss/pages/_knowledge.scss
@@ -77,9 +77,12 @@
   li { flex: 0 0 auto; }
 
   a {
+    display: inline-block;
     color: c(text);
     text-decoration: none;
     letter-spacing: 0.02em; // design sign-off
+    padding: s(3) s(4);
+    @include focus-ring(c(blue));
 
     &:hover,
     &:focus {
@@ -122,6 +125,8 @@
   color: inherit;
   border-radius: r(sm);
   overflow: hidden;
+  min-height: s(7);
+  @include focus-ring(c(blue));
 }
 
 .knowledge-card--featured {
@@ -239,6 +244,6 @@
 /* Footer separator */
 
 main + footer {
-  border-top: 1px solid c(border);
+  border-top: bw(sm) solid c(border);
 }
 

--- a/coresite/templates/coresite/partials/hero.html
+++ b/coresite/templates/coresite/partials/hero.html
@@ -3,7 +3,7 @@
   <div class="hero__bg" aria-hidden="true">
     {% if site_images.hero1 and site_images.hero1.video and site_images.hero1.image %}
       <img src="{{ site_images.hero1.image.url }}"
-           alt="{{ site_images.hero1.alt_text|default:'' }}"
+           alt="{{ site_images.hero1.alt_text|default:'Technofatty hero' }}"
            class="hero__image hero__placeholder"
            fetchpriority="high"
            loading="eager"
@@ -26,7 +26,7 @@
         Your browser does not support the video tag.
       </video>
     {% elif site_images.hero1 and site_images.hero1.image %}
-      <img src="{{ site_images.hero1.image.url }}" alt="{{ site_images.hero1.alt_text|default:'' }}" class="hero__image" decoding="async" fetchpriority="high" width="{{ site_images.hero1.image.width }}" height="{{ site_images.hero1.image.height }}">
+      <img src="{{ site_images.hero1.image.url }}" alt="{{ site_images.hero1.alt_text|default:'Technofatty hero' }}" class="hero__image" decoding="async" fetchpriority="high" width="{{ site_images.hero1.image.width }}" height="{{ site_images.hero1.image.height }}">
     {% endif %}
   </div>
 

--- a/coresite/tests/test_alt_text.py
+++ b/coresite/tests/test_alt_text.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import re
+
+IMG_TAG = re.compile(r"<img[^>]*>", re.IGNORECASE)
+ALT_ATTR = re.compile(r'''alt=(?:"[^"]+"|'[^']+')''')
+
+
+def test_all_imgs_have_alt_text():
+    templates_dir = Path(__file__).resolve().parents[1] / "templates"
+    for path in templates_dir.rglob("*.html"):
+        html = path.read_text()
+        for tag in IMG_TAG.findall(html):
+            assert ALT_ATTR.search(tag), f"Missing alt text in {path}: {tag}"
+
+


### PR DESCRIPTION
## Summary
- increase filter link hit area and add focus ring
- add focus ring and minimum height for knowledge cards
- enforce alt text on hero images and check templates for missing alt attributes

## Testing
- `pytest coresite/tests/test_alt_text.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `npx lighthouse https://technofatty.com --config-path=scripts/lighthouse.config.js --quiet` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lighthouse)*

------
https://chatgpt.com/codex/tasks/task_e_68af28512388832a9468f8576c202ad2