### PR TITLE
Switch admin editor to CKEditor 5 and document options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ See `.env.example` for placeholder values.
 ## Admin editor
 
 The Django admin uses [`django-ckeditor-5`](https://pypi.org/project/django-ckeditor-5/) for rich-text fields.
+The package wraps the open-source CKEditor 5 core; premium features are optional.
 Toolbar and plugin options live in `CKEDITOR_5_CONFIGS` inside `technofatty_com/settings.py`.
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Required variables:
 
 See `.env.example` for placeholder values.
 
+## Admin editor
+
+The Django admin uses [`django-ckeditor-5`](https://pypi.org/project/django-ckeditor-5/) for rich-text fields.
+Toolbar and plugin options live in `CKEDITOR_5_CONFIGS` inside `technofatty_com/settings.py`.
+
 ## Deployment
 
 See `docs/deployment.md` for details on production deployment with Apache + mod_wsgi.

--- a/coresite/admin.py
+++ b/coresite/admin.py
@@ -14,11 +14,13 @@ from .models import (
     ContactEvent,
     StatusChoices,
 )
-from ckeditor.widgets import CKEditorWidget
+from django_ckeditor_5.widgets import CKEditor5Widget
 
 
 class KnowledgeArticleAdminForm(forms.ModelForm):
-    content = forms.CharField(widget=CKEditorWidget(), required=False)
+    content = forms.CharField(
+        widget=CKEditor5Widget(config_name="default"), required=False
+    )
 
     class Meta:
         model = KnowledgeArticle

--- a/docs/editor-options.md
+++ b/docs/editor-options.md
@@ -1,0 +1,23 @@
+# Editor Options Evaluation
+
+This document compares two rich text editor approaches for the project: `django-ckeditor-5` and a simple Markdown textarea.
+
+## django-ckeditor-5
+- **Pros**
+  - Provides a full-featured WYSIWYG editing experience powered by CKEditor 5.
+  - Supports rich formatting such as headings, lists, and block quotes out of the box.
+  - Produces HTML compatible with existing `content` fields.
+- **Cons**
+  - Adds a JavaScript bundle and additional static assets.
+  - More complex configuration compared to a plain textarea.
+
+## Simple Markdown
+- **Pros**
+  - Lightweight and minimal dependencies.
+  - Content stored as Markdown which is easy to version and edit manually.
+- **Cons**
+  - Requires a renderer to convert Markdown to HTML on display.
+  - Less intuitive for non-technical users who prefer a WYSIWYG interface.
+
+## Recommendation
+`django-ckeditor-5` offers a modern WYSIWYG editor with HTML output compatible with existing data, making migration straightforward while preserving authoring convenience. The open-source core meets our needs, so premium CKEditor add-ons remain optional.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.8.1
 Django==4.2.23
-django-ckeditor==6.7.1
+django-ckeditor-5==0.2.9
 django-compressor==4.4
 django-sass-processor==1.4.1
 easy-thumbnails==2.9.1

--- a/technofatty_com/settings.py
+++ b/technofatty_com/settings.py
@@ -312,3 +312,6 @@ CKEDITOR_5_CONFIGS = {
         ],
     }
 }
+
+# store uploaded assets under MEDIA_ROOT/ckeditor5/
+CKEDITOR_5_FILE_UPLOAD_PATH = "ckeditor5/"

--- a/technofatty_com/settings.py
+++ b/technofatty_com/settings.py
@@ -94,7 +94,7 @@ INSTALLED_APPS = [
     "sass_processor",
     "compressor",
     'easy_thumbnails',
-    'ckeditor',
+    'django_ckeditor_5',
 ]
 
 MIDDLEWARE = [
@@ -296,10 +296,19 @@ CONSENT_COOKIE_HTTPONLY = (
 
 
 # -------------------------------------------------
-# CKEditor
+# CKEditor 5
 # -------------------------------------------------
-CKEDITOR_CONFIGS = {
+CKEDITOR_5_CONFIGS = {
     "default": {
-        "toolbar": "full",
+        "toolbar": [
+            "heading",
+            "|",
+            "bold",
+            "italic",
+            "link",
+            "bulletedList",
+            "numberedList",
+            "blockQuote",
+        ],
     }
 }

--- a/technofatty_com/urls.py
+++ b/technofatty_com/urls.py
@@ -67,6 +67,7 @@ account_patterns = [
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('ckeditor5/', include('django_ckeditor_5.urls')),
     path('', include('coresite.urls')),
     path('newsletter/', include('newsletter.urls')),
     path('robots.txt', core_views.robots_txt, name="robots_txt"),


### PR DESCRIPTION
## Summary
- use CKEditor5Widget for authoring knowledge articles and wire the form into KnowledgeArticleAdmin
- configure CKEditor 5 in Django settings
- replace CKEditor 4 dependency with `django-ckeditor-5` and document editor evaluation
- note in README where to adjust CKEditor 5 configs

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement asgiref==3.8.1 - Cannot connect to proxy. 403 Forbidden)
- `pytest` (fails: ModuleNotFoundError: No module named 'django')
- `python manage.py check` (fails: ModuleNotFoundError: No module named 'django`)


------
https://chatgpt.com/codex/tasks/task_e_68b158ad1398832ab6a03ad60f9b63b9