### PR TITLE
feat: enhance tools page layout with CTA and navigation strips

### DIFF
--- a/coresite/static/coresite/scss/abstracts/_variables.scss
+++ b/coresite/static/coresite/scss/abstracts/_variables.scss
@@ -22,6 +22,8 @@ $colors: (
   bg-accent-light: #F5FBFF  // light accent backgrounds
 );
 
+$color-focus: map-get($colors, blue);
+
 /* Layout width */
 $container-max: 68rem; // ≈1088px target content width
 $container-max-width-wide: 90rem; // ≈1440px wide container
@@ -58,6 +60,7 @@ $dimensions: (
 /* Spacing scale (t-shirt friendly) */
 $space: (
   0: 0,
+  0.5: .125rem,
   1: .25rem,   // 4px
   2: .5rem,    // 8px
   3: .75rem,   // 12px

--- a/coresite/static/coresite/scss/main.scss
+++ b/coresite/static/coresite/scss/main.scss
@@ -38,6 +38,7 @@
 @import "sections/community";
 @import "sections/newsletter";
 @import "sections/footer";
+@import "sections/tools";
 
   // Pages
   @import "pages/infra";

--- a/coresite/static/coresite/scss/sections/_tools.scss
+++ b/coresite/static/coresite/scss/sections/_tools.scss
@@ -1,0 +1,21 @@
+.tools__subscribe .btn,
+.tools__grid .btn {
+  min-width: s(7);
+  min-height: s(7);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tools__link {
+  display: block;
+  min-height: s(7);
+  padding: s(2) 0;
+}
+
+.tools__link:focus-visible,
+.tools__link:focus {
+  outline: s(0.5) solid var(--focus-outline, $color-focus);
+  outline-offset: s(0.5);
+  text-decoration: underline;
+}

--- a/coresite/templates/coresite/tools.html
+++ b/coresite/templates/coresite/tools.html
@@ -3,14 +3,56 @@
 {% block structured_data %}{{ block.super }}{% endblock %}
 
 {% block content %}
-  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+  <section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
+      <p class="page-intro">{{ page_intro }}</p>
       <div class="scaffold__body">
-          {% include "coresite/partials/global/status_placeholder.html" %}
-        <!-- Empty placeholder container. Content to be built in later passes. -->
+        {% include "coresite/partials/global/status_placeholder.html" %}
+        <p class="tools__subscribe">
+          <a
+            href="#signup"
+            class="btn btn--cta"
+            data-analytics-event="cta.tools.signup"
+            data-analytics-label="Get AI Growth Tips"
+            data-analytics-url="#signup"
+          >Get AI Growth Tips</a>
+        </p>
+        <div class="tools__grid">
+          {% for tool in tools %}
+            <article class="tool-card">
+              <h2 class="tool-card__title">{{ tool.title }}</h2>
+              <p class="tool-card__desc">{{ tool.description }}</p>
+              <p><a
+                class="btn btn--secondary"
+                href="{{ tool.url }}"
+                data-analytics-event="cta.tools.open"
+                data-analytics-label="{{ tool.title }}"
+                data-analytics-url="{{ tool.url }}"
+                aria-label="Open {{ tool.title }}"
+              >Open tool</a></p>
+            </article>
+          {% endfor %}
+        </div>
+        <section class="tools__learn" aria-labelledby="tools-learn-heading">
+          <h2 id="tools-learn-heading">Learn</h2>
+          <ul class="tools__links">
+            {% for item in knowledge_items %}
+              <li><a href="{{ item.url }}" class="tools__link">{{ item.title }}</a></li>
+            {% endfor %}
+          </ul>
+        </section>
+        <section class="tools__blog" aria-labelledby="tools-blog-heading">
+          <h2 id="tools-blog-heading">From the Blog</h2>
+          <ul class="tools__links">
+            {% for post in blog_posts %}
+              <li><a href="{{ post.url }}" class="tools__link">{{ post.title }}</a></li>
+            {% endfor %}
+          </ul>
+        </section>
       </div>
     </div>
   </section>
+  {% include "coresite/partials/newsletter_signup.html" %}
 {% endblock %}
 

--- a/coresite/tests/test_tools_page.py
+++ b/coresite/tests/test_tools_page.py
@@ -1,0 +1,33 @@
+import re
+import pytest
+from django.urls import reverse
+
+
+def test_tools_page_has_content(client):
+    res = client.get(reverse("tools"))
+    html = res.content.decode()
+    assert "Get AI Growth Tips" in html
+    assert 'aria-label="Open ROI Calculator"' in html
+    assert 'aria-label="Open Content Ideator"' in html
+    assert "Learn" in html
+    assert "From the Blog" in html
+
+
+def test_tools_page_section_has_no_region_role(client):
+    res = client.get(reverse("tools"))
+    html = res.content.decode()
+    scaffold = re.search(r'<section class="section section--scaffold"[^>]*>', html)
+    assert scaffold is not None
+    assert "role=" not in scaffold.group(0)
+
+
+def test_tool_button_has_analytics(client):
+    res = client.get(reverse("tools"))
+    html = res.content.decode()
+    assert 'data-analytics-event="cta.tools.open"' in html
+
+
+def test_focus_style_exists_in_css():
+    sass = pytest.importorskip("sass")
+    css = sass.compile(filename="coresite/static/coresite/scss/main.scss")
+    assert ".tools__link:focus-visible" in css

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -423,12 +423,48 @@ def resources(request):
 def tools(request):
     footer = get_footer_content()
     robots = "index,follow" if settings.TOOLS_INDEXABLE else "noindex,nofollow"
+    tools_list = [
+        {
+            "title": "ROI Calculator",
+            "description": "Estimate returns from your AI marketing spend.",
+            "url": "/tools/roi-calculator/",
+        },
+        {
+            "title": "Content Ideator",
+            "description": "Generate growth ideas powered by machine intelligence.",
+            "url": "/tools/content-ideator/",
+        },
+    ]
+    learn_items = [
+        {
+            "title": "What is AI marketing?",
+            "url": "/knowledge/ai-marketing/",
+        },
+        {
+            "title": "How to measure AI ROI",
+            "url": "/knowledge/ai-roi/",
+        },
+    ]
+    blog_items = [
+        {
+            "title": "Launching our ROI tool",
+            "url": "/blog/roi-tool/",
+        },
+        {
+            "title": "3 AI tips for Q4",
+            "url": "/blog/ai-tips-q4/",
+        },
+    ]
     context = {
         "footer": footer,
         "page_id": "tools",
         "page_title": "Tools",
+        "page_intro": "Short utilities to explore AI for growth.",
         "canonical_url": "/tools/",
         "meta_robots": robots,
+        "tools": tools_list,
+        "knowledge_items": learn_items,
+        "blog_posts": blog_items,
     }
     response = render(
         request,


### PR DESCRIPTION
## Summary
- align tools subscribe CTA with standard button styling and analytics tracking
- add analytics and unique labels to tool buttons
- move hit-target styles to SCSS partial and import
- add focus outlines, intro text, and no longer mark internal links as nofollow
- shorten tool buttons to "Open tool" with aria-label for context
- note: tool, knowledge, and blog lists are stubbed placeholders

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68af62e72bec832a9e15598e73803065