### PR TITLE
Add service health checks and analytics logging

### DIFF
--- a/coresite/health.py
+++ b/coresite/health.py
@@ -1,0 +1,49 @@
+from django.conf import settings
+from django.http import JsonResponse
+from django.views.decorators.http import require_GET
+from django.db import connections
+from django.core.cache import cache
+
+
+def _json_ok():
+    resp = JsonResponse({"status": "ok"})
+    resp["Cache-Control"] = "no-store"
+    return resp
+
+
+@require_GET
+def db_health(request):
+    try:
+        with connections["default"].cursor() as cursor:
+            cursor.execute("SELECT 1")
+            cursor.fetchone()
+    except Exception as exc:
+        payload = {"status": "error"}
+        if settings.DEBUG:
+            payload["detail"] = str(exc)
+        resp = JsonResponse(payload, status=500)
+        resp["Cache-Control"] = "no-store"
+        return resp
+    return _json_ok()
+
+
+@require_GET
+def cache_health(request):
+    try:
+        cache.set("__healthcheck__", "ok", 1)
+        if cache.get("__healthcheck__") != "ok":
+            raise ValueError("cache read/write failed")
+        cache.delete("__healthcheck__")
+    except Exception as exc:
+        payload = {"status": "error"}
+        if settings.DEBUG:
+            payload["detail"] = str(exc)
+        resp = JsonResponse(payload, status=500)
+        resp["Cache-Control"] = "no-store"
+        return resp
+    return _json_ok()
+
+
+@require_GET
+def live_health(request):
+    return _json_ok()

--- a/coresite/static/coresite/js/consent.js
+++ b/coresite/static/coresite/js/consent.js
@@ -66,7 +66,8 @@ document.addEventListener('DOMContentLoaded', () => {
       /* ignore */
     }
 
-    body.dataset.consentGranted = 'true';
+    body.dataset.consentGranted = state === 'accepted' ? 'true' : 'false';
+    document.dispatchEvent(new Event('tf:consent-updated'));
     hideBanner();
   }
 

--- a/coresite/templates/coresite/base.html
+++ b/coresite/templates/coresite/base.html
@@ -48,6 +48,13 @@
 
   <script src="{% static 'coresite/js/consent.js' %}?v={{ now|date:'U' }}" defer></script>
   <script src="{% static 'coresite/js/main.js' %}?v={{ now|date:'U' }}" defer></script>
+  <script>
+  (function() {
+    if (new URLSearchParams(location.search).get('consent') === 'updated') {
+      document.dispatchEvent(new Event('tf:consent-updated'));
+    }
+  })();
+  </script>
   {% block body_scripts %}{% endblock %}
 </body>
 </html>

--- a/coresite/templates/coresite/partials/global/analytics.html
+++ b/coresite/templates/coresite/partials/global/analytics.html
@@ -15,10 +15,37 @@
     (function(){
       var body=document.body;
       var p=body.dataset.analyticsProvider;
+      var enabled=(body.dataset.analyticsEnabled||'true')==='true';
       function hasConsent(){return body.dataset.consentRequired!=='true'||body.dataset.consentGranted==='true';}
-      function send(n,m){if(!hasConsent())return;m=m||{};if(p==='plausible'&&window.plausible){window.plausible(n,{props:m});}
-        else if(p==='ga4'&&window.gtag){window.gtag('event',n,m);}}
-      if (hasConsent()) { window.tfSend = send; }
+      function isActive(){return enabled&&hasConsent();}
+      function log(kind,data){
+        if(window.logAggregator&&typeof window.logAggregator[kind]==='function'){
+          window.logAggregator[kind](data);
+        } else if(window.console&&typeof window.console[kind]==='function'){
+          window.console[kind](data);
+        }
+      }
+      function send(n,m){
+        if(!isActive())return;
+        m=m||{};
+        try{
+          if(p==='plausible'&&window.plausible){
+            window.plausible(n,{props:m});
+            log('info',{event:n,meta:m,provider:p,ok:true});
+          } else if(p==='ga4'&&window.gtag){
+            window.gtag('event',n,m);
+            log('info',{event:n,meta:m,provider:p,ok:true});
+          } else {
+            log('warn',{event:n,meta:m,provider:p,ok:false,reason:'provider-missing'});
+          }
+        } catch(e){
+          log('error',{event:n,meta:m,provider:p,ok:false,error:e.toString()});
+        }
+      }
+      if (isActive()) { window.tfSend = send; }
+      document.addEventListener('tf:consent-updated',function(){
+        if(isActive()&&!window.tfSend){window.tfSend=send;}
+      });
       var fired={};
       function meta(el){try{return JSON.parse(el.dataset.analyticsMeta||'{}')}catch(e){return {};}}
       document.addEventListener('click',function(e){var el=e.target;

--- a/coresite/tests/test_analytics_flags.py
+++ b/coresite/tests/test_analytics_flags.py
@@ -45,7 +45,7 @@ def test_consent_not_granted_with_invalid_cookie(settings):
 def test_accept_sets_signed_cookie(client, settings):
     response = client.get(reverse('consent_accept'), HTTP_REFERER='/prev/')
     assert response.status_code == 302
-    assert response['Location'] == '/prev/'
+    assert response['Location'] == '/prev/?consent=updated'
     assert (
         signing.loads(
             response.cookies[settings.CONSENT_COOKIE_NAME].value
@@ -57,7 +57,7 @@ def test_accept_sets_signed_cookie(client, settings):
 def test_decline_sets_signed_cookie(client, settings):
     response = client.get(reverse('consent_decline'), HTTP_REFERER='/prev/')
     assert response.status_code == 302
-    assert response['Location'] == '/prev/'
+    assert response['Location'] == '/prev/?consent=updated'
     assert (
         signing.loads(
             response.cookies[settings.CONSENT_COOKIE_NAME].value

--- a/coresite/tests/test_health_endpoints.py
+++ b/coresite/tests/test_health_endpoints.py
@@ -1,0 +1,53 @@
+from django.urls import reverse
+from django.db import connections
+
+
+def test_db_health(client):
+    resp = client.get(reverse('health_db'))
+    assert resp.status_code == 200
+    assert resp.json() == {'status': 'ok'}
+    assert resp['Cache-Control'] == 'no-store'
+
+
+def test_cache_health(client):
+    resp = client.get(reverse('health_cache'))
+    assert resp.status_code == 200
+    assert resp.json() == {'status': 'ok'}
+    assert resp['Cache-Control'] == 'no-store'
+
+
+def test_live_health(client):
+    resp = client.get(reverse('health_live'))
+    assert resp.status_code == 200
+    assert resp.json() == {'status': 'ok'}
+    assert resp['Cache-Control'] == 'no-store'
+
+
+def test_db_health_error_hides_detail(client, monkeypatch, settings):
+    class BadCursor:
+        def __enter__(self):
+            raise Exception('boom')
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(connections['default'], 'cursor', lambda *a, **kw: BadCursor())
+    settings.DEBUG = False
+    resp = client.get(reverse('health_db'))
+    assert resp.status_code == 500
+    assert resp.json() == {'status': 'error'}
+
+
+def test_db_health_error_shows_detail_when_debug(client, monkeypatch, settings):
+    class BadCursor:
+        def __enter__(self):
+            raise Exception('boom')
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(connections['default'], 'cursor', lambda *a, **kw: BadCursor())
+    settings.DEBUG = True
+    resp = client.get(reverse('health_db'))
+    assert resp.status_code == 500
+    assert resp.json() == {'status': 'error', 'detail': 'boom'}

--- a/coresite/tests/test_tf_send_consent.py
+++ b/coresite/tests/test_tf_send_consent.py
@@ -6,46 +6,56 @@ import textwrap
 import pytest
 
 
-def _run_plausible(consent_granted):
+def _run_plausible(consent_granted, enabled=True, provide_api=True):
     script = textwrap.dedent(
         f"""
         var window={{}};
-        var document={{body:{{dataset:{{analyticsProvider:'plausible',consentRequired:'true',consentGranted:'{str(consent_granted).lower()}'}}}}}};
+        var events={{}};
+        var document={{body:{{dataset:{{analyticsProvider:'plausible',analyticsEnabled:'{str(enabled).lower()}',consentRequired:'true',consentGranted:'{str(consent_granted).lower()}'}}}},addEventListener:function(n,f){{events[n]=f;}}}};
+        var logs=[];
         (function(){{
           var body=document.body;
           var p=body.dataset.analyticsProvider;
+          var enabled=(body.dataset.analyticsEnabled||'true')==='true';
           function hasConsent(){{return body.dataset.consentRequired!=='true'||body.dataset.consentGranted==='true';}}
-          function send(n,m){{if(!hasConsent())return;m=m||{{}};if(p==='plausible'&&window.plausible){{window.plausible(n,{{props:m}});}}
-            else if(p==='ga4'&&window.gtag){{window.gtag('event',n,m);}}}}
-          if (hasConsent()) {{ window.tfSend = send; }}
+          function isActive(){{return enabled&&hasConsent();}}
+          function log(k,d){{logs.push([k,d]);}}
+          function send(n,m){{if(!isActive())return;m=m||{{}};try{{if(p==='plausible'&&window.plausible){{window.plausible(n,{{props:m}});log('info',{{event:n,meta:m,provider:p,ok:true}});}}else if(p==='ga4'&&window.gtag){{window.gtag('event',n,m);log('info',{{event:n,meta:m,provider:p,ok:true}});}}else{{log('warn',{{event:n,meta:m,provider:p,ok:false,reason:'provider-missing'}});}}}}catch(e){{log('error',{{event:n,meta:m,provider:p,ok:false,error:e.toString()}});}}}}
+          if(isActive()){{window.tfSend=send;}}
+          document.addEventListener('tf:consent-updated',function(){{if(isActive()&&!window.tfSend){{window.tfSend=send;}}}});
         }})();
         var calls=[];
-        window.plausible=function(n,o){{calls.push([n,o]);}};
+        if({str(provide_api).lower()}) window.plausible=function(n,o){{calls.push([n,o]);}};
         if(window.tfSend) window.tfSend('evt',{{foo:'bar'}});
-        console.log(JSON.stringify(calls));
+        console.log(JSON.stringify({{calls:calls,logs:logs}}));
         """
     )
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
     return json.loads(result.stdout.strip())
 
 
-def _run_ga4(consent_granted):
+def _run_ga4(consent_granted, enabled=True, provide_api=True):
     script = textwrap.dedent(
         f"""
         var window={{}};
-        var document={{body:{{dataset:{{analyticsProvider:'ga4',consentRequired:'true',consentGranted:'{str(consent_granted).lower()}'}}}}}};
+        var events={{}};
+        var document={{body:{{dataset:{{analyticsProvider:'ga4',analyticsEnabled:'{str(enabled).lower()}',consentRequired:'true',consentGranted:'{str(consent_granted).lower()}'}}}},addEventListener:function(n,f){{events[n]=f;}}}};
+        var logs=[];
         (function(){{
           var body=document.body;
           var p=body.dataset.analyticsProvider;
+          var enabled=(body.dataset.analyticsEnabled||'true')==='true';
           function hasConsent(){{return body.dataset.consentRequired!=='true'||body.dataset.consentGranted==='true';}}
-          function send(n,m){{if(!hasConsent())return;m=m||{{}};if(p==='plausible'&&window.plausible){{window.plausible(n,{{props:m}});}}
-            else if(p==='ga4'&&window.gtag){{window.gtag('event',n,m);}}}}
-          if (hasConsent()) {{ window.tfSend = send; }}
+          function isActive(){{return enabled&&hasConsent();}}
+          function log(k,d){{logs.push([k,d]);}}
+          function send(n,m){{if(!isActive())return;m=m||{{}};try{{if(p==='plausible'&&window.plausible){{window.plausible(n,{{props:m}});log('info',{{event:n,meta:m,provider:p,ok:true}});}}else if(p==='ga4'&&window.gtag){{window.gtag('event',n,m);log('info',{{event:n,meta:m,provider:p,ok:true}});}}else{{log('warn',{{event:n,meta:m,provider:p,ok:false,reason:'provider-missing'}});}}}}catch(e){{log('error',{{event:n,meta:m,provider:p,ok:false,error:e.toString()}});}}}}
+          if(isActive()){{window.tfSend=send;}}
+          document.addEventListener('tf:consent-updated',function(){{if(isActive()&&!window.tfSend){{window.tfSend=send;}}}});
         }})();
         var calls=[];
-        window.gtag=function(kind,name,meta){{calls.push([kind,name,meta]);}};
+        if({str(provide_api).lower()}) window.gtag=function(kind,name,meta){{calls.push([kind,name,meta]);}};
         if(window.tfSend) window.tfSend('evt',{{foo:'bar'}});
-        console.log(JSON.stringify(calls));
+        console.log(JSON.stringify({{calls:calls,logs:logs}}));
         """
     )
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
@@ -54,20 +64,67 @@ def _run_ga4(consent_granted):
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
 def test_tf_send_plausible_respects_consent():
-    assert _run_plausible(False) == []
+    assert _run_plausible(False)["calls"] == []
+    assert _run_plausible(False)["logs"] == []
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
 def test_tf_send_plausible_sends_with_consent():
-    assert _run_plausible(True) == [['evt', {'props': {'foo': 'bar'}}]]
+    result = _run_plausible(True)
+    assert result["calls"] == [['evt', {'props': {'foo': 'bar'}}]]
+    assert result["logs"] == [['info', {'event': 'evt', 'meta': {'foo': 'bar'}, 'provider': 'plausible', 'ok': True}]]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_tf_send_logs_when_provider_missing():
+    result = _run_plausible(True, provide_api=False)
+    assert result["calls"] == []
+    assert result["logs"] == [['warn', {'event': 'evt', 'meta': {'foo': 'bar'}, 'provider': 'plausible', 'ok': False, 'reason': 'provider-missing'}]]
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
 def test_tf_send_ga4_respects_consent():
-    assert _run_ga4(False) == []
+    assert _run_ga4(False)["calls"] == []
+    assert _run_ga4(False)["logs"] == []
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
 def test_tf_send_ga4_sends_with_consent():
-    assert _run_ga4(True) == [['event', 'evt', {'foo': 'bar'}]]
+    result = _run_ga4(True)
+    assert result["calls"] == [['event', 'evt', {'foo': 'bar'}]]
+    assert result["logs"] == [['info', {'event': 'evt', 'meta': {'foo': 'bar'}, 'provider': 'ga4', 'ok': True}]]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_tf_send_enables_after_consent_event():
+    script = textwrap.dedent(
+        """
+        var window={};
+        var events={};
+        var document={body:{dataset:{analyticsProvider:'plausible',analyticsEnabled:'true',consentRequired:'true',consentGranted:'false'}},addEventListener:function(n,f){events[n]=f;}};
+        var logs=[];
+        (function(){
+          var body=document.body;
+          var p=body.dataset.analyticsProvider;
+          var enabled=(body.dataset.analyticsEnabled||'true')==='true';
+          function hasConsent(){return body.dataset.consentRequired!=='true'||body.dataset.consentGranted==='true';}
+          function isActive(){return enabled&&hasConsent();}
+          function log(k,d){logs.push([k,d]);}
+          function send(n,m){if(!isActive())return;m=m||{};try{if(p==='plausible'&&window.plausible){window.plausible(n,{props:m});log('info',{event:n,meta:m,provider:p,ok:true});}else if(p==='ga4'&&window.gtag){window.gtag('event',n,m);log('info',{event:n,meta:m,provider:p,ok:true});}else{log('warn',{event:n,meta:m,provider:p,ok:false,reason:'provider-missing'});}}catch(e){log('error',{event:n,meta:m,provider:p,ok:false,error:e.toString()});}}
+          if(isActive()){window.tfSend=send;}
+          document.addEventListener('tf:consent-updated',function(){if(isActive()&&!window.tfSend){window.tfSend=send;}});
+        })();
+        var calls=[];
+        window.plausible=function(n,o){calls.push([n,o]);};
+        if(window.tfSend) window.tfSend('pre',{});
+        document.body.dataset.consentGranted='true';
+        events['tf:consent-updated']();
+        if(window.tfSend) window.tfSend('post',{});
+        console.log(JSON.stringify({calls:calls,logs:logs}));
+        """
+    )
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout.strip())
+    assert data["calls"] == [['post', {'props': {}}]]
+    assert data["logs"][-1] == ['info', {'event': 'post', 'meta': {}, 'provider': 'plausible', 'ok': True}]
 

--- a/coresite/urls.py
+++ b/coresite/urls.py
@@ -13,8 +13,12 @@ from .feeds import (
     blog_json_feed,
     knowledge_json_feed,
 )
+from .health import db_health, cache_health, live_health
 
 urlpatterns = [
+    path("health/db/", db_health, name="health_db"),
+    path("health/cache/", cache_health, name="health_cache"),
+    path("health/live/", live_health, name="health_live"),
     path("", views.homepage, name="home"),
     path("consent/accept/", views.consent_accept, name="consent_accept"),
     path("consent/decline/", views.consent_decline, name="consent_decline"),

--- a/docs/rollout_checklist.md
+++ b/docs/rollout_checklist.md
@@ -3,3 +3,4 @@
 - [ ] Run full test suite.
 - [ ] Verify legacy redirects in the staging environment before deploying to production.
 - [ ] Confirm critical pages respond with expected status codes.
+- [ ] Configure monitoring probes: GET /health/live/ (liveness) and /health/db/, /health/cache/ (readiness) every 10s with 2s timeout.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -59,6 +59,20 @@ Use `tool_detail.view` with the tool identifier on individual tool pages:
 </script>
 ```
 
+## Log aggregation
+
+The analytics wrapper logs send outcomes to a `window.logAggregator` object when available, falling back to `console`. The aggregator should expose `info`, `warn`, and `error` methods that accept a structured payload:
+
+```js
+window.logAggregator = {
+  info:  (data) => {},
+  warn:  (data) => {},
+  error: (data) => {}
+};
+```
+
+Avoid including personal data in event metadata; scrub emails, phone numbers, or other identifiers before sending or logging.
+
 ## Current events
 
 These events support upcoming filtering and pagination features:


### PR DESCRIPTION
## Summary
- harden DB and cache health endpoints and add liveness check
- enable analytics logging after consent updates and document log aggregator interface
- expand health and analytics tests
- emit consent-updated event on redirects and note monitoring probes

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b182b522dc832a9e07ab2fd2c4b404