### PR TITLE
feat: add tools page styles

### DIFF
--- a/coresite/static/coresite/scss/main.scss
+++ b/coresite/static/coresite/scss/main.scss
@@ -50,3 +50,4 @@
   @import "pages/legal";
   @import "pages/auth";
   @import "pages/knowledge";
+  @import "pages/tools";

--- a/coresite/static/coresite/scss/pages/_tools.scss
+++ b/coresite/static/coresite/scss/pages/_tools.scss
@@ -1,0 +1,40 @@
+/* =============================
+   Tools page styles
+   ============================= */
+
+.tools__grid {
+  display: grid;
+  gap: s(5);
+
+  @include mq(md) {
+    grid-template-columns: repeat(auto-fit, minmax(dim(grid-min), 1fr));
+  }
+}
+
+.tool-card {
+  padding: s(4);
+  background: c(mid);
+  border-radius: r(md);
+  box-shadow: sh(sm);
+}
+
+.tools__links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: s(2);
+}
+
+.tools__link {
+  display: inline-block;
+  padding: s(1) s(2);
+  border-radius: r(sm);
+  color: c(text);
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+  }
+}


### PR DESCRIPTION
## Summary
- add token-based styles for Tools page
- wire Tools page stylesheet into main SCSS bundle

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `npx sass coresite/static/coresite/scss/main.scss` *(fails: 403 Forbidden to fetch sass)*

------
https://chatgpt.com/codex/tasks/task_e_68b0170a3004832a9041953cede52f47