### PR TITLE
Add robots handling to tool detail view

### DIFF
--- a/coresite/tests/test_tools_indexing.py
+++ b/coresite/tests/test_tools_indexing.py
@@ -2,6 +2,7 @@ import re
 import pytest
 from django.urls import reverse
 from django.test import override_settings
+from coresite.models import Tool
 
 
 def test_tools_view_not_indexable(client):
@@ -28,3 +29,28 @@ def test_tools_view_indexable(client):
 def test_tools_has_canonical(client):
     res = client.get(reverse("tools"))
     assert '<link rel="canonical"' in res.content.decode()
+
+
+@pytest.mark.django_db
+def test_tool_detail_view_not_indexable(client):
+    tool = Tool.objects.create(title="Tool", is_published=True)
+    res = client.get(reverse("tool_detail", kwargs={"slug": tool.slug}))
+    assert res["X-Robots-Tag"] == "noindex,nofollow"
+    assert re.search(
+        r'<meta\s+name="robots"\s+content="noindex,nofollow"\s*/?>',
+        res.content.decode(),
+        re.I,
+    )
+
+
+@override_settings(TOOLS_INDEXABLE=True)
+@pytest.mark.django_db
+def test_tool_detail_view_indexable(client):
+    tool = Tool.objects.create(title="Tool", is_published=True)
+    res = client.get(reverse("tool_detail", kwargs={"slug": tool.slug}))
+    assert res["X-Robots-Tag"] == "index,follow"
+    assert re.search(
+        r'<meta\s+name="robots"\s+content="index,follow"\s*/?>',
+        res.content.decode(),
+        re.I,
+    )

--- a/coresite/urls.py
+++ b/coresite/urls.py
@@ -44,6 +44,7 @@ urlpatterns = [
     ),
     path("resources/", views.resources, name="resources"),
     path("tools/", views.tools, name="tools"),
+    path("tools/<slug:slug>/", views.tool_detail, name="tool_detail"),
     path("community/", views.community, name="community"),
     path("blog/", views.blog, name="blog"),
     path("blog/rss/", BlogRSSFeed(), name="blog_rss"),

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -8,7 +8,7 @@ from django.db.models import Q
 from newsletter.utils import log_newsletter_event
 from django.core.cache import cache
 from coresite.services.contact import contact_event
-from .models import SiteImage, BlogPost, KnowledgeCategory, KnowledgeArticle
+from .models import SiteImage, BlogPost, KnowledgeCategory, KnowledgeArticle, Tool
 from .forms import ContactForm
 from .notifiers import ContactNotifier
 from datetime import datetime
@@ -473,6 +473,24 @@ def tools(request):
         "coresite/tools.html",
         context,
     )
+    response["X-Robots-Tag"] = robots
+    return response
+
+
+def tool_detail(request, slug: str):
+    footer = get_footer_content()
+    tool = get_object_or_404(Tool.objects.published(), slug=slug)
+    robots = "index,follow" if settings.TOOLS_INDEXABLE else "noindex,nofollow"
+    context = {
+        "footer": footer,
+        "page_id": "tool-detail",
+        "page_title": tool.title,
+        "tool": tool,
+        "tool_slug": tool.slug,
+        "canonical_url": f"/tools/{tool.slug}/",
+        "meta_robots": robots,
+    }
+    response = render(request, "coresite/tool_detail.html", context)
     response["X-Robots-Tag"] = robots
     return response
 


### PR DESCRIPTION
## Summary
- compute robots directives in tool_detail view and expose via meta tag and X-Robots-Tag header
- add URL route for tool detail pages
- test indexing behavior for tool detail view

## Testing
- `python -m pytest coresite/tests/test_tools_indexing.py -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies asgiref==3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ccc82380832aaecb8a5dc24e0f80