### PR TITLE
Add moderation dashboard, reporting queue, and CoC links

### DIFF
--- a/coresite/content/footer.json
+++ b/coresite/content/footer.json
@@ -16,7 +16,8 @@
       "label": "Company",
       "links": [
         {"label": "Privacy", "url": "/legal/privacy/"},
-        {"label": "Terms", "url": "/legal/terms/"}
+        {"label": "Terms", "url": "/legal/terms/"},
+        {"label": "Code of Conduct", "url": "/code-of-conduct/"}
       ]
     }
   ],

--- a/coresite/moderation.py
+++ b/coresite/moderation.py
@@ -1,0 +1,27 @@
+"""Simple in-memory moderation utilities."""
+
+from datetime import datetime
+
+REPORT_QUEUE = []
+AUDIT_LOG = []
+
+
+def log_action(user, action, target):
+    AUDIT_LOG.append(
+        {
+            "timestamp": datetime.utcnow(),
+            "user": getattr(user, "username", "anonymous"),
+            "action": action,
+            "target": target,
+        }
+    )
+
+
+def queue_report(user, target):
+    entry = {
+        "timestamp": datetime.utcnow(),
+        "user": getattr(user, "username", "anonymous"),
+        "target": target,
+    }
+    REPORT_QUEUE.append(entry)
+    log_action(user, "report", target)

--- a/coresite/templates/coresite/moderation_dashboard.html
+++ b/coresite/templates/coresite/moderation_dashboard.html
@@ -1,0 +1,25 @@
+{% extends "coresite/base.html" %}
+
+{% block content %}
+<section class="moderation-dashboard" aria-labelledby="mod-heading">
+  <div class="wrap">
+    <h1 id="mod-heading">Moderation Dashboard</h1>
+    <h2>Reports Queue</h2>
+    <ul>
+      {% for r in reports %}
+        <li>{{ r.timestamp }} – {{ r.target.type }} {{ r.target.id }} reported by {{ r.user }}</li>
+      {% empty %}
+        <li>No reports.</li>
+      {% endfor %}
+    </ul>
+    <h2>Audit Log</h2>
+    <ul>
+      {% for item in audit_log %}
+        <li>{{ item.timestamp }} – {{ item.user }} {{ item.action }} {{ item.target.type }} {{ item.target.id }}</li>
+      {% empty %}
+        <li>No actions logged.</li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>
+{% endblock %}

--- a/coresite/templates/coresite/thread.html
+++ b/coresite/templates/coresite/thread.html
@@ -55,7 +55,7 @@
   <div class="wrap">
     <article class="thread-question">
       <h1 id="thread-heading">{{ thread.title }}</h1>
-      <p class="post-meta"><span class="post-author">{{ thread.author }}</span> <span class="badge badge--op">OP</span></p>
+      <p class="post-meta"><span class="post-author">{{ thread.author }}</span> <span class="badge badge--op">OP</span> <a class="post-report" href="{% url 'community_report_thread' thread.slug %}">Report</a></p>
       <div class="post-body"><p>{{ thread.body }}</p></div>
     </article>
 
@@ -76,6 +76,7 @@
               <span class="post-author">{{ answer.author }}</span>
               {% if answer.is_staff %}<span class="badge badge--staff">Staff</span>{% endif %}
               {% if answer.author == thread.author %}<span class="badge badge--op">OP</span>{% endif %}
+              <a class="post-report" href="{% url 'community_report_answer' thread.slug answer.id %}">Report</a>
             </p>
             <div class="post-body"><p>{{ answer.body }}</p></div>
           </article>
@@ -98,6 +99,7 @@
       {% endif %}
     </nav>
     {% endif %}
+    <footer class="thread-footer"><a href="/code-of-conduct/">Code of Conduct</a></footer>
   </div>
 </section>
 {% endblock %}

--- a/coresite/tests/test_code_of_conduct_links.py
+++ b/coresite/tests/test_code_of_conduct_links.py
@@ -1,0 +1,4 @@
+def test_thread_page_has_code_of_conduct_link(client):
+    res = client.get('/community/t/deploy-technofatty/')
+    html = res.content.decode()
+    assert '/code-of-conduct/' in html

--- a/coresite/tests/test_moderation_reporting.py
+++ b/coresite/tests/test_moderation_reporting.py
@@ -1,0 +1,11 @@
+from coresite import moderation
+
+
+def test_report_thread_adds_to_queue(client):
+    moderation.REPORT_QUEUE.clear()
+    res = client.get('/community/t/deploy-technofatty/report/')
+    assert res.status_code == 302
+    assert len(moderation.REPORT_QUEUE) == 1
+    entry = moderation.REPORT_QUEUE[0]
+    assert entry['target']['type'] == 'thread'
+    assert entry['target']['id'] == 'deploy-technofatty'

--- a/coresite/urls.py
+++ b/coresite/urls.py
@@ -51,6 +51,13 @@ urlpatterns = [
     path("tools/<slug:slug>/", views.tool_detail, name="tool_detail"),
     path("community/", views.community, name="community"),
     path("community/t/<slug:slug>/", views.community_thread, name="community_thread"),
+    path("community/t/<slug:slug>/report/", views.report_thread, name="community_report_thread"),
+    path(
+        "community/t/<slug:slug>/a/<int:answer_id>/report/",
+        views.report_answer,
+        name="community_report_answer",
+    ),
+    path("community/moderation/", views.moderation_dashboard, name="moderation_dashboard"),
     path("blog/", views.blog, name="blog"),
     path("blog/rss/", BlogRSSFeed(), name="blog_rss"),
     path("blog/atom/", BlogAtomFeed(), name="blog_atom"),

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -26,6 +26,8 @@ from .signals import get_signals_content
 from .support import get_support_content
 from .community import get_community_content
 from .footer import get_footer_content
+from . import moderation
+from django.contrib.admin.views.decorators import staff_member_required
 
 
 KNOWLEDGE_SUB_SECTIONS = [
@@ -98,6 +100,15 @@ THREADS = [
         "answered": False,
         "author": "Ava",
     },
+    {
+        "title": "How do I contribute to Technofatty?",
+        "slug": "contribute-to-technofatty",
+        "tags": ["community"],
+        "replies": 1,
+        "updated": datetime(2024, 3, 5),
+        "answered": True,
+        "author": "Mia",
+    },
 ]
 
 RELATED_CONTENT_ITEMS = {
@@ -169,6 +180,22 @@ THREAD_DETAILS = {
                 "is_staff": False,
                 "accepted": False,
                 "created": datetime(2024, 2, 6),
+            }
+        ],
+    },
+    "contribute-to-technofatty": {
+        "title": "How do I contribute to Technofatty?",
+        "body": "I'd like to help. Where should I start?",
+        "author": "Mia",
+        "created": datetime(2024, 3, 1),
+        "answers": [
+            {
+                "id": 1,
+                "author": "Zoe",
+                "body": "Check out our CONTRIBUTING guide and join discussions in this community.",
+                "is_staff": True,
+                "accepted": True,
+                "created": datetime(2024, 3, 6),
             }
         ],
     },
@@ -776,6 +803,36 @@ def community_thread(request, slug: str):
     response = render(request, "coresite/thread.html", context)
     response["X-Robots-Tag"] = "noindex"
     return response
+
+
+def report_thread(request, slug: str):
+    """Queue a report for the thread and log it."""
+    moderation.queue_report(
+        request.user,
+        {"type": "thread", "id": slug},
+    )
+    return redirect("community_thread", slug=slug)
+
+
+def report_answer(request, slug: str, answer_id: int):
+    """Queue a report for a specific answer and log it."""
+    moderation.queue_report(
+        request.user,
+        {"type": "answer", "thread": slug, "id": answer_id},
+    )
+    return redirect("community_thread", slug=slug)
+
+
+@staff_member_required
+def moderation_dashboard(request):
+    """Simple staff-only dashboard listing reports and audit log."""
+    footer = get_footer_content()
+    context = {
+        "footer": footer,
+        "reports": moderation.REPORT_QUEUE,
+        "audit_log": moderation.AUDIT_LOG,
+    }
+    return render(request, "coresite/moderation_dashboard.html", context)
 
 
 def blog(request):


### PR DESCRIPTION
## Summary
- Add in-memory moderation utilities and staff-only dashboard for audit log and reports
- Seed new community thread with staff answer to highlight community culture
- Add report actions, link to Code of Conduct in thread view and global footer

## Testing
- `pytest` *(fails: fixture 'client' not found; pytest-django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f34957d4832a9334fde53c6e2e4e