### PR TITLE
Pin Tool index names to match migrations

### DIFF
--- a/coresite/models.py
+++ b/coresite/models.py
@@ -254,8 +254,14 @@ class Tool(TimestampedModel):
     class Meta:
         ordering = ("display_order", "title")
         indexes = [
-            models.Index(fields=("is_published", "display_order")),
-            models.Index(fields=("schema_kind",)),
+            models.Index(
+                fields=["is_published", "display_order"],
+                name="tool_pub_order_idx",
+            ),
+            models.Index(
+                fields=["schema_kind"],
+                name="tool_schema_idx",
+            ),
         ]
 
 


### PR DESCRIPTION
## Summary
- name `Tool` model indexes so Django does not attempt to rename them each run

## Testing
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68b0c6234fd8832ab29efb698f024ffa