### PR TITLE
test: add community hub regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - run: pytest

--- a/coresite/tests/test_community_hub.py
+++ b/coresite/tests/test_community_hub.py
@@ -1,0 +1,52 @@
+import json
+import re
+import shutil
+import subprocess
+
+import pytest
+from django.test import override_settings
+
+
+def _extract_json(html: str) -> dict:
+    match = re.search(r'<script type="application/ld\+json">(.*?)</script>', html, re.DOTALL)
+    assert match, "No JSON-LD script found"
+    return json.loads(match.group(1))
+
+
+@override_settings(SITE_BASE_URL="https://technofatty.com")
+def test_community_hub_has_canonical_and_jsonld(client):
+    res = client.get("/community/")
+    html = res.content.decode()
+    assert '<link rel="canonical" href="/community/">' in html
+    data = _extract_json(html)
+    types = {item["@type"] for item in data["@graph"]}
+    assert {"CollectionPage", "BreadcrumbList", "ItemList"}.issubset(types)
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_community_view_event_respects_consent():
+    script = """
+        var calls = [];
+        var window = {};
+        var document = {addEventListener:function(ev,fn){fn();}};
+        (function(){
+          var payload = {surface:'community', filter:'latest'};
+          if (window.tfSend) { window.tfSend('community.view_hub', payload); }
+        })();
+        console.log(JSON.stringify(calls));
+    """
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    assert result.stdout.strip() == "[]"
+
+    script2 = """
+        var calls = [];
+        var window = {tfSend:function(ev,payload){calls.push([ev,payload]);}};
+        var document = {addEventListener:function(ev,fn){fn();}};
+        (function(){
+          var payload = {surface:'community', filter:'latest'};
+          if (window.tfSend) { window.tfSend('community.view_hub', payload); }
+        })();
+        console.log(JSON.stringify(calls));
+    """
+    result2 = subprocess.run(['node', '-e', script2], capture_output=True, text=True, check=True)
+    assert result2.stdout.strip() == '[["community.view_hub",{"surface":"community","filter":"latest"}]]'

--- a/coresite/tests/test_community_hub_copy_tokens.py
+++ b/coresite/tests/test_community_hub_copy_tokens.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+def test_community_hub_copy_and_tokens_guarded():
+    template = Path(__file__).resolve().parents[1] / "templates/coresite/community.html"
+    text = template.read_text()
+    assert "Technofatty Community" in text
+    assert (
+        "Get practical answers from peers and TF staff on growth, content, analytics, and tools." in text
+    )
+    tokens = [
+        "community.view_hub",
+        "cta.community.ask_question",
+        "cta.community.subscribe_updates",
+        "community.filter.latest",
+        "community.filter.unanswered",
+        "community.filter.tag",
+    ]
+    for tok in tokens:
+        assert tok in text

--- a/coresite/tests/test_sitemap_env_rules.py
+++ b/coresite/tests/test_sitemap_env_rules.py
@@ -1,0 +1,15 @@
+import importlib
+
+
+def test_sitemap_env_rules_respect_canonical_host(monkeypatch):
+    import coresite.tests.test_sitemap_validation as sm
+    monkeypatch.setenv("ENV", "production")
+    monkeypatch.setenv("CANONICAL_HOST", "example.com")
+    sm = importlib.reload(sm)
+    t = sm.SitemapValidationTest()
+    problems = []
+    t._validate_url("https://wrong.com/page/", set(), set(), problems)
+    assert any("Non-canonical host" in p for p in problems)
+    monkeypatch.setenv("ENV", "development")
+    monkeypatch.setenv("CANONICAL_HOST", "technofatty.com")
+    importlib.reload(sm)

--- a/docs/community-hub.md
+++ b/docs/community-hub.md
@@ -66,3 +66,9 @@ All community events include payload properties:
 
 Events are emitted only after consent; before consent, event senders must no-op.
 
+### Gating & Tests
+- Canonical URL and JSON-LD schema are regression-tested for stability.
+- Hero copy and analytics event tokens are snapshot-tested to guard accidental changes.
+- `community.view_hub` fires only when consent enables `tfSend`.
+- Sitemap validation honors `ENV`/`CANONICAL_HOST` environment variables.
+


### PR DESCRIPTION
## Summary
- add community hub regression tests
- document hub gating rules
- wire tests into CI

## Testing
- `pytest coresite/tests/test_community_hub.py coresite/tests/test_community_hub_copy_tokens.py coresite/tests/test_sitemap_env_rules.py` *(fails: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d4c78d10832aa1d8eaf525718fc4