### PR TITLE
Remove redundant region roles

### DIFF
--- a/coresite/templates/404.html
+++ b/coresite/templates/404.html
@@ -7,7 +7,7 @@
 {% block title %}Page not found{% endblock %}
 
 {% block content %}
-  <section class="section section--scaffold" role="region" aria-labelledby="error-404-heading">
+  <section class="section section--scaffold" aria-labelledby="error-404-heading">
     <div class="wrap">
       <h1 id="error-404-heading">Page not found</h1>
       {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/500.html
+++ b/coresite/templates/500.html
@@ -7,7 +7,7 @@
 {% block title %}Server error{% endblock %}
 
 {% block content %}
-  <section class="section section--scaffold" role="region" aria-labelledby="error-500-heading">
+  <section class="section section--scaffold" aria-labelledby="error-500-heading">
     <div class="wrap">
       <h1 id="error-500-heading">Server error</h1>
       {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/coresite/about.html
+++ b/coresite/templates/coresite/about.html
@@ -32,43 +32,43 @@
 {% endblock %}
 
 {% block content %}
-<section id="about-hero" class="section section--scaffold" role="region" aria-labelledby="about-hero-heading">
+<section id="about-hero" class="section section--scaffold" aria-labelledby="about-hero-heading">
   <div class="wrap">
     {% include "coresite/partials/about/about-hero.html" %}
   </div>
 </section>
 
-<section id="about-story" class="section" role="region" aria-labelledby="about-story-heading">
+<section id="about-story" class="section" aria-labelledby="about-story-heading">
   <div class="wrap">
     {% include "coresite/partials/about/about-story.html" %}
   </div>
 </section>
 
-<section id="about-principles" class="section" role="region" aria-labelledby="about-principles-heading">
+<section id="about-principles" class="section" aria-labelledby="about-principles-heading">
   <div class="wrap">
     {% include "coresite/partials/about/about-principles.html" %}
   </div>
 </section>
 
-<section id="about-team" class="section" role="region" aria-labelledby="about-team-heading">
+<section id="about-team" class="section" aria-labelledby="about-team-heading">
   <div class="wrap">
     {% include "coresite/partials/about/about-team.html" %}
   </div>
 </section>
 
-<section id="about-milestones" class="section" role="region" aria-labelledby="about-milestones-heading">
+<section id="about-milestones" class="section" aria-labelledby="about-milestones-heading">
   <div class="wrap">
     {% include "coresite/partials/about/about-milestones.html" %}
   </div>
 </section>
 
-<section id="about-trust" class="section" role="region" aria-labelledby="about-trust-heading">
+<section id="about-trust" class="section" aria-labelledby="about-trust-heading">
   <div class="wrap">
     {% include "coresite/partials/about/about-trust.html" %}
   </div>
 </section>
 
-<section id="about-cta" class="section" role="region" aria-labelledby="about-cta-heading">
+<section id="about-cta" class="section" aria-labelledby="about-cta-heading">
   <div class="wrap">
     {% include "coresite/partials/about/about-cta.html" %}
   </div>

--- a/coresite/templates/coresite/account/account_home.html
+++ b/coresite/templates/coresite/account/account_home.html
@@ -1,7 +1,7 @@
 {% extends "coresite/base.html" %}
 
 {% block content %}
-<section class="section" role="region" aria-labelledby="account-home-heading">
+<section class="section" aria-labelledby="account-home-heading">
   <div class="wrap">
     <h1 id="account-home-heading">Account</h1>
     <p>Welcome to your account dashboard.</p>

--- a/coresite/templates/coresite/blog.html
+++ b/coresite/templates/coresite/blog.html
@@ -56,7 +56,7 @@
 {% endblock %}
 
 {% block content %}
-  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+  <section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <div class="scaffold__header">
         <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
@@ -92,7 +92,7 @@
                 {% endfor %}
               </div>
             </div>
-            <aside class="topics" role="region" aria-labelledby="topics-heading">
+            <aside class="topics" aria-labelledby="topics-heading">
               <h2 id="topics-heading">Topics</h2>
               <ul class="topics__list">
                 {% for category in categories %}

--- a/coresite/templates/coresite/blog_category.html
+++ b/coresite/templates/coresite/blog_category.html
@@ -7,7 +7,7 @@
 {% endblock %}
 {% block structured_data %}{{ block.super }}{% endblock %}
 {% block content %}
-  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+  <section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
       <div class="scaffold__body">

--- a/coresite/templates/coresite/blog_detail.html
+++ b/coresite/templates/coresite/blog_detail.html
@@ -57,7 +57,7 @@
 {% endblock %}
 
 {% block content %}
-  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+  <section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
         <div class="scaffold__body">
           {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/coresite/blog_rss.html
+++ b/coresite/templates/coresite/blog_rss.html
@@ -2,7 +2,7 @@
 
 {% block structured_data %}{{ block.super }}{% endblock %}
 {% block content %}
-  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+  <section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
       <div class="scaffold__body">

--- a/coresite/templates/coresite/blog_tag.html
+++ b/coresite/templates/coresite/blog_tag.html
@@ -7,7 +7,7 @@
 {% endblock %}
 {% block structured_data %}{{ block.super }}{% endblock %}
 {% block content %}
-  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+  <section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
       <div class="scaffold__body">

--- a/coresite/templates/coresite/case_studies/landing.html
+++ b/coresite/templates/coresite/case_studies/landing.html
@@ -34,7 +34,7 @@
 {% endblock %}
 
 {% block content %}
-  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+  <section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
       <div class="scaffold__body">

--- a/coresite/templates/coresite/community.html
+++ b/coresite/templates/coresite/community.html
@@ -3,7 +3,7 @@
 {% block structured_data %}{{ block.super }}{% endblock %}
 
 {% block content %}
-  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+  <section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
       <div class="scaffold__body">

--- a/coresite/templates/coresite/contact.html
+++ b/coresite/templates/coresite/contact.html
@@ -32,13 +32,13 @@
 {% endblock %}
 
 {% block content %}
-<section id="contact-intro" class="section section--scaffold" role="region" aria-labelledby="contact-intro-heading">
+<section id="contact-intro" class="section section--scaffold" aria-labelledby="contact-intro-heading">
   <div class="wrap">
     {% include "coresite/partials/contact/contact-intro.html" %}
   </div>
 </section>
 
-<section id="contact-form" class="section" role="region" aria-labelledby="contact-form-heading">
+<section id="contact-form" class="section" aria-labelledby="contact-form-heading">
   <div class="wrap">
     {% if sent %}
     <div class="form-success" role="status" aria-live="polite">
@@ -49,25 +49,25 @@
   </div>
 </section>
 
-<section id="contact-info" class="section" role="region" aria-labelledby="contact-info-heading">
+<section id="contact-info" class="section" aria-labelledby="contact-info-heading">
   <div class="wrap">
     {% include "coresite/partials/contact/contact-info.html" %}
   </div>
 </section>
 
-<section id="contact-social" class="section" role="region" aria-labelledby="contact-social-heading">
+<section id="contact-social" class="section" aria-labelledby="contact-social-heading">
   <div class="wrap">
     {% include "coresite/partials/contact/contact-social.html" %}
   </div>
 </section>
 
-<section id="contact-trust" class="section" role="region" aria-labelledby="contact-trust-heading">
+<section id="contact-trust" class="section" aria-labelledby="contact-trust-heading">
   <div class="wrap">
     {% include "coresite/partials/contact/contact-trust.html" %}
   </div>
 </section>
 
-<section id="contact-cta" class="section" role="region" aria-labelledby="contact-cta-heading">
+<section id="contact-cta" class="section" aria-labelledby="contact-cta-heading">
   <div class="wrap">
     {% include "coresite/partials/contact/contact-cta.html" %}
   </div>

--- a/coresite/templates/coresite/join.html
+++ b/coresite/templates/coresite/join.html
@@ -3,7 +3,7 @@
 {% block structured_data %}{{ block.super }}{% endblock %}
 
 {% block content %}
-  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+  <section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
       <div class="scaffold__body">

--- a/coresite/templates/coresite/knowledge/_hero.html
+++ b/coresite/templates/coresite/knowledge/_hero.html
@@ -1,4 +1,4 @@
-<section class="hero kn-hero" role="region" aria-label="Knowledge base hero">
+<section class="hero kn-hero" aria-label="Knowledge base hero">
   <div class="hero__content container">
     <h1>Welcome to the Knowledge Hub</h1>
     <p class="hero__sub">Dive into guides, glossary terms, and signals tailored for you.</p>

--- a/coresite/templates/coresite/knowledge/_related_articles.html
+++ b/coresite/templates/coresite/knowledge/_related_articles.html
@@ -1,5 +1,5 @@
 {% if related_articles %}
-<section class="related-articles" role="region" aria-labelledby="related-articles-heading">
+<section class="related-articles" aria-labelledby="related-articles-heading">
   <div class="wrap">
     <h2 id="related-articles-heading">Related Articles</h2>
     <div class="knowledge-grid">

--- a/coresite/templates/coresite/knowledge/_share_buttons.html
+++ b/coresite/templates/coresite/knowledge/_share_buttons.html
@@ -1,6 +1,6 @@
 {% load seo_tags %}
 {% canonical_url canonical_url as resolved_canonical %}
-<div class="share-buttons" role="region" aria-label="Share">
+<div class="share-buttons">
   <a href="https://twitter.com/intent/tweet?url={{ resolved_canonical|urlencode }}&text={{ article.title|urlencode }}"
      target="_blank" rel="noopener"
      data-analytics-event="share.twitter"

--- a/coresite/templates/coresite/knowledge/article.html
+++ b/coresite/templates/coresite/knowledge/article.html
@@ -59,7 +59,7 @@
 {% endblock %}
 
 {% block content %}
-<section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+<section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
   <div class="wrap">
     <h1 id="{{ page_id }}-heading">{{ article.title }}</h1>
     {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/coresite/knowledge/category.html
+++ b/coresite/templates/coresite/knowledge/category.html
@@ -8,7 +8,7 @@
 {% block structured_data %}{{ block.super }}{% endblock %}
 
 {% block content %}
-<section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+<section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
   <div class="wrap">
     <h1 id="{{ page_id }}-heading">{{ category.title }}</h1>
     {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/coresite/knowledge/hub.html
+++ b/coresite/templates/coresite/knowledge/hub.html
@@ -32,7 +32,7 @@
 {% endblock %}
 
 {% block content %}
-<section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+<section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
   <div class="wrap">
     <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
     {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/coresite/legal.html
+++ b/coresite/templates/coresite/legal.html
@@ -32,49 +32,49 @@
 {% endblock %}
 
 {% block content %}
-<section id="legal-intro" class="section section--scaffold" role="region" aria-labelledby="legal-intro-heading">
+<section id="legal-intro" class="section section--scaffold" aria-labelledby="legal-intro-heading">
   <div class="wrap">
     {% include "coresite/partials/legal/legal-intro.html" %}
   </div>
 </section>
 
-<section id="legal-terms" class="section" role="region" aria-labelledby="legal-terms-heading">
+<section id="legal-terms" class="section" aria-labelledby="legal-terms-heading">
   <div class="wrap">
     {% include "coresite/partials/legal/legal-terms.html" %}
   </div>
 </section>
 
-<section id="legal-privacy" class="section" role="region" aria-labelledby="legal-privacy-heading">
+<section id="legal-privacy" class="section" aria-labelledby="legal-privacy-heading">
   <div class="wrap">
     {% include "coresite/partials/legal/legal-privacy.html" %}
   </div>
 </section>
 
-<section id="legal-cookies" class="section" role="region" aria-labelledby="legal-cookies-heading">
+<section id="legal-cookies" class="section" aria-labelledby="legal-cookies-heading">
   <div class="wrap">
     {% include "coresite/partials/legal/legal-cookies.html" %}
   </div>
 </section>
 
-<section id="legal-accessibility" class="section" role="region" aria-labelledby="legal-accessibility-heading">
+<section id="legal-accessibility" class="section" aria-labelledby="legal-accessibility-heading">
   <div class="wrap">
     {% include "coresite/partials/legal/legal-accessibility.html" %}
   </div>
 </section>
 
-<section id="legal-licensing" class="section" role="region" aria-labelledby="legal-licensing-heading">
+<section id="legal-licensing" class="section" aria-labelledby="legal-licensing-heading">
   <div class="wrap">
     {% include "coresite/partials/legal/legal-licensing.html" %}
   </div>
 </section>
 
-<section id="legal-compliance" class="section" role="region" aria-labelledby="legal-compliance-heading">
+<section id="legal-compliance" class="section" aria-labelledby="legal-compliance-heading">
   <div class="wrap">
     {% include "coresite/partials/legal/legal-compliance.html" %}
   </div>
 </section>
 
-<section id="legal-contact" class="section" role="region" aria-labelledby="legal-contact-heading">
+<section id="legal-contact" class="section" aria-labelledby="legal-contact-heading">
   <div class="wrap">
     {% include "coresite/partials/legal/legal-contact.html" %}
   </div>

--- a/coresite/templates/coresite/partials/community_block.html
+++ b/coresite/templates/coresite/partials/community_block.html
@@ -1,5 +1,5 @@
 {# See docs/structured-data.md#community_block for context keys #}
-<section class="section section--community" role="region" aria-labelledby="community-heading" data-section="community">
+<section class="section section--community" aria-labelledby="community-heading" data-section="community">
   <div class="wrap">
     {% with level=community.heading_level|default:'h2' %}
       <{{ level }} id="community-heading" class="section-title">{{ community.headline }}</{{ level }}>

--- a/coresite/templates/coresite/partials/consent_banner.html
+++ b/coresite/templates/coresite/partials/consent_banner.html
@@ -1,5 +1,5 @@
 {# See docs/structured-data.md#consent_banner for context keys #}
-<div id="consent-banner" class="consent-banner" role="region" aria-label="Cookie consent" hidden data-consent-banner>
+<div id="consent-banner" class="consent-banner" hidden data-consent-banner>
   <p>We use cookies for analytics. You can accept or decline.</p>
   <div class="consent-banner__actions">
     <a href="{% url 'consent_accept' %}" data-consent-choice="accept" class="button">Accept</a>

--- a/coresite/templates/coresite/partials/hero.html
+++ b/coresite/templates/coresite/partials/hero.html
@@ -1,5 +1,5 @@
 {# See docs/structured-data.md#hero for context keys #}
-<section class="hero" role="region" aria-label="{{ site_images.hero1.alt_text|default:'Technofatty hero' }}">
+<section class="hero" aria-label="{{ site_images.hero1.alt_text|default:'Technofatty hero' }}">
   <div class="hero__bg" aria-hidden="true">
     {% if site_images.hero1 and site_images.hero1.video and site_images.hero1.image %}
       <img src="{{ site_images.hero1.image.url }}"

--- a/coresite/templates/coresite/partials/newsletter_block.html
+++ b/coresite/templates/coresite/partials/newsletter_block.html
@@ -2,7 +2,6 @@
 <!-- TODO: Stakeholder decision: headline_scope (music) -->
 <section id="signup"
          class="newsletter-band"
-         role="region"
          aria-labelledby="newsletter-heading"
          data-section="newsletter"
          data-analytics-section="newsletter">

--- a/coresite/templates/coresite/partials/signals_block.html
+++ b/coresite/templates/coresite/partials/signals_block.html
@@ -1,5 +1,5 @@
 {# See docs/structured-data.md#signals_block for context keys #}
-<section class="section section--signals" role="region" aria-labelledby="signals-heading" data-section="signals">
+<section class="section section--signals" aria-labelledby="signals-heading" data-section="signals">
   <div class="container-wide">
     {% with level=signals.heading_level|default:'h2' %}
       <{{ level }} id="signals-heading" class="section-title">{{ signals.headline }}</{{ level }}>

--- a/coresite/templates/coresite/partials/support_block.html
+++ b/coresite/templates/coresite/partials/support_block.html
@@ -1,5 +1,5 @@
 {# See docs/structured-data.md#support_block for context keys #}
-<section class="section section--support" role="region" aria-labelledby="support-heading" data-section="support">
+<section class="section section--support" aria-labelledby="support-heading" data-section="support">
   <div class="wrap">
     {% with level=support.heading_level|default:'h2' %}
       <{{ level }} id="support-heading" class="section-title">{{ support.headline }}</{{ level }}>

--- a/coresite/templates/coresite/resources.html
+++ b/coresite/templates/coresite/resources.html
@@ -2,7 +2,7 @@
 
 {% block structured_data %}{{ block.super }}{% endblock %}
 {% block content %}
-  <section class="section section--scaffold" role="region" aria-labelledby="{{ page_id }}-heading">
+  <section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
       <div class="scaffold__body">

--- a/coresite/templates/coresite/support.html
+++ b/coresite/templates/coresite/support.html
@@ -32,55 +32,55 @@
 {% endblock %}
 
 {% block content %}
-<section id="support-intro" class="section section--scaffold" role="region" aria-labelledby="support-intro-heading">
+<section id="support-intro" class="section section--scaffold" aria-labelledby="support-intro-heading">
   <div class="wrap">
     {% include "coresite/partials/support/support-intro.html" %}
   </div>
 </section>
 
-<section id="support-faqs" class="section" role="region" aria-labelledby="support-faqs-heading">
+<section id="support-faqs" class="section" aria-labelledby="support-faqs-heading">
   <div class="wrap">
     {% include "coresite/partials/support/support-faqs.html" %}
   </div>
 </section>
 
-<section id="support-guides" class="section" role="region" aria-labelledby="support-guides-heading">
+<section id="support-guides" class="section" aria-labelledby="support-guides-heading">
   <div class="wrap">
     {% include "coresite/partials/support/support-guides.html" %}
   </div>
 </section>
 
-<section id="support-troubleshooting" class="section" role="region" aria-labelledby="support-troubleshooting-heading">
+<section id="support-troubleshooting" class="section" aria-labelledby="support-troubleshooting-heading">
   <div class="wrap">
     {% include "coresite/partials/support/support-troubleshooting.html" %}
   </div>
 </section>
 
-<section id="support-account-billing" class="section" role="region" aria-labelledby="support-account-billing-heading">
+<section id="support-account-billing" class="section" aria-labelledby="support-account-billing-heading">
   <div class="wrap">
     {% include "coresite/partials/support/support-account-billing.html" %}
   </div>
 </section>
 
-<section id="support-privacy-security" class="section" role="region" aria-labelledby="support-privacy-security-heading">
+<section id="support-privacy-security" class="section" aria-labelledby="support-privacy-security-heading">
   <div class="wrap">
     {% include "coresite/partials/support/support-privacy-security.html" %}
   </div>
 </section>
 
-<section id="support-accessibility" class="section" role="region" aria-labelledby="support-accessibility-heading">
+<section id="support-accessibility" class="section" aria-labelledby="support-accessibility-heading">
   <div class="wrap">
     {% include "coresite/partials/support/support-accessibility.html" %}
   </div>
 </section>
 
-<section id="support-status" class="section" role="region" aria-labelledby="support-status-heading">
+<section id="support-status" class="section" aria-labelledby="support-status-heading">
   <div class="wrap">
     {% include "coresite/partials/support/support-status.html" %}
   </div>
 </section>
 
-<section id="support-contact" class="section" role="region" aria-labelledby="support-contact-heading">
+<section id="support-contact" class="section" aria-labelledby="support-contact-heading">
   <div class="wrap">
     {% include "coresite/partials/support/support-contact.html" %}
   </div>

--- a/coresite/tests/test_landmarks.py
+++ b/coresite/tests/test_landmarks.py
@@ -1,0 +1,31 @@
+import re
+import pytest
+from django.urls import reverse, NoReverseMatch
+
+PAGES = ["home", "about", "contact", "blog", "support", "resources", "tools"]
+
+@pytest.mark.parametrize("urlname", PAGES)
+def test_no_role_region_on_core_pages(client, urlname):
+    try:
+        url = reverse(urlname)
+    except NoReverseMatch:
+        pytest.skip(f"{urlname} not routed")
+    res = client.get(url)
+    html = res.content.decode()
+    assert 'role="region"' not in html
+
+def test_404_has_no_region_role(client, settings):
+    settings.DEBUG = False  # force default 404 template
+    res = client.get("/definitely-not-here-xyz/")
+    html = res.content.decode()
+    assert 'role="region"' not in html
+
+def test_500_has_no_region_role(client, settings):
+    # This simulates rendering the 500 template directly if you have a route; otherwise skip.
+    try:
+        url = reverse("five_hundred_test")  # if you don't have one, skip
+    except NoReverseMatch:
+        pytest.skip("No explicit 500 route to exercise")
+    res = client.get(url)
+    html = res.content.decode()
+    assert 'role="region"' not in html

--- a/docs/global_partials_readme.md
+++ b/docs/global_partials_readme.md
@@ -13,13 +13,13 @@ Pages use only one `<h1>`. When a design calls for a visually hidden title, the 
 Content blocks are wrapped in:
 
 ```html
-<section id="section-id" class="section" role="region" aria-labelledby="section-id-heading">
+<section id="section-id" class="section" aria-labelledby="section-id-heading">
   <div class="wrap">
     ...
   </div>
 </section>
 ```
-The `id` matches the heading’s `-heading` suffix. Example usage appears throughout `about.html`【F:coresite/templates/coresite/about.html†L20-L24】.
+The `id` matches the heading’s `-heading` suffix. Example usage appears throughout `about.html`【F:coresite/templates/coresite/about.html†L35-L39】.
 
 ### Design tokens
 All styling values come from `_variables.scss`, the single source of truth for SCSS/CSS tokens【F:coresite/static/coresite/scss/abstracts/_variables.scss†L1-L8】.


### PR DESCRIPTION
## Summary
- Remove redundant `aria-label` from consent banner to avoid unnamed landmark noise
- Add tests ensuring key pages and error templates contain no stray `role="region"`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest coresite/tests/test_landmarks.py` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b07d3dbc84832ab2c985e61b711c95