### PR TITLE
Add Tool model with slug creation and admin UI

### DIFF
--- a/coresite/admin.py
+++ b/coresite/admin.py
@@ -10,6 +10,7 @@ from .models import (
     KnowledgeArticle,
     KnowledgeTag,
     BlogPost,
+    Tool,
     ContactEvent,
     StatusChoices,
 )
@@ -140,6 +141,31 @@ class BlogPostAdmin(admin.ModelAdmin):
     list_filter = ("status",)
     prepopulated_fields = {"slug": ("title",)}
     date_hierarchy = "published_at"
+
+
+@admin.register(Tool)
+class ToolAdmin(admin.ModelAdmin):
+    def thumb(self, obj):
+        return (
+            format_html('<img src="{}" style="height:32px;">', obj.image.url)
+            if obj.image
+            else ""
+        )
+
+    thumb.short_description = "Image"
+
+    list_display = (
+        "title",
+        "thumb",
+        "schema_kind",
+        "is_published",
+        "is_premium",
+        "display_order",
+    )
+    list_editable = ("display_order", "is_published", "is_premium")
+    list_filter = ("is_published", "is_premium", "schema_kind")
+    search_fields = ("title", "slug")
+    prepopulated_fields = {"slug": ("title",)}
 
 
 @admin.register(ContactEvent)

--- a/coresite/migrations/0010_tool.py
+++ b/coresite/migrations/0010_tool.py
@@ -40,8 +40,11 @@ class Migration(migrations.Migration):
             options={
                 "ordering": ("display_order", "title"),
                 "indexes": [
-                    models.Index(fields=("is_published", "display_order")),
-                    models.Index(fields=("schema_kind",)),
+                    models.Index(
+                        fields=["is_published", "display_order"],
+                        name="tool_pub_order_idx",
+                    ),
+                    models.Index(fields=["schema_kind"], name="tool_schema_idx"),
                 ],
             },
         ),

--- a/coresite/migrations/0010_tool.py
+++ b/coresite/migrations/0010_tool.py
@@ -1,0 +1,49 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("coresite", "0009_publish_semantics_and_indexes"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Tool",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("title", models.CharField(max_length=200)),
+                ("slug", models.SlugField(blank=True, unique=True)),
+                ("description", models.TextField(blank=True)),
+                (
+                    "image",
+                    models.ImageField(
+                        blank=True, null=True, upload_to="tools/"
+                    ),
+                ),
+                ("external_url", models.URLField(blank=True)),
+                ("schema_kind", models.CharField(blank=True, max_length=100)),
+                ("is_published", models.BooleanField(default=False)),
+                ("is_premium", models.BooleanField(default=False)),
+                ("display_order", models.PositiveIntegerField(default=0)),
+            ],
+            options={
+                "ordering": ("display_order", "title"),
+                "indexes": [
+                    models.Index(fields=("is_published", "display_order")),
+                    models.Index(fields=("schema_kind",)),
+                ],
+            },
+        ),
+    ]
+

--- a/coresite/tests/test_tool_model.py
+++ b/coresite/tests/test_tool_model.py
@@ -1,0 +1,35 @@
+import pytest
+from django.urls import path
+from django.http import HttpResponse
+from django.test import override_settings
+
+from coresite.models import Tool
+
+
+def dummy_tool_detail(request, slug):
+    return HttpResponse("ok")
+
+
+urlpatterns = [path("tools/<slug:slug>/", dummy_tool_detail, name="tool_detail")]
+
+
+@pytest.mark.django_db
+def test_tool_slug_autogenerates_and_uniquifies():
+    t1 = Tool.objects.create(title="My Tool")
+    t2 = Tool.objects.create(title="My Tool")
+    assert t1.slug == "my-tool"
+    assert t2.slug == "my-tool-1"
+
+
+@override_settings(ROOT_URLCONF=__name__)
+@pytest.mark.django_db
+def test_tool_get_absolute_url_uses_slug():
+    tool = Tool.objects.create(title="Example Tool")
+    assert tool.get_absolute_url() == f"/tools/{tool.slug}/"
+
+
+@pytest.mark.django_db
+def test_tool_published_manager_filters_correctly():
+    published = Tool.objects.create(title="Published", is_published=True)
+    Tool.objects.create(title="Draft", is_published=False)
+    assert list(Tool.objects.published()) == [published]


### PR DESCRIPTION
## Summary
- add `Tool` model with slug generation and absolute URL helper
- register `Tool` in admin with thumbnail preview and inline editing
- create migration for new `Tool` model with ordering and indexes
- add queryset helper and tests for slug, URL, and published filter

## Testing
- `python manage.py makemigrations coresite` *(fails: ModuleNotFoundError: No module named 'django')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b0a8c75474832aa413f3455bc1588e