### PR TITLE
Add event IDs for funnel tracking

### DIFF
--- a/coresite/templates/coresite/partials/global/analytics.html
+++ b/coresite/templates/coresite/partials/global/analytics.html
@@ -25,21 +25,24 @@
           window.console[kind](data);
         }
       }
+      function uid(){try{return crypto.randomUUID()}catch(e){return Date.now().toString(36)+Math.random().toString(36).slice(2);}}
       function send(n,m){
         if(!isActive())return;
         m=m||{};
+        var id=m.id||uid();
+        m.id=id;
         try{
           if(p==='plausible'&&window.plausible){
             window.plausible(n,{props:m});
-            log('info',{event:n,meta:m,provider:p,ok:true});
+            log('info',{id:id,event:n,meta:m,provider:p,ok:true});
           } else if(p==='ga4'&&window.gtag){
             window.gtag('event',n,m);
-            log('info',{event:n,meta:m,provider:p,ok:true});
+            log('info',{id:id,event:n,meta:m,provider:p,ok:true});
           } else {
-            log('warn',{event:n,meta:m,provider:p,ok:false,reason:'provider-missing'});
+            log('warn',{id:id,event:n,meta:m,provider:p,ok:false,reason:'provider-missing'});
           }
         } catch(e){
-          log('error',{event:n,meta:m,provider:p,ok:false,error:e.toString()});
+          log('error',{id:id,event:n,meta:m,provider:p,ok:false,error:e.toString()});
         }
       }
       if (isActive()) { window.tfSend = send; }

--- a/docs/analytics_events.md
+++ b/docs/analytics_events.md
@@ -1,5 +1,7 @@
 # Analytics Events
 
+Each event includes a unique `id` property used to stitch sessions into funnels. Events must only be sent after consent is granted.
+
 Event Name | Location | Business Goal
 --- | --- | ---
 `cta.nav.join` | Header primary CTA "Join Us" | Grow community membership
@@ -22,6 +24,10 @@ Event Name | Location | Business Goal
 `community.filter.latest` | Filter strip: Latest | Understand filter preference
 `community.filter.unanswered` | Filter strip: Unanswered | Track interest in unanswered threads
 `community.filter.tag` | Tag pill selection | Gauge tag-based navigation
+
+Required properties for every event:
+
+- `id` – UUID generated client-side for funnel analysis
 
 All `community.*` and `cta.community.*` events include payload properties:
 - `surface`: "community"

--- a/docs/funnel_dashboard.md
+++ b/docs/funnel_dashboard.md
@@ -1,0 +1,32 @@
+# Funnel Dashboard
+
+This dashboard visualises user journeys across the key events defined in `analytics_events.md`.
+
+## Data model
+
+Each analytics event includes an `id` and optional metadata. Store events in a table with at least:
+
+- `id` – event identifier
+- `name` – event name
+- `ts` – timestamp
+- `meta` – JSON payload
+
+The `id` lets you join consecutive events to reconstruct funnels.
+
+## Looker/Metabase setup
+
+1. Connect the events table to your BI tool.
+2. Create a funnel view with steps ordered by `ts` and grouped by `id`.
+3. Build visualisations for drop‑off between steps.
+4. Filter by properties in `meta` (e.g. `surface`, `position`).
+
+## Example SQL
+
+```sql
+select id, name, ts
+from events
+where name in ('cta.nav.join','form.newsletter.submit')
+order by ts;
+```
+
+This query can be the basis for funnels tracking sign‑up journeys.


### PR DESCRIPTION
## Summary
- document required `id` property and consent expectations for analytics events
- log unique IDs in frontend analytics helper
- add funnel dashboard instructions for Looker/Metabase

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68b29c38ddf0832aba0e0bad6b8787e6