### PR TITLE
Add meta tag length checks and case study breadcrumbs

### DIFF
--- a/coresite/templates/coresite/case_studies/detail.html
+++ b/coresite/templates/coresite/case_studies/detail.html
@@ -10,14 +10,37 @@
 {% block structured_data %}
   {{ block.super }}
   {% canonical_url canonical_url as resolved_canonical %}
+  {% canonical_url '/' as site_base_url %}
+  {% canonical_url '/case-studies/' as case_studies_url %}
   {% jsonld %}
   {
     "@context": "https://schema.org",
-    "@type": "Article",
-    "headline": "{{ case_study.title|escapejs }}",
-    "url": "{{ resolved_canonical }}",
-    "dateModified": "{{ case_study.updated_at|date:'c' }}"{% if case_study.image %},
-    "image": "{{ case_study.image.url|escapejs }}"{% endif %}
+    "@graph": [
+      {
+        "@type": "Article",
+        "@id": "{{ resolved_canonical }}#article",
+        "headline": "{{ case_study.title|escapejs }}",
+        "inLanguage": "en",
+        "url": "{{ resolved_canonical }}",
+        "datePublished": "{{ case_study.created_at|date:'c' }}",
+        "dateModified": "{{ case_study.updated_at|date:'c' }}"{% if case_study.image %},
+        "image": {
+          "@type": "ImageObject",
+          "url": "{{ case_study.image.url|escapejs }}"{% if case_study.image.width and case_study.image.height %},
+          "width": {{ case_study.image.width }},
+          "height": {{ case_study.image.height }}{% endif %}
+        }{% endif %}
+      },
+      {
+        "@type": "BreadcrumbList",
+        "@id": "{{ resolved_canonical }}#breadcrumb",
+        "itemListElement": [
+          {"@type": "ListItem", "position": 1, "name": "Home", "item": "{{ site_base_url }}"},
+          {"@type": "ListItem", "position": 2, "name": "Case Studies", "item": "{{ case_studies_url }}"},
+          {"@type": "ListItem", "position": 3, "name": "{{ case_study.title|escapejs }}", "item": "{{ resolved_canonical }}"}
+        ]
+      }
+    ]
   }
   {% endjsonld %}
 {% endblock %}
@@ -25,6 +48,13 @@
 {% block content %}
 <section class="section section--scaffold" aria-labelledby="{{ page_id }}-heading">
   <div class="wrap">
+    <nav class="breadcrumbs" aria-label="Breadcrumb">
+      <ol>
+        <li><a href="/">Home</a></li>
+        <li><a href="/case-studies/">Case Studies</a></li>
+        <li aria-current="page">{{ case_study.title }}</li>
+      </ol>
+    </nav>
     <h1 id="{{ page_id }}-heading">{{ case_study.title }}</h1>
     <div class="scaffold__body">
       {% include "coresite/partials/global/status_placeholder.html" %}

--- a/coresite/templates/coresite/partials/seo/meta_head.html
+++ b/coresite/templates/coresite/partials/seo/meta_head.html
@@ -1,27 +1,31 @@
 {# See docs/structured-data.md#seo-meta_head for context keys #}
 {% load seo_tags %}
 {% canonical_url canonical_url as resolved_canonical %}
-{% if meta_title %}
-<title>{{ meta_title }}</title>
-<meta property="og:title" content="{{ meta_title }}">
-<meta name="twitter:title" content="{{ meta_title }}">
-{% elif page_title %}{% with full_title=page_title|add:' | Technofatty' %}
-<title>{{ full_title }}</title>
-<meta property="og:title" content="{{ full_title }}">
-<meta name="twitter:title" content="{{ full_title }}">
+{% if meta_title %}{% with mt=meta_title|truncatechars:60 %}
+<title>{{ mt }}</title>
+<meta property="og:title" content="{{ mt }}">
+<meta name="twitter:title" content="{{ mt }}">
 {% endwith %}
+{% elif page_title %}{% with full_title=page_title|add:' | Technofatty' %}{% with mt=full_title|truncatechars:60 %}
+<title>{{ mt }}</title>
+<meta property="og:title" content="{{ mt }}">
+<meta name="twitter:title" content="{{ mt }}">
+{% endwith %}{% endwith %}
 {% else %}
 <title>Technofatty</title>
 <meta property="og:title" content="Technofatty">
 <meta name="twitter:title" content="Technofatty">
 {% endif %}
-{% with desc=meta_description|default:"Tech resources and community." %}
+{% with desc=meta_description|default:"Tech resources and community."|truncatechars:155 %}
 <meta name="description" content="{{ desc }}">
 <meta property="og:description" content="{{ desc }}">
 <meta name="twitter:description" content="{{ desc }}">
 {% endwith %}
 {% if meta_robots %}<meta name="robots" content="{{ meta_robots }}">{% endif %}
 <link rel="canonical" href="{{ resolved_canonical }}">
+{% if request and request.build_absolute_uri != resolved_canonical %}
+<!-- canonical-mismatch -->
+{% endif %}
 <meta property="og:url" content="{{ resolved_canonical }}">
 <meta property="og:type" content="{{ og_type|default:'website' }}">
 <meta property="og:site_name" content="Technofatty">

--- a/coresite/tests/test_case_studies_pages.py
+++ b/coresite/tests/test_case_studies_pages.py
@@ -38,7 +38,12 @@ def test_case_study_detail_page(client):
     )
     assert res["X-Robots-Tag"] == expected
     assert f'<h1 id="case-study-detail-heading">{study.title}</h1>' in html
+    assert '<nav class="breadcrumbs"' in html
     assert '"@type": "Article"' in html
+    assert '"@type": "BreadcrumbList"' in html
+    assert '"inLanguage": "en"' in html
+    assert '"datePublished":' in html
+    assert 'http://testserver/case-studies/' in html
 
 
 @pytest.mark.django_db

--- a/coresite/tests/test_meta_head.py
+++ b/coresite/tests/test_meta_head.py
@@ -1,0 +1,38 @@
+import re
+from django.template import Template, Context
+from django.test import RequestFactory, override_settings
+
+
+def render_meta(context):
+    tpl = Template("{% include 'coresite/partials/seo/meta_head.html' %}")
+    return tpl.render(Context(context))
+
+
+def test_meta_title_description_truncated():
+    long_title = 'T' * 80
+    long_desc = 'D' * 200
+    html = render_meta({'meta_title': long_title, 'meta_description': long_desc, 'canonical_url': '/foo/'})
+    title_match = re.search(r"<title>(.*?)</title>", html)
+    assert title_match
+    assert len(title_match.group(1)) <= 60
+    desc_match = re.search(r'<meta name="description" content="(.*?)">', html)
+    assert desc_match
+    assert len(desc_match.group(1)) <= 155
+
+
+@override_settings(SITE_BASE_URL="https://technofatty.com")
+def test_canonical_matches_request():
+    rf = RequestFactory()
+    request = rf.get('/foo/', secure=True, HTTP_HOST='technofatty.com')
+    html = render_meta({'canonical_url': '/foo/', 'request': request})
+    assert '<link rel="canonical" href="https://technofatty.com/foo/">' in html
+    assert '<!-- canonical-mismatch -->' not in html
+
+
+@override_settings(SITE_BASE_URL="https://technofatty.com")
+def test_canonical_mismatch_emits_comment():
+    rf = RequestFactory()
+    request = rf.get('/foo/', secure=True, HTTP_HOST='technofatty.com')
+    html = render_meta({'canonical_url': '/bar/', 'request': request})
+    assert '<link rel="canonical" href="https://technofatty.com/bar/">' in html
+    assert '<!-- canonical-mismatch -->' in html


### PR DESCRIPTION
## Summary
- enforce 155-character cap on shared meta descriptions
- use site base URL for breadcrumb JSON-LD and enrich Article schema with language, publish date, and image metadata
- expand tests to cover canonical mismatches and schema details

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

## Notes
- Internal link auditing between case studies and other site sections is still pending and should be addressed separately.


------
https://chatgpt.com/codex/tasks/task_e_68b2a1b73ff0832aa1949a94736a5b10