### PR TITLE
Expose case studies in featured grid with analytics tracking

### DIFF
--- a/coresite/templates/coresite/partials/featured_grid.html
+++ b/coresite/templates/coresite/partials/featured_grid.html
@@ -13,13 +13,39 @@
           <p class="card__blurb">{{ resource.blurb }}</p>
           <a class="card__link"
              href="{{ resource.url }}"
-             data-analytics-event="featured_card_click"
+             data-analytics-event="{{ resource.event|default:'featured_card_click' }}"
              data-analytics-section="featured"
              data-analytics-label="{{ resource.title }}"
              data-analytics-url="{{ resource.url }}">Read more</a>
         </article>
       {% endfor %}
+      {% if case_studies %}
+      {% for cs in case_studies %}
+        <article class="card">
+          <div class="card__img" aria-hidden="true"></div>
+          <h3 class="card__title">{{ cs.title }}</h3>
+          <p class="card__blurb">{{ cs.summary }}</p>
+          <a class="card__link"
+             href="{{ cs.get_absolute_url }}"
+             aria-label="Read case study: {{ cs.title }}"
+             data-analytics-event="case_study_card_click"
+             data-analytics-section="featured"
+             data-analytics-label="{{ cs.title }}"
+             data-analytics-url="{{ cs.get_absolute_url }}">Read more</a>
+        </article>
+      {% endfor %}
+      {% endif %}
     </div>
+    {% if case_studies %}
+    <p class="featured__cta">
+      <a class="btn btn--secondary"
+         href="{% url 'case_studies' %}"
+         data-analytics-event="cta.case_studies.open"
+         data-analytics-section="featured"
+         data-analytics-label="All case studies"
+         data-analytics-url="{% url 'case_studies' %}">View all case studies</a>
+    </p>
+    {% endif %}
   </div>
 
 </section>

--- a/coresite/tests/test_case_studies_pages.py
+++ b/coresite/tests/test_case_studies_pages.py
@@ -1,4 +1,5 @@
 import pytest
+from django.conf import settings
 from django.urls import reverse
 from coresite.models import CaseStudy
 
@@ -8,16 +9,23 @@ def test_case_studies_page(client):
     CaseStudy.objects.create(title="Alpha", is_published=True)
     res = client.get(reverse("case_studies"))
     html = res.content.decode()
-    assert res["X-Robots-Tag"] == "noindex,nofollow"
+    expected = (
+        "index,follow" if settings.CASE_STUDIES_INDEXABLE else "noindex,nofollow"
+    )
+    assert res["X-Robots-Tag"] == expected
     assert '<h1 id="case-studies-heading">Case Studies</h1>' in html
     assert '"@type": "BreadcrumbList"' in html
+    assert 'data-analytics-event="case_study_card_click"' in html
 
 
 @pytest.mark.django_db
 def test_case_study_detail_page(client):
     study = CaseStudy.objects.create(title="Alpha", summary="Summary", is_published=True)
-    res = client.get(reverse("case_study_detail", kwargs={"slug": study.slug}))
+    res = client.get(study.get_absolute_url())
     html = res.content.decode()
-    assert res["X-Robots-Tag"] == "noindex,nofollow"
+    expected = (
+        "index,follow" if settings.CASE_STUDIES_INDEXABLE else "noindex,nofollow"
+    )
+    assert res["X-Robots-Tag"] == expected
     assert f'<h1 id="case-study-detail-heading">{study.title}</h1>' in html
     assert '"@type": "Article"' in html

--- a/coresite/tests/test_featured_grid.py
+++ b/coresite/tests/test_featured_grid.py
@@ -1,0 +1,12 @@
+import pytest
+from django.urls import reverse
+from coresite.models import CaseStudy
+
+
+@pytest.mark.django_db
+def test_homepage_featured_grid_has_case_studies(client):
+    CaseStudy.objects.create(title="Alpha", summary="Summary", is_published=True)
+    res = client.get(reverse("home"))
+    html = res.content.decode()
+    assert 'data-analytics-event="case_study_card_click"' in html
+    assert 'data-analytics-event="cta.case_studies.open"' in html

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -47,11 +47,17 @@ TOP_LEVEL_URLS = [
         "priority": "0.8",
         "changefreq": "weekly",
     },
-    {
-        "loc": f"{settings.SITE_BASE_URL}/case-studies/",
-        "priority": "0.8",
-        "changefreq": "weekly",
-    },
+    *(
+        [
+            {
+                "loc": f"{settings.SITE_BASE_URL}/case-studies/",
+                "priority": "0.7",
+                "changefreq": "weekly",
+            }
+        ]
+        if settings.CASE_STUDIES_INDEXABLE
+        else []
+    ),
     {
         "loc": f"{settings.SITE_BASE_URL}/community/",
         "priority": "0.8",
@@ -98,12 +104,8 @@ def homepage(request):
             "blurb": "Cut waste and streamline workflows with predictive AI.",
             "url": "/resources/operations/",
         },
-        {
-            "title": "AI Case Studies",
-            "blurb": "See how real businesses turned AI into growth.",
-            "url": "/case-studies/",
-        },
     ]
+    case_studies = CaseStudy.objects.filter(is_published=True)[:3]
     try:
         images = {img.key.replace("-", "_"): img for img in SiteImage.objects.all()}
     except Exception:
@@ -117,6 +119,7 @@ def homepage(request):
         "is_homepage": True,
         "now": datetime.now(),
         "resources": resources,
+        "case_studies": case_studies,
         "signals": signals,
         "support": support,
         "community": community,

--- a/docs/analytics_events.md
+++ b/docs/analytics_events.md
@@ -5,6 +5,7 @@ Event Name | Location | Business Goal
 `cta.nav.join` | Header primary CTA "Join Us" | Grow community membership
 `cta.hero.signup` | Hero section CTA "Get AI Growth Tips" | Capture newsletter leads
 `cta.trust.case_studies` | Trust block link to case studies | Drive case study exploration
+`cta.case_studies.open` | Featured grid CTA to case studies | Drive case study exploration
 `cta.community.primary` | Community section primary CTA | Encourage community engagement
 `cta.support.<slug>` | Support cards on homepage (slug varies) | Route visitors to help resources
 `form.newsletter.start` | Newsletter email field focus | Measure newsletter form engagement
@@ -14,3 +15,4 @@ Event Name | Location | Business Goal
 `link.legal.email` | Legal email link on contact/legal pages | Enable legal notices
 `share.twitter` | Twitter share button on articles | Encourage content sharing
 `share.linkedin` | LinkedIn share button on articles | Encourage professional engagement
+`case_study_card_click` | Case study card links | Explore individual case studies

--- a/docs/structured-data.md
+++ b/docs/structured-data.md
@@ -80,7 +80,7 @@ This document lists required and optional context dictionary keys for each templ
 <a id="featured_grid"></a>
 ### featured_grid.html
 - Required: resources (list of {title, blurb, url})
-- Optional: None
+- Optional: case_studies (list of CaseStudy objects)
 
 <a id="knowledge-featured"></a>
 ### knowledge/_featured.html

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -69,6 +69,8 @@ These events support upcoming filtering and pagination features:
 - `form.newsletter.submit` – newsletter form submitted. Meta `{ "form": "newsletter" }`
 - `cta.tools.signup` – click on the Tools page signup CTA.
 - `cta.tools.open` – open a tool from the Tools page. Meta `{ "tool": "<slug>" }`
+- `cta.case_studies.open` – click CTA to explore all case studies.
+- `case_study_card_click` – open an individual case study.
 
 ## KPIs and how to compute
 Time-to-first-value: difference between `tool_run` and `tool_result_render`. Completion rate: `tool_result_render / tool_run` per tool. Assisted conversions: number of sessions that include a `tool_*` event and end with `form_submit` or `booking_start` within 7 days.


### PR DESCRIPTION
## Summary
- Surface published case studies on the homepage featured grid with tracked CTAs
- Document new analytics events and featured grid context options
- Add tests for case study analytics hooks
- Guard case-study loop in the featured grid partial and provide `get_absolute_url`
- Use model-aware slug fallbacks and CASE_STUDIES_INDEXABLE-aware tests
- Conditionally add case studies to the sitemap when indexable

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68b14e91bb9c832aaf65da4d0c7dabae