### PR TITLE
Add consent-aware analytics hooks for newsletter and tools

### DIFF
--- a/coresite/templates/coresite/partials/global/analytics.html
+++ b/coresite/templates/coresite/partials/global/analytics.html
@@ -13,8 +13,10 @@
 {% if ANALYTICS_PROVIDER == 'plausible' or ANALYTICS_PROVIDER == 'ga4' %}
   <script>
     (function(){
-      var p=document.body.dataset.analyticsProvider;
-      function send(n,m){m=m||{};if(p==='plausible'&&window.plausible){window.plausible(n,{props:m});}
+      var body=document.body;
+      var p=body.dataset.analyticsProvider;
+      function hasConsent(){return body.dataset.consentRequired!=='true'||body.dataset.consentGranted==='true';}
+      function send(n,m){if(!hasConsent())return;m=m||{};if(p==='plausible'&&window.plausible){window.plausible(n,{props:m});}
         else if(p==='ga4'&&window.gtag){window.gtag('event',n,m);}}
       var fired={};
       function meta(el){try{return JSON.parse(el.dataset.analyticsMeta||'{}')}catch(e){return {};}}

--- a/coresite/templates/coresite/partials/newsletter_block.html
+++ b/coresite/templates/coresite/partials/newsletter_block.html
@@ -25,7 +25,11 @@
                      aria-describedby="newsletter-privacy newsletter-status"
                      data-analytics-event="form.newsletter.start">
               <input type="text" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" hidden>
-              <button type="submit" aria-label="Subscribe to the newsletter" class="btn btn--cta radius-md">{{ APPROVED_CTA|default:'Subscribe' }}</button>
+              <button type="submit"
+                      aria-label="Subscribe to the newsletter"
+                      class="btn btn--cta radius-md"
+                      data-analytics-event="cta.newsletter.subscribe"
+                      data-analytics-meta='{"form":"newsletter"}'>{{ APPROVED_CTA|default:'Subscribe' }}</button>
               <div id="newsletter-status" role="status" aria-live="polite" aria-atomic="true" class="form-message is-{{ m.tags }}">{{ m }}</div>
             </fieldset>
           </form>
@@ -44,7 +48,11 @@
                  aria-describedby="newsletter-privacy newsletter-status"
                  data-analytics-event="form.newsletter.start">
           <input type="text" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" hidden>
-          <button type="submit" aria-label="Subscribe to the newsletter" class="btn btn--cta radius-md">{{ APPROVED_CTA|default:'Subscribe' }}</button>
+          <button type="submit"
+                  aria-label="Subscribe to the newsletter"
+                  class="btn btn--cta radius-md"
+                  data-analytics-event="cta.newsletter.subscribe"
+                  data-analytics-meta='{"form":"newsletter"}'>{{ APPROVED_CTA|default:'Subscribe' }}</button>
           <div id="newsletter-status" role="status" aria-live="polite" aria-atomic="true" class="form-message"></div>
         </fieldset>
       </form>

--- a/coresite/templates/coresite/tools.html
+++ b/coresite/templates/coresite/tools.html
@@ -36,6 +36,7 @@
             href="#signup"
             class="btn btn--cta"
             data-analytics-event="cta.tools.signup"
+            data-analytics-meta='{"cta":"tools-signup"}'
             data-analytics-label="Get AI Growth Tips"
             data-analytics-url="#signup"
           >Get AI Growth Tips</a>
@@ -49,6 +50,7 @@
                 class="btn btn--secondary"
                 href="{{ tool.url }}"
                 data-analytics-event="cta.tools.open"
+                data-analytics-meta='{"tool":"{{ tool.slug }}"}'
                 data-analytics-label="{{ tool.title }}"
                 data-analytics-url="{{ tool.url }}"
                 aria-label="Open {{ tool.title }}"

--- a/coresite/tests/test_newsletter_block.py
+++ b/coresite/tests/test_newsletter_block.py
@@ -1,0 +1,9 @@
+from django.urls import reverse
+
+
+def test_newsletter_button_has_analytics(client):
+    res = client.get(reverse("home"))
+    html = res.content.decode()
+    assert 'data-analytics-event="cta.newsletter.subscribe"' in html
+    assert 'data-analytics-meta="{\"form\":\"newsletter\"}"' in html
+

--- a/coresite/tests/test_tools_page.py
+++ b/coresite/tests/test_tools_page.py
@@ -25,6 +25,7 @@ def test_tool_button_has_analytics(client):
     res = client.get(reverse("tools"))
     html = res.content.decode()
     assert 'data-analytics-event="cta.tools.open"' in html
+    assert 'data-analytics-meta="{\"tool\":\"roi-calculator\"}"' in html
 
 
 def test_focus_style_exists_in_css():

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -428,11 +428,13 @@ def tools(request):
             "title": "ROI Calculator",
             "description": "Estimate returns from your AI marketing spend.",
             "url": "/tools/roi-calculator/",
+            "slug": "roi-calculator",
         },
         {
             "title": "Content Ideator",
             "description": "Generate growth ideas powered by machine intelligence.",
             "url": "/tools/content-ideator/",
+            "slug": "content-ideator",
         },
     ]
     learn_items = [

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -32,5 +32,16 @@ Blog CTA:
 ## Implementation note
 Emit events with a thin wrapper that no-ops if network is unavailable. Batch where possible. Respect consent flags from `coresite.context_processors.analytics_flags`.
 
+## Current events
+
+These events support upcoming filtering and pagination features:
+
+- All events honor user consent; the global analytics script prevents sends until required consent is granted.
+- `cta.newsletter.subscribe` – click on the newsletter subscribe button. Meta `{ "form": "newsletter" }`
+- `form.newsletter.start` – email field focused.
+- `form.newsletter.submit` – newsletter form submitted. Meta `{ "form": "newsletter" }`
+- `cta.tools.signup` – click on the Tools page signup CTA.
+- `cta.tools.open` – open a tool from the Tools page. Meta `{ "tool": "<slug>" }`
+
 ## KPIs and how to compute
 Time-to-first-value: difference between `tool_run` and `tool_result_render`. Completion rate: `tool_result_render / tool_run` per tool. Assisted conversions: number of sessions that include a `tool_*` event and end with `form_submit` or `booking_start` within 7 days.


### PR DESCRIPTION
## Summary
- Gate global analytics events behind consent flags
- Add analytics metadata to newsletter and tools CTAs
- Document new analytics events for filtering and pagination

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68af70133c90832ab0fbf0024823388f