### PR TITLE
Fix case studies nav link

### DIFF
--- a/coresite/context_processors.py
+++ b/coresite/context_processors.py
@@ -20,7 +20,7 @@ def _build_nav_links():
         },
         {
             "label": "Case Studies",
-            "url": "case_studies_landing",
+            "url": "case_studies",
             "locations": ["header", "footer"],
             "order": 3,
         },

--- a/coresite/tests.py
+++ b/coresite/tests.py
@@ -71,7 +71,7 @@ class UrlResolutionTests(SimpleTestCase):
             "home",
             "knowledge",
             "tools",
-            "case_studies_landing",
+            "case_studies",
             "community",
             "blog",
         ]


### PR DESCRIPTION
## Summary
- Correct main navigation case studies link to point to the `/case-studies/` route
- Update URL resolution tests accordingly

## Testing
- `pytest` *(fails: ERROR during collection for multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b1504cd998832ab87cfbd4cc966ebc