### PR TITLE
Add internal strategy documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,16 @@ Required variables:
 - `TF_EMAIL_BACKEND`
 
 See `.env.example` for placeholder values.
+
+## Deployment
+
+See `docs/deployment.md` for details on production deployment with Apache + mod_wsgi.
+
+## Internal Strategy Docs
+
+For collaborators:  
+We maintain internal notes on site philosophy, content strategy, and revenue pathways.  
+See [`docs/strategy.md`](docs/strategy.md) for the latest thinking.  
+
+## License
+MIT

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -1,0 +1,63 @@
+# Technofatty Internal Strategy Notes
+
+⚠️ **Collaborator-only aide-memoire. Not intended for public-facing audiences.**
+
+---
+
+## Vision
+Technofatty is not “just” a tech blog. It is a **business intelligence hub** that brings together:
+- **Knowledge**: curated, authoritative articles on core concepts.
+- **Tools**: practical AI-powered business utilities (apps, extensions, calculators, diagnostics).
+- **Blog**: timely insights, opinion, and signals about what matters now.
+
+The connective tissue across these areas creates a **neural net of interlinked value**, ensuring no user session is a dead end.
+
+---
+
+## Mandate for Interconnection
+1. **Every Knowledge Article** should point to:
+   - Relevant Tools (when they exist).  
+   - Blog commentary / real-world applications.  
+   - Calls-to-action where commercial offers fit naturally.  
+
+2. **Every Tool** should:
+   - Offer immediate utility (save time, money, or uncertainty).  
+   - Link to Knowledge resources explaining the “why” behind it.  
+   - Encourage deeper engagement (newsletter, trials, premium tiers).  
+
+3. **The Blog** should:
+   - Surface new problems that our Tools and Knowledge solve.  
+   - Act as the heartbeat — news, signals, trends — always with a tie-back to what we offer.  
+
+---
+
+## Revenue Pathways
+- **Freemium tools**: free baseline, with paid premium features.  
+- **Leads & conversions**: tools and knowledge articles double as lead generators.  
+- **Membership / subscriptions**: curated bundles of knowledge + premium tools.  
+- **Partnerships / affiliates**: where third-party integrations solve business pain points.  
+
+---
+
+## Page-Level Guidance
+- **Knowledge index**: educational gateway. Must feel like “library + map” with direct links into tools.  
+- **Tools index**: utility-first, but segmented by business problems (finance, HR, growth, compliance).  
+- **Blog index**: dynamic, timely, reinforcing relevance of Knowledge + Tools.  
+
+---
+
+## Operational Principles
+- **SEO is not the sole lens**: business utility, credibility, and trust lead.  
+- **Heavyweight up-front**: provide substance, not fluff. Users must feel the site *saves them time*.  
+- **Interconnection first**: no section exists in isolation. Each is a portal to the others.  
+
+---
+
+## Next Steps for Implementation
+- Bake these principles into **templates** (e.g. Knowledge article template must render “related tools”).  
+- Extend the **CMS/admin** so authors are nudged to cross-link.  
+- Build analytics to measure *cross-pollination* between Knowledge, Tools, and Blog.  
+
+---
+
+✦ **Remember:** This is our compass. Not public messaging. The goal is consistency across all collaborators, so our “neural net” site strategy compounds over time.


### PR DESCRIPTION
## Summary
- document Technofatty site strategy for collaborators
- link README to strategy notes and mention deployment docs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68af33d16d50832aafe2c5666ad71825