### PR TITLE
Add community content brief template

### DIFF
--- a/docs/community-content-brief.md
+++ b/docs/community-content-brief.md
@@ -1,0 +1,110 @@
+# Technofatty Community – Content Brief Template
+
+This template defines the required format and standards for all Community content:  
+questions, discussion threads, and tags.  
+All moderators, staff, and contributors must follow this template.  
+Paula is responsible for approval; deviations require explicit sign-off.
+
+---
+
+## 1. Questions (`/community/q/<slug>/`)
+
+**Title**  
+- Max 60 characters.  
+- Written in plain language (no jargon).  
+- Must begin with a clear problem statement or “How/What/Why.”  
+- Example: *How do I configure consent middleware in Django?*
+
+**Body**  
+- Concise description of the issue (1–3 short paragraphs).  
+- May include code snippets or screenshots (must use accessible alt text).  
+- Must end with a clear request: “I need help with…”  
+
+**Tags**  
+- 2–4 tags only.  
+- Tags must match existing taxonomy where possible.  
+- No duplicates or near-synonyms (enforced by moderators).
+
+**SEO Metadata**  
+- Meta title auto-generated from thread title.  
+- Meta description = first 155 characters of body (auto-truncated).  
+
+**Trust Signals**  
+- Every question must show author + created date.  
+- Code of Conduct link visible at bottom of thread.  
+
+---
+
+## 2. Discussion Threads (`/community/t/<slug>/`)
+
+**Title**  
+- Max 60 characters.  
+- Must describe the topic neutrally.  
+- Example: *Experiences using Plausible Analytics in production.*
+
+**Body**  
+- Opening statement (1–2 paragraphs).  
+- Tone: professional, not promotional.  
+- May reference Technofatty Knowledge/Tools/Case Studies.  
+
+**Tags**  
+- Same rules as questions.  
+- Tags must be reviewed for consistency.
+
+**SEO Metadata**  
+- Meta title = thread title (≤60 chars).  
+- Meta description = first reply excerpt if original body >155 chars.
+
+**Trust Signals**  
+- Staff participation labeled “Technofatty Staff.”  
+- Moderation visible where applied.
+
+---
+
+## 3. Tags (`/community/tag/<slug>/`)
+
+**Tag Naming**  
+- Single word or short phrase (≤20 chars).  
+- Lowercase, hyphenated if multi-word (e.g. `cookie-consent`).  
+- Must match terms used in Knowledge, Tools, Case Studies.  
+
+**Tag Description**  
+- 1–2 sentences explaining the scope of the tag.  
+- Example: *Posts about implementing cookie consent banners, policies, and middleware.*  
+
+**SEO Metadata**  
+- Meta title: *Technofatty Community – <Tag> Discussions*.  
+- Meta description: *Explore community questions and discussions on <Tag>.*  
+
+---
+
+## 4. Tone and Style
+
+- Professional, concise, plain English.  
+- No slang, no filler.  
+- Encourage clarity over cleverness (*Don’t Make Me Think* principle).  
+- Body text line length must remain within 70 characters for readability.  
+
+---
+
+## 5. Conversion Alignment
+
+- Every thread and tag page must include:  
+  - Inline newsletter opt-in (“Subscribe to Updates”).  
+  - “Ask a Question” CTA.  
+- Forms must clearly state: *“Your email is never shown publicly.”*  
+
+---
+
+## 6. Governance
+
+- Moderators must review all new questions for:  
+  - Title clarity.  
+  - Proper tags.  
+  - Compliance with Code of Conduct.  
+- Unclear or off-topic posts must be edited or rejected.  
+- All accepted answers must be marked promptly when appropriate.
+
+---
+
+*This brief ensures community content compounds value: discoverable via SEO, trustworthy to users, and aligned with Technofatty’s growth engine.*


### PR DESCRIPTION
## Summary
- add community content brief template for moderators and contributors

## Testing
- `pytest` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bed24848832a8bb40007360f64de