### PR TITLE
Implement caching and image thumbnails

### DIFF
--- a/coresite/middleware.py
+++ b/coresite/middleware.py
@@ -19,3 +19,21 @@ class ConsentMiddleware:
         request.CONSENT_GRANTED = consent_granted
         response = self.get_response(request)
         return response
+
+
+class StaticCacheControlMiddleware:
+    """Add long-lived Cache-Control headers for static assets.
+
+    Only relevant when Django serves static files (e.g., in DEBUG).
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if request.path.startswith(settings.STATIC_URL):
+            response.headers.setdefault(
+                "Cache-Control", "public, max-age=31536000, immutable"
+            )
+        return response

--- a/coresite/models.py
+++ b/coresite/models.py
@@ -4,8 +4,9 @@ from django.db import models
 from django.utils import timezone
 from django.utils.text import slugify
 from django.urls import reverse
-from django.db.models.signals import pre_save
+from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver
+from django.core.cache import cache
 import math
 
 
@@ -315,6 +316,15 @@ def set_blogpost_slug(sender, instance, **kwargs):
         instance.slug = _generate_unique_slug(
             instance.title, BlogPost.objects.exclude(pk=instance.pk), fallback="blog-post"
         )
+
+
+SITEMAP_CACHE_KEY = "sitemap_xml"
+
+
+@receiver(post_save, sender=BlogPost)
+@receiver(post_save, sender=CaseStudy)
+def clear_sitemap_cache(**kwargs):
+    cache.delete(SITEMAP_CACHE_KEY)
 
 
 class ContactEvent(models.Model):

--- a/coresite/templates/coresite/case_studies/index.html
+++ b/coresite/templates/coresite/case_studies/index.html
@@ -1,5 +1,5 @@
 {% extends "coresite/base.html" %}
-{% load jsonld seo_tags %}
+{% load jsonld seo_tags thumbnail %}
 
 {% block meta %}
   {% with meta_description="Client success stories from Technofatty." %}
@@ -42,6 +42,9 @@
       <div class="case-studies__grid">
         {% for cs in case_studies %}
         <article class="case-study-card">
+          {% if cs.image %}
+          <img src="{{ cs.image|thumbnail_url:'case_study_card' }}" alt="" class="case-study-card__img" loading="lazy">
+          {% endif %}
           <h2 class="case-study-card__title">{{ cs.title }}</h2>
           <p class="case-study-card__summary">{{ cs.summary }}</p>
           <p><a

--- a/coresite/templates/coresite/partials/featured_grid.html
+++ b/coresite/templates/coresite/partials/featured_grid.html
@@ -1,6 +1,7 @@
 {# See docs/structured-data.md#featured_grid for context keys #}
-{% load static %}
+{% load static cache thumbnail %}
 
+{% cache 3600 featured_grid featured_grid_version|default:"v1" %}
 <section id="featured" class="featured" aria-labelledby="featured-heading">
   <div class="container-wide">
     <h2 id="featured-heading" class="section-title">Featured Resources</h2>
@@ -22,7 +23,13 @@
       {% if case_studies %}
       {% for cs in case_studies %}
         <article class="card">
+          {% if cs.image %}
+          <div class="card__img">
+            <img src="{{ cs.image|thumbnail_url:'case_study_card' }}" alt="" loading="lazy">
+          </div>
+          {% else %}
           <div class="card__img" aria-hidden="true"></div>
+          {% endif %}
           <h3 class="card__title">{{ cs.title }}</h3>
           <p class="card__blurb">{{ cs.summary }}</p>
           <a class="card__link"
@@ -49,3 +56,4 @@
   </div>
 
 </section>
+{% endcache %}

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,0 +1,23 @@
+# Caching Strategy
+
+This project uses multiple caching layers to reduce response time and load on the application.
+
+## Homepage featured grid
+- The `featured_grid` template fragment is cached for one hour with a key that changes when resources or case studies are edited.
+- No manual invalidation is required; updating content automatically produces a new cache key.
+
+## Sitemap
+- The `/sitemap.xml` output is cached for one hour.
+- Saving a `BlogPost` or `CaseStudy` automatically clears the cache to keep listings fresh.
+
+## JSON-LD blocks
+- Rendered JSON-LD script tags are cached using a hash of their content for one hour.
+- Any change to the underlying data automatically generates a new hash and refreshes the cache.
+
+## Static assets
+- Static files use hashed filenames via `ManifestStaticFilesStorage`.
+- Long‑lived `Cache-Control` headers should be set by the web server or CDN (e.g. Apache `Header` directive).
+
+## General invalidation
+- Clearing the default cache clears view and fragment caches.
+- Deployments that change static assets automatically bust CDN caches thanks to hashed filenames.

--- a/technofatty_com/settings.py
+++ b/technofatty_com/settings.py
@@ -20,6 +20,7 @@ THUMBNAIL_ALIASES = {
         'hero_desktop': {'size': (1920, 1080), 'crop': True},
         'hero_tablet': {'size': (1280, 720), 'crop': True},
         'hero_mobile': {'size': (640, 360), 'crop': True},
+        'case_study_card': {'size': (600, 400), 'crop': True},
     },
 }
 
@@ -108,6 +109,9 @@ MIDDLEWARE = [
     "coresite.middleware.ConsentMiddleware",
 ]
 
+if DEBUG:
+    MIDDLEWARE.insert(1, "coresite.middleware.StaticCacheControlMiddleware")
+
 ROOT_URLCONF = "technofatty_com.urls"
 
 TEMPLATES = [
@@ -185,7 +189,7 @@ STATICFILES_DIRS = []
 # Where collectstatic will gather files for production serving (Nginx, etc.)
 STATIC_ROOT = Path("/var/www/technofatty_com/static")
 
-# Hash filenames for cache-busting in prod (works fine with Nginx or any static server)
+# Hash filenames for cache-busting; CDN should set long-lived cache headers
 STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
 
 # Let Django find compiled CSS from sass_processor


### PR DESCRIPTION
## Summary
- tighten fragment caching for homepage featured grid and document new strategy
- auto-bust sitemap cache on content publish and restrict static cache middleware to DEBUG
- keep static URL local until CDN is configured
- use shared `SITEMAP_CACHE_KEY` constant and default fragment cache version

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68b175c0dd88832aa1d0fae595ca5293