### PR TITLE
docs: add internal README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# Technofatty Internal Docs
+
+⚠️ **Collaborator-only. This folder is not for public consumption.**
+
+This is our **lab notebook + compass** for how Technofatty evolves.
+
+---
+
+## Core Mandates
+- [`strategy.md`](strategy.md) → our overarching site strategy and neural-net model.  
+- [`knowledge.md`](knowledge.md) → documentation of the Knowledge segment (articles, taxonomy, SEO/structured data).  
+- [`tools.md`](tools.md) → playbook for ideating, logging, and prioritising business tools.  
+- [`blog.md`](blog.md) → framing and guidance for blog entries (positioning, tie-ins, tone).  
+
+---
+
+## How to Use
+- Treat these docs as **aide-memoires** for collaborators.  
+- Capture *everything* — ideas, patterns, experiments, even half-baked gems.  
+- Don’t worry about polish: this is our **gold dust sieve**.  
+- Cross-link aggressively between sections: the power is in the neural net.  
+
+---
+
+✦ Remember: none of this is public messaging. These docs are for us to keep continuity, so we never lose what we surfaced in conversation.
+


### PR DESCRIPTION
## Summary
- add collaborator-only README for internal documentation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68af374035a0832aac8243897d543c27