### PR TITLE
Add tag descriptions and related content on tag pages

### DIFF
--- a/coresite/templates/coresite/blog_tag.html
+++ b/coresite/templates/coresite/blog_tag.html
@@ -1,15 +1,50 @@
 {% extends "coresite/base.html" %}
+{% load jsonld seo_tags %}
 
 {% block meta %}
   {% with meta_description="Posts tagged #"|add:page_title|add:"." %}
     {% include "coresite/partials/seo/meta_head.html" %}
   {% endwith %}
 {% endblock %}
-{% block structured_data %}{{ block.super }}{% endblock %}
+{% block structured_data %}
+  {{ block.super }}
+  {% canonical_url canonical_url as resolved_canonical %}
+  {% jsonld %}
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "CollectionPage",
+        "@id": "{{ resolved_canonical }}#webpage",
+        "url": "{{ resolved_canonical }}",
+        "name": "{{ page_title|escapejs }}",
+        "inLanguage": "en"
+      },
+      {
+        "@type": "BreadcrumbList",
+        "@id": "{{ resolved_canonical }}#breadcrumb",
+        "itemListElement": [
+          {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://technofatty.com/"},
+          {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://technofatty.com/blog/"},
+          {"@type": "ListItem", "position": 3, "name": "{{ page_title|escapejs }}", "item": "{{ resolved_canonical }}"}
+        ]
+      },
+      {
+        "@type": "ItemList",
+        "@id": "{{ resolved_canonical }}#list",
+        "itemListElement": [
+          {% for post in posts %}{"@type": "ListItem", "position": {{ forloop.counter }}, "url": "https://technofatty.com/blog/{{ post.slug }}/"}{% if not forloop.last %},{% endif %}{% endfor %}
+        ]
+      }
+    ]
+  }
+  {% endjsonld %}
+{% endblock %}
 {% block content %}
   <section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
     <div class="wrap">
       <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
+      {% if tag_description %}<p>{{ tag_description }}</p>{% endif %}
       <div class="scaffold__body">
           {% include "coresite/partials/global/status_placeholder.html" %}
         <p>Back to Blog</p>
@@ -32,6 +67,31 @@
           <a href="{{ next_page_url }}">Older posts</a>
         </nav>
         {% include "coresite/partials/newsletter_signup.html" %}
+        {% if related_content.knowledge or related_content.tools or related_content.case_studies %}
+        <section aria-labelledby="related-heading" class="related-content">
+          <h2 id="related-heading">Related across TF</h2>
+          <div class="related-groups">
+            {% for item in related_content.knowledge %}
+            <div class="related-card">
+              <span class="related-label">From Knowledge</span>
+              <a href="{{ item.url }}">{{ item.title }}</a>
+            </div>
+            {% endfor %}
+            {% for item in related_content.tools %}
+            <div class="related-card">
+              <span class="related-label">From Tools</span>
+              <a href="{{ item.url }}">{{ item.title }}</a>
+            </div>
+            {% endfor %}
+            {% for item in related_content.case_studies %}
+            <div class="related-card">
+              <span class="related-label">From Case Studies</span>
+              <a href="{{ item.url }}">{{ item.title }}</a>
+            </div>
+            {% endfor %}
+          </div>
+        </section>
+        {% endif %}
       </div>
     </div>
   </section>

--- a/coresite/tests/test_blog_tag_page.py
+++ b/coresite/tests/test_blog_tag_page.py
@@ -1,0 +1,35 @@
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from coresite.models import BlogPost, StatusChoices
+
+
+@pytest.mark.django_db
+def test_blog_tag_page_renders_description_cta_and_related(client, settings):
+    settings.SITE_BASE_URL = "https://technofatty.com"
+    BlogPost.objects.create(
+        title="Tag Post",
+        slug="tag-post",
+        status=StatusChoices.PUBLISHED,
+        excerpt="excerpt",
+        content="content",
+        published_at=timezone.now(),
+        category_slug="general",
+        category_title="General",
+        tags=[
+            {
+                "slug": "deployment",
+                "title": "Deployment",
+                "description": "About deployment",
+            }
+        ],
+    )
+
+    response = client.get(reverse("blog_tag", args=["deployment"]))
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "About deployment" in content
+    assert "Subscribe for short, useful tech & music tips" in content
+    assert "Related across TF" in content
+    assert '"@type": "ItemList"' in content
+    assert '<link rel="canonical" href="http://testserver/blog/tag/deployment/">' in content

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -882,14 +882,30 @@ def blog_tag(request, tag_slug: str):
         if any(t.get("slug") == tag_slug for t in p.tags)
     ]
     tag_title = tag_slug.replace("-", " ").title()
+    tag_description = ""
+    for post in posts:
+        for t in post.tags:
+            if t.get("slug") == tag_slug:
+                tag_description = t.get("description", "")
+                break
+        if tag_description:
+            break
+
+    related = {}
+    for key, items in RELATED_CONTENT_ITEMS.items():
+        filtered = [i for i in items if tag_slug in i["tags"]]
+        related[key] = filtered[:2] if key == "knowledge" else filtered[:1]
+
     context = {
         "footer": footer,
         "page_id": "blog-tag",
         "page_title": tag_title,
+        "tag_description": tag_description,
         "posts": posts,
         "next_page_url": "#",
         "prev_page_url": "#",
         "canonical_url": f"/blog/tag/{tag_slug}/",
+        "related_content": related,
     }
     return render(request, "coresite/blog_tag.html", context)
 


### PR DESCRIPTION
## Summary
- show tag descriptions and related content on blog tag pages
- output canonical ItemList JSON-LD for tag pages
- add regression test for tag page schema

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies requirement asgiref==3.8.1 (ProxyError 403))*

------
https://chatgpt.com/codex/tasks/task_e_68b1f10865f4832a80a85110629bbc9a