### PR TITLE
Handle tool schema kinds in JSON-LD

### DIFF
--- a/coresite/templates/coresite/tool_detail.html
+++ b/coresite/templates/coresite/tool_detail.html
@@ -1,4 +1,21 @@
 {% extends "coresite/base.html" %}
+{% load jsonld %}
+
+{% block structured_data %}{{ block.super }}
+  {% if tool %}
+  {% jsonld %}
+  {
+    "@context": "https://schema.org",
+    "@type": "{% if tool.schema_kind == 'software' %}SoftwareApplication{% else %}CreativeWork{% endif %}",
+    "name": "{{ tool.title|escapejs }}",
+    "description": "{{ tool.description|escapejs }}",
+    "url": "{{ tool.url|escapejs }}"{% if tool.image %},
+    "image": "{{ tool.image|escapejs }}"{% endif %}{% if tool.schema_kind == 'software' %},
+    "operatingSystem": "Web"{% endif %}
+  }
+  {% endjsonld %}
+  {% endif %}
+{% endblock %}
 
 {% block content %}
   <section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">

--- a/coresite/templates/coresite/tools.html
+++ b/coresite/templates/coresite/tools.html
@@ -10,12 +10,12 @@
       "@graph": [
         {% for tool in tools %}
         {
-          "@type": "SoftwareApplication",
+          "@type": "{% if tool.schema_kind == 'software' %}SoftwareApplication{% else %}CreativeWork{% endif %}",
           "name": "{{ tool.title|escapejs }}",
           "description": "{{ tool.description|escapejs }}",
-          "url": "{{ tool.url|escapejs }}",
-          {% if tool.image %}"image": "{{ tool.image|escapejs }}",{% endif %}
-          "operatingSystem": "Web"
+          "url": "{{ tool.url|escapejs }}"{% if tool.image %},
+          "image": "{{ tool.image|escapejs }}"{% endif %}{% if tool.schema_kind == 'software' %},
+          "operatingSystem": "Web"{% endif %}
         }{% if not forloop.last %},{% endif %}
         {% endfor %}
       ]

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -1,6 +1,9 @@
 import json
 import pathlib
+import re
 import sys
+
+import pytest
 from django.utils.safestring import SafeString
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
@@ -19,3 +22,90 @@ def test_render_jsonld_minified_and_deterministic():
     # ensure minified: no unnecessary whitespace
     inner = out1.split('>', 1)[1].rsplit('<', 1)[0]
     assert '\n' not in inner and ' ' not in inner
+
+
+def _render(template_str: str, context: dict) -> str:
+    django = pytest.importorskip("django")
+    from django.conf import settings
+    from django.template import Context, Template
+
+    if not settings.configured:
+        settings.configure(
+            TEMPLATES=[{"BACKEND": "django.template.backends.django.DjangoTemplates"}]
+        )
+        django.setup()
+
+    template = Template(template_str)
+    return template.render(Context(context))
+
+
+def _extract_json(html: str) -> dict:
+    match = re.search(r'<script type="application/ld\+json">(.*?)</script>', html, re.DOTALL)
+    assert match, "No JSON-LD script found"
+    return json.loads(match.group(1))
+
+
+TOOLS_TEMPLATE = """
+{% load jsonld %}
+{% jsonld %}
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {% for tool in tools %}
+    {
+      "@type": "{% if tool.schema_kind == 'software' %}SoftwareApplication{% else %}CreativeWork{% endif %}",
+      "name": "{{ tool.title|escapejs }}",
+      "description": "{{ tool.description|escapejs }}",
+      "url": "{{ tool.url|escapejs }}"{% if tool.image %},
+      "image": "{{ tool.image|escapejs }}"{% endif %}{% if tool.schema_kind == 'software' %},
+      "operatingSystem": "Web"{% endif %}
+    }{% if not forloop.last %},{% endif %}
+    {% endfor %}
+  ]
+}
+{% endjsonld %}
+"""
+
+
+def test_tools_jsonld_handles_schema_kinds():
+    tools = [
+        {"title": "App", "description": "A", "url": "/app/", "schema_kind": "software"},
+        {"title": "Guide", "description": "G", "url": "/guide/", "schema_kind": "guide"},
+    ]
+    html = _render(TOOLS_TEMPLATE, {"tools": tools})
+    data = _extract_json(html)
+    app, guide = data["@graph"]
+    assert app["@type"] == "SoftwareApplication"
+    assert app["operatingSystem"] == "Web"
+    assert guide["@type"] == "CreativeWork"
+    assert "operatingSystem" not in guide
+
+
+TOOL_DETAIL_TEMPLATE = """
+{% load jsonld %}
+{% jsonld %}
+{
+  "@context": "https://schema.org",
+  "@type": "{% if tool.schema_kind == 'software' %}SoftwareApplication{% else %}CreativeWork{% endif %}",
+  "name": "{{ tool.title|escapejs }}",
+  "description": "{{ tool.description|escapejs }}",
+  "url": "{{ tool.url|escapejs }}"{% if tool.image %},
+  "image": "{{ tool.image|escapejs }}"{% endif %}{% if tool.schema_kind == 'software' %},
+  "operatingSystem": "Web"{% endif %}
+}
+{% endjsonld %}
+"""
+
+
+def test_tool_detail_jsonld_handles_schema_kinds():
+    tool = {"title": "App", "description": "A", "url": "/app/", "schema_kind": "software"}
+    html = _render(TOOL_DETAIL_TEMPLATE, {"tool": tool})
+    data = _extract_json(html)
+    assert data["@type"] == "SoftwareApplication"
+    assert data["operatingSystem"] == "Web"
+
+    tool = {"title": "Guide", "description": "G", "url": "/guide/", "schema_kind": "guide"}
+    html = _render(TOOL_DETAIL_TEMPLATE, {"tool": tool})
+    data = _extract_json(html)
+    assert data["@type"] == "CreativeWork"
+    assert "operatingSystem" not in data


### PR DESCRIPTION
## Summary
- Render SoftwareApplication JSON-LD with operatingSystem only for software tools
- Fallback to CreativeWork for non-software tools in listings and detail
- Test JSON-LD output for both software and non-software schema kinds

## Testing
- ❌ `pytest -q` *(missing Django dependency)*
- ❌ `pip install -r requirements.txt` *(403 proxy error)*

------
https://chatgpt.com/codex/tasks/task_e_68b0cb323780832a9b85a508649abe5d