### PR TITLE
Include case studies in sitemap and add schema/indexing tests

### DIFF
--- a/coresite/tests/test_case_studies_indexing.py
+++ b/coresite/tests/test_case_studies_indexing.py
@@ -1,0 +1,73 @@
+import re
+import pytest
+from django.urls import reverse
+from django.test import override_settings
+from django.conf import settings
+from coresite.models import CaseStudy
+
+
+@pytest.mark.django_db
+def test_case_studies_view_not_indexable(client):
+    res = client.get(reverse("case_studies"))
+    assert res["X-Robots-Tag"] == "noindex,nofollow"
+    assert re.search(
+        r'<meta\s+name="robots"\s+content="noindex,nofollow"\s*/?>',
+        res.content.decode(),
+        re.I,
+    )
+
+
+@override_settings(CASE_STUDIES_INDEXABLE=True)
+@pytest.mark.django_db
+def test_case_studies_view_indexable(client):
+    res = client.get(reverse("case_studies"))
+    assert res["X-Robots-Tag"] == "index,follow"
+    assert re.search(
+        r'<meta\s+name="robots"\s+content="index,follow"\s*/?>',
+        res.content.decode(),
+        re.I,
+    )
+
+
+@pytest.mark.django_db
+def test_case_study_detail_view_not_indexable(client):
+    study = CaseStudy.objects.create(title="Alpha", summary="Summary", is_published=True)
+    res = client.get(study.get_absolute_url())
+    assert res["X-Robots-Tag"] == "noindex,nofollow"
+    assert re.search(
+        r'<meta\s+name="robots"\s+content="noindex,nofollow"\s*/?>',
+        res.content.decode(),
+        re.I,
+    )
+
+
+@override_settings(CASE_STUDIES_INDEXABLE=True)
+@pytest.mark.django_db
+def test_case_study_detail_view_indexable(client):
+    study = CaseStudy.objects.create(title="Alpha", summary="Summary", is_published=True)
+    res = client.get(study.get_absolute_url())
+    assert res["X-Robots-Tag"] == "index,follow"
+    assert re.search(
+        r'<meta\s+name="robots"\s+content="index,follow"\s*/?>',
+        res.content.decode(),
+        re.I,
+    )
+
+
+@pytest.mark.django_db
+def test_sitemap_excludes_case_studies_when_not_indexable(client, settings):
+    study = CaseStudy.objects.create(title="Alpha", summary="Summary", is_published=True)
+    res = client.get(reverse("sitemap_xml"))
+    xml = res.content.decode()
+    assert f"{settings.SITE_BASE_URL}/case-studies/" not in xml
+    assert f"{settings.SITE_BASE_URL}{study.get_absolute_url()}" not in xml
+
+
+@override_settings(CASE_STUDIES_INDEXABLE=True)
+@pytest.mark.django_db
+def test_sitemap_includes_case_studies_when_indexable(client, settings):
+    study = CaseStudy.objects.create(title="Alpha", summary="Summary", is_published=True)
+    res = client.get(reverse("sitemap_xml"))
+    xml = res.content.decode()
+    assert f"{settings.SITE_BASE_URL}/case-studies/" in xml
+    assert f"{settings.SITE_BASE_URL}{study.get_absolute_url()}" in xml

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -695,6 +695,17 @@ def sitemap_xml(request):
                 "changefreq": "monthly",
             }
         )
+    if settings.CASE_STUDIES_INDEXABLE:
+        studies = CaseStudy.objects.filter(is_published=True).only("slug", "updated_at")
+        for study in studies:
+            urls.append(
+                {
+                    "loc": f"{settings.SITE_BASE_URL}{study.get_absolute_url()}",
+                    "priority": "0.5",
+                    "changefreq": "monthly",
+                    "lastmod": (study.updated_at or timezone.now()).date().isoformat(),
+                }
+            )
     xml_parts = [
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
         '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
@@ -703,6 +714,8 @@ def sitemap_xml(request):
         xml_parts.append("  <url>")
         xml_parts.append(f"    <loc>{url['loc']}</loc>")
         xml_parts.append(f"    <changefreq>{url['changefreq']}</changefreq>")
+        if 'lastmod' in url:
+            xml_parts.append(f"    <lastmod>{url['lastmod']}</lastmod>")
         xml_parts.append(f"    <priority>{url['priority']}</priority>")
         xml_parts.append("  </url>")
     xml_parts.append("</urlset>")

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -109,3 +109,18 @@ def test_tool_detail_jsonld_handles_schema_kinds():
     data = _extract_json(html)
     assert data["@type"] == "CreativeWork"
     assert "operatingSystem" not in data
+
+
+FIXTURES_DIR = pathlib.Path(__file__).resolve().parent / "fixtures"
+
+
+@pytest.fixture
+def case_study_json():
+    html = (FIXTURES_DIR / "case_study.html").read_text()
+    return _extract_json(html)
+
+
+def test_case_study_detail_schema(case_study_json):
+    assert case_study_json["@type"] == "Article"
+    assert case_study_json["url"] == "https://example.com/case-studies/acme"
+    assert case_study_json["publisher"]["@type"] == "Organization"


### PR DESCRIPTION
## Summary
- add case study URLs to sitemap with `lastmod`
- test case study JSON-LD schema
- ensure case studies toggle robots and sitemap entries

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1 (from versions: none))*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68b153bd3b54832a9a46e2bfae5cec85