### PR TITLE
Respect indexability flags in robots.txt

### DIFF
--- a/coresite/tests/test_robots_txt.py
+++ b/coresite/tests/test_robots_txt.py
@@ -1,0 +1,29 @@
+import pytest
+from django.urls import reverse
+from django.test import override_settings
+from django.conf import settings
+
+
+@pytest.mark.parametrize(
+    "case_flag, tool_flag, expect_case, expect_tool",
+    [
+        (False, False, True, True),
+        (True, False, False, True),
+        (False, True, True, False),
+        (True, True, False, False),
+    ],
+)
+def test_robots_txt_respects_flags(client, case_flag, tool_flag, expect_case, expect_tool):
+    with override_settings(CASE_STUDIES_INDEXABLE=case_flag, TOOLS_INDEXABLE=tool_flag):
+        res = client.get(reverse("robots_txt"), HTTP_HOST="technofatty.com")
+    lines = res.content.decode().splitlines()
+    assert "Allow: /" in lines
+    if expect_case:
+        assert "Disallow: /case-studies/" in lines
+    else:
+        assert "Disallow: /case-studies/" not in lines
+    if expect_tool:
+        assert "Disallow: /tools/" in lines
+    else:
+        assert "Disallow: /tools/" not in lines
+    assert f"Sitemap: {settings.SITE_BASE_URL}/sitemap.xml" in lines

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -741,11 +741,12 @@ def robots_txt(request):
     host = request.get_host().split(":")[0].lower()
     production_hosts = {"technofatty.com", "www.technofatty.com"}
     if host in production_hosts:
-        lines = [
-            "User-agent: *",
-            "Allow: /",
-            f"Sitemap: {settings.SITE_BASE_URL}/sitemap.xml",
-        ]
+        lines = ["User-agent: *", "Allow: /"]
+        if not settings.CASE_STUDIES_INDEXABLE:
+            lines.append("Disallow: /case-studies/")
+        if not settings.TOOLS_INDEXABLE:
+            lines.append("Disallow: /tools/")
+        lines.append(f"Sitemap: {settings.SITE_BASE_URL}/sitemap.xml")
     else:
         lines = [
             "User-agent: *",


### PR DESCRIPTION
## Summary
- Generate `robots.txt` disallow lines based on CASE_STUDIES_INDEXABLE and TOOLS_INDEXABLE flags
- Cover `robots.txt` logic with tests for various indexability combinations

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b17ea666e8832a85f94b63f0d4765c