### PR TITLE
Expose telemetry send helper

### DIFF
--- a/coresite/templates/coresite/partials/global/analytics.html
+++ b/coresite/templates/coresite/partials/global/analytics.html
@@ -18,6 +18,7 @@
       function hasConsent(){return body.dataset.consentRequired!=='true'||body.dataset.consentGranted==='true';}
       function send(n,m){if(!hasConsent())return;m=m||{};if(p==='plausible'&&window.plausible){window.plausible(n,{props:m});}
         else if(p==='ga4'&&window.gtag){window.gtag('event',n,m);}}
+      if (hasConsent()) { window.tfSend = send; }
       var fired={};
       function meta(el){try{return JSON.parse(el.dataset.analyticsMeta||'{}')}catch(e){return {};}}
       document.addEventListener('click',function(e){var el=e.target;

--- a/coresite/templates/coresite/tool_detail.html
+++ b/coresite/templates/coresite/tool_detail.html
@@ -1,0 +1,20 @@
+{% extends "coresite/base.html" %}
+
+{% block content %}
+  <section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
+    <div class="wrap">
+      <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
+    </div>
+  </section>
+{% endblock %}
+
+{% block body_scripts %}
+  {{ block.super }}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      if (window.tfSend) {
+        window.tfSend('tool_detail.view', { tool: '{{ tool_slug|default:"" }}' });
+      }
+    });
+  </script>
+{% endblock %}

--- a/coresite/templates/coresite/tools.html
+++ b/coresite/templates/coresite/tools.html
@@ -80,3 +80,14 @@
   {% include "coresite/partials/newsletter_signup.html" %}
 {% endblock %}
 
+{% block body_scripts %}
+  {{ block.super }}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      if (window.tfSend) {
+        window.tfSend('tools_list.view', { count: {{ tools|length|default:0 }} });
+      }
+    });
+  </script>
+{% endblock %}
+

--- a/coresite/tests/test_tf_send_consent.py
+++ b/coresite/tests/test_tf_send_consent.py
@@ -1,0 +1,73 @@
+import json
+import shutil
+import subprocess
+import textwrap
+
+import pytest
+
+
+def _run_plausible(consent_granted):
+    script = textwrap.dedent(
+        f"""
+        var window={{}};
+        var document={{body:{{dataset:{{analyticsProvider:'plausible',consentRequired:'true',consentGranted:'{str(consent_granted).lower()}'}}}}}};
+        (function(){{
+          var body=document.body;
+          var p=body.dataset.analyticsProvider;
+          function hasConsent(){{return body.dataset.consentRequired!=='true'||body.dataset.consentGranted==='true';}}
+          function send(n,m){{if(!hasConsent())return;m=m||{{}};if(p==='plausible'&&window.plausible){{window.plausible(n,{{props:m}});}}
+            else if(p==='ga4'&&window.gtag){{window.gtag('event',n,m);}}}}
+          if (hasConsent()) {{ window.tfSend = send; }}
+        }})();
+        var calls=[];
+        window.plausible=function(n,o){{calls.push([n,o]);}};
+        if(window.tfSend) window.tfSend('evt',{{foo:'bar'}});
+        console.log(JSON.stringify(calls));
+        """
+    )
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    return json.loads(result.stdout.strip())
+
+
+def _run_ga4(consent_granted):
+    script = textwrap.dedent(
+        f"""
+        var window={{}};
+        var document={{body:{{dataset:{{analyticsProvider:'ga4',consentRequired:'true',consentGranted:'{str(consent_granted).lower()}'}}}}}};
+        (function(){{
+          var body=document.body;
+          var p=body.dataset.analyticsProvider;
+          function hasConsent(){{return body.dataset.consentRequired!=='true'||body.dataset.consentGranted==='true';}}
+          function send(n,m){{if(!hasConsent())return;m=m||{{}};if(p==='plausible'&&window.plausible){{window.plausible(n,{{props:m}});}}
+            else if(p==='ga4'&&window.gtag){{window.gtag('event',n,m);}}}}
+          if (hasConsent()) {{ window.tfSend = send; }}
+        }})();
+        var calls=[];
+        window.gtag=function(kind,name,meta){{calls.push([kind,name,meta]);}};
+        if(window.tfSend) window.tfSend('evt',{{foo:'bar'}});
+        console.log(JSON.stringify(calls));
+        """
+    )
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    return json.loads(result.stdout.strip())
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_tf_send_plausible_respects_consent():
+    assert _run_plausible(False) == []
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_tf_send_plausible_sends_with_consent():
+    assert _run_plausible(True) == [['evt', {'props': {'foo': 'bar'}}]]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_tf_send_ga4_respects_consent():
+    assert _run_ga4(False) == []
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_tf_send_ga4_sends_with_consent():
+    assert _run_ga4(True) == [['event', 'evt', {'foo': 'bar'}]]
+

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -32,6 +32,33 @@ Blog CTA:
 ## Implementation note
 Emit events with a thin wrapper that no-ops if network is unavailable. Batch where possible. Respect consent flags from `coresite.context_processors.analytics_flags`.
 
+## Using tfSend
+Pages can dispatch analytics events through the global `tfSend(name, meta)` function exposed by the
+`analytics.html` partial. The helper is defined only when an analytics provider is configured and
+required consent is granted, so guard calls with `if (window.tfSend)`.
+
+```html
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    if (window.tfSend) {
+      window.tfSend('tools_list.view', { count: 3 });
+    }
+  });
+</script>
+```
+
+Use `tool_detail.view` with the tool identifier on individual tool pages:
+
+```html
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    if (window.tfSend) {
+      window.tfSend('tool_detail.view', { tool: 'pricing-calibrator' });
+    }
+  });
+</script>
+```
+
 ## Current events
 
 These events support upcoming filtering and pagination features:


### PR DESCRIPTION
## Summary
- expose telemetry send function globally as `tfSend`, only when consent is granted
- fire page view events on tools list and tool detail
- document `tfSend` API and add consent gating tests

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pytest coresite/tests/test_tf_send_consent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b09f6265d4832aabfb08b0b75ab1df