### PR TITLE
Add CaseStudy model and migration

### DIFF
--- a/coresite/migrations/0011_casestudy.py
+++ b/coresite/migrations/0011_casestudy.py
@@ -1,0 +1,49 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("coresite", "0010_tool"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="CaseStudy",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("title", models.CharField(max_length=200)),
+                ("slug", models.SlugField(blank=True, unique=True)),
+                ("summary", models.TextField(blank=True)),
+                ("body", models.TextField(blank=True)),
+                (
+                    "image",
+                    models.ImageField(
+                        blank=True, null=True, upload_to="case_studies/"
+                    ),
+                ),
+                ("display_order", models.PositiveIntegerField(default=0)),
+                ("is_published", models.BooleanField(default=False)),
+            ],
+            options={
+                "ordering": ("display_order", "title"),
+                "indexes": [
+                    models.Index(
+                        fields=["is_published", "display_order"],
+                        name="casestudy_pub_order_idx",
+                    )
+                ],
+            },
+        ),
+    ]
+

--- a/coresite/models.py
+++ b/coresite/models.py
@@ -265,6 +265,35 @@ class Tool(TimestampedModel):
         ]
 
 
+class CaseStudy(TimestampedModel):
+    title = models.CharField(max_length=200)
+    slug = models.SlugField(unique=True, blank=True)
+    summary = models.TextField(blank=True)
+    body = models.TextField(blank=True)
+    image = models.ImageField(upload_to="case_studies/", blank=True, null=True)
+    display_order = models.PositiveIntegerField(default=0)
+    is_published = models.BooleanField(default=False)
+
+    def __str__(self):
+        return self.title
+
+    def save(self, *args, **kwargs):
+        if not self.slug and self.title:
+            self.slug = _generate_unique_slug(
+                self.title, CaseStudy.objects.exclude(pk=self.pk)
+            )
+        super().save(*args, **kwargs)
+
+    class Meta:
+        ordering = ("display_order", "title")
+        indexes = [
+            models.Index(
+                fields=["is_published", "display_order"],
+                name="casestudy_pub_order_idx",
+            ),
+        ]
+
+
 def _generate_unique_slug(title: str, queryset):
     """Return a slug unique within the given queryset."""
     base = slugify(title) or "tool"


### PR DESCRIPTION
## Summary
- define `CaseStudy` model with title, slug, summary, body, image, display_order, and publication flag
- add explicit composite index on `(is_published, display_order)`
- include schema migration for `CaseStudy`

## Testing
- `python manage.py makemigrations coresite` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68b1430f9878832aa81d8f62e9004663