### PR TITLE
Add tools indexability flag with robots controls

### DIFF
--- a/coresite/tests/test_tools_indexing.py
+++ b/coresite/tests/test_tools_indexing.py
@@ -1,0 +1,30 @@
+import re
+import pytest
+from django.urls import reverse
+from django.test import override_settings
+
+
+def test_tools_view_not_indexable(client):
+    res = client.get(reverse("tools"))
+    assert res["X-Robots-Tag"] == "noindex,nofollow"
+    assert re.search(
+        r'<meta\s+name="robots"\s+content="noindex,nofollow"\s*/?>',
+        res.content.decode(),
+        re.I,
+    )
+
+
+@override_settings(TOOLS_INDEXABLE=True)
+def test_tools_view_indexable(client):
+    res = client.get(reverse("tools"))
+    assert res["X-Robots-Tag"] == "index,follow"
+    assert re.search(
+        r'<meta\s+name="robots"\s+content="index,follow"\s*/?>',
+        res.content.decode(),
+        re.I,
+    )
+
+
+def test_tools_has_canonical(client):
+    res = client.get(reverse("tools"))
+    assert '<link rel="canonical"' in res.content.decode()

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -422,16 +422,21 @@ def resources(request):
 
 def tools(request):
     footer = get_footer_content()
-    return render(
+    robots = "index,follow" if settings.TOOLS_INDEXABLE else "noindex,nofollow"
+    context = {
+        "footer": footer,
+        "page_id": "tools",
+        "page_title": "Tools",
+        "canonical_url": "/tools/",
+        "meta_robots": robots,
+    }
+    response = render(
         request,
         "coresite/tools.html",
-        {
-            "footer": footer,
-            "page_id": "tools",
-            "page_title": "Tools",
-            "canonical_url": "/tools/",
-        },
+        context,
     )
+    response["X-Robots-Tag"] = robots
+    return response
 
 
 def community(request):

--- a/technofatty_com/settings.py
+++ b/technofatty_com/settings.py
@@ -66,6 +66,10 @@ ALLOWED_HOSTS = os.environ.get(
 SITE_CANONICAL_HOST = os.environ.get("SITE_CANONICAL_HOST", "technofatty.com")
 SITE_BASE_URL = os.environ.get("SITE_BASE_URL", f"https://{SITE_CANONICAL_HOST}")
 
+# Whether tools pages should be indexable by search engines.
+# Only the lowercase string "true" enables indexing.
+TOOLS_INDEXABLE = os.environ.get("TOOLS_INDEXABLE", "false").lower() == "true"
+
 # -------------------------------------------------
 # Applications
 # -------------------------------------------------


### PR DESCRIPTION
## Summary
- add `TOOLS_INDEXABLE` setting with default `False`
- conditionally set robots meta tag and header in tools view
- add tests for tools indexing flag with resilient markup checks

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68af5c3086e4832aa587417c10fcea76