### PR TITLE
Add consent-aware newsletter signup and post throttling

### DIFF
--- a/coresite/middleware.py
+++ b/coresite/middleware.py
@@ -1,5 +1,8 @@
 from django.conf import settings
 from django.core.signing import BadSignature
+from django.http import HttpResponse
+from django.core.cache import cache
+import re
 
 
 class ConsentMiddleware:
@@ -37,3 +40,48 @@ class StaticCacheControlMiddleware:
                 "Cache-Control", "public, max-age=31536000, immutable"
             )
         return response
+
+
+PENDING_POST_QUEUE = []
+
+
+class PostRateLimitMiddleware:
+    """Rate limit and link throttle for community posts.
+
+    - Limits posts to 1 per minute per user/IP.
+    - Users with fewer than 3 approved posts may include only one link.
+    - Unverified users' first posts are queued for moderation.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.method == "POST" and request.path.startswith("/community"):
+            user = getattr(request, "user", None)
+            identifier = (
+                getattr(user, "id", None)
+                if getattr(user, "is_authenticated", False)
+                else request.META.get("REMOTE_ADDR", "")
+            )
+            key = f"post:rate:{identifier}"
+            if cache.get(key):
+                return HttpResponse("Too many posts", status=429)
+            cache.set(key, 1, 60)
+
+            body = request.POST.get("body", "")
+            if getattr(user, "approved_posts", 0) < 3:
+                if len(re.findall(r"https?://", body)) > 1:
+                    return HttpResponse("Too many links", status=400)
+
+            if getattr(user, "approved_posts", 0) == 0 and not getattr(
+                user, "is_verified", False
+            ):
+                PENDING_POST_QUEUE.append({
+                    "user": user,
+                    "title": request.POST.get("title", ""),
+                    "body": body,
+                })
+                return HttpResponse("Post queued", status=202)
+
+        return self.get_response(request)

--- a/coresite/tests/test_post_middleware.py
+++ b/coresite/tests/test_post_middleware.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+
+from django.core.cache import cache
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+
+from coresite.middleware import PENDING_POST_QUEUE, PostRateLimitMiddleware
+
+
+def dummy_view(request):
+    return HttpResponse("ok")
+
+
+class PostRateLimitMiddlewareTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        PENDING_POST_QUEUE.clear()
+        self.factory = RequestFactory()
+        self.middleware = PostRateLimitMiddleware(dummy_view)
+
+    def test_rate_limit(self):
+        user = SimpleNamespace(is_authenticated=True, id=1, approved_posts=3, is_verified=True)
+        req1 = self.factory.post("/community/post/", {"body": "hi"})
+        req1.user = user
+        self.assertEqual(self.middleware(req1).status_code, 200)
+        req2 = self.factory.post("/community/post/", {"body": "hi"})
+        req2.user = user
+        self.assertEqual(self.middleware(req2).status_code, 429)
+
+    def test_link_throttle(self):
+        user = SimpleNamespace(is_authenticated=True, id=2, approved_posts=0, is_verified=True)
+        req = self.factory.post(
+            "/community/post/",
+            {"body": "http://a.com http://b.com"},
+        )
+        req.user = user
+        self.assertEqual(self.middleware(req).status_code, 400)
+
+    def test_queue_unverified_first_post(self):
+        user = SimpleNamespace(is_authenticated=True, id=3, approved_posts=0, is_verified=False)
+        req = self.factory.post("/community/post/", {"body": "hi", "title": "t"})
+        req.user = user
+        resp = self.middleware(req)
+        self.assertEqual(resp.status_code, 202)
+        self.assertEqual(len(PENDING_POST_QUEUE), 1)

--- a/newsletter/copy.py
+++ b/newsletter/copy.py
@@ -7,6 +7,7 @@ def get_copy() -> dict:
         "server_busy": "We’re having trouble right now. Try again in a few minutes.",
         "required_email": "Please enter your email address to subscribe.",
         "invalid_email": "Enter a valid email address (example: name@example.com).",
+        "consent": "By subscribing, you consent to receive emails from Technofatty. You can unsubscribe at any time.",
     }
     if getattr(settings, "OPT_IN_MODE", "single") == "double":
         copy["success"] = (

--- a/newsletter/templates/newsletter/confirm.html
+++ b/newsletter/templates/newsletter/confirm.html
@@ -1,0 +1,13 @@
+{% extends "coresite/base.html" %}
+
+{% block meta %}
+  {% with meta_title=page_title meta_robots=meta_robots %}
+    {% include "coresite/partials/seo/meta_head.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block content %}
+<h1>You're on the list</h1>
+<p>{{ message }}</p>
+{% endblock %}
+

--- a/newsletter/templates/newsletter/form.html
+++ b/newsletter/templates/newsletter/form.html
@@ -1,0 +1,24 @@
+{% extends "coresite/base.html" %}
+{% load static %}
+
+{% block meta %}
+  {% with meta_title=page_title meta_robots=meta_robots %}
+    {% include "coresite/partials/seo/meta_head.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block content %}
+<h1>Subscribe to the Newsletter</h1>
+<p>{{ copy.consent|default:"By subscribing, you consent to receive emails from Technofatty." }}</p>
+<form method="post" novalidate>
+  {% csrf_token %}
+  {{ form.non_field_errors }}
+  <div>
+    {{ form.email.label_tag }} {{ form.email }}
+    {% if form.email.errors %}<div class="error">{{ form.email.errors|striptags }}</div>{% endif %}
+  </div>
+  {{ form.website }}
+  <button type="submit">Subscribe</button>
+</form>
+{% endblock %}
+

--- a/newsletter/urls.py
+++ b/newsletter/urls.py
@@ -3,5 +3,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path("", views.newsletter_form, name="newsletter_form"),
     path("subscribe/", views.newsletter_subscribe, name="newsletter_subscribe"),
 ]

--- a/technofatty_com/settings.py
+++ b/technofatty_com/settings.py
@@ -108,6 +108,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "coresite.middleware.ConsentMiddleware",
+    "coresite.middleware.PostRateLimitMiddleware",
 ]
 
 if DEBUG:


### PR DESCRIPTION
## Summary
- Add dedicated newsletter signup form and confirmation pages with consent-aware copy
- Implement rate-limit and link-throttle middleware queuing unverified first posts
- Respect single/double opt-in via settings and mark newsletter pages as `noindex`

## Testing
- `python3 -m py_compile newsletter/views.py coresite/middleware.py newsletter/copy.py newsletter/tests.py coresite/tests/test_post_middleware.py technofatty_com/settings.py`
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ee2926b0832ab4042bbaed8f5955