### PR TITLE
docs: add performance baseline and budget check

### DIFF
--- a/docs/performance/baseline.md
+++ b/docs/performance/baseline.md
@@ -1,0 +1,18 @@
+# Performance Baseline
+
+This document records baseline performance metrics and target budgets for the project.
+
+## Baseline Metrics
+- Bootstrap CSS (`node_modules/bootstrap/dist/css/bootstrap.min.css`): 232,111 bytes (~227 KB)
+- Bootstrap JS (`node_modules/bootstrap/dist/js/bootstrap.bundle.min.js`): 80,496 bytes (~79 KB)
+
+## Target Budgets
+- CSS bundle size ≤ 250 KB
+- JavaScript bundle size ≤ 90 KB
+- Image assets per page ≤ 300 KB total
+
+## Asset Checklist
+- Provide explicit width and height for images to avoid layout shifts.
+- Use `loading="lazy"` for images below the initial viewport.
+- Apply spacing using design tokens (`--space-1` … `--space-8`) instead of hard-coded values.
+

--- a/scripts/check_budgets.sh
+++ b/scripts/check_budgets.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+CSS_FILE="node_modules/bootstrap/dist/css/bootstrap.min.css"
+JS_FILE="node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
+
+CSS_SIZE=$(stat -c%s "$CSS_FILE")
+JS_SIZE=$(stat -c%s "$JS_FILE")
+
+MAX_CSS=$((250 * 1024))
+MAX_JS=$((90 * 1024))
+
+if [ "$CSS_SIZE" -gt "$MAX_CSS" ]; then
+  echo "::warning file=$CSS_FILE::CSS bundle size exceeds budget (${CSS_SIZE} bytes > ${MAX_CSS} bytes)"
+fi
+
+if [ "$JS_SIZE" -gt "$MAX_JS" ]; then
+  echo "::warning file=$JS_FILE::JS bundle size exceeds budget (${JS_SIZE} bytes > ${MAX_JS} bytes)"
+fi


### PR DESCRIPTION
## Summary
- document baseline asset sizes and budgets
- add budget check script for CSS/JS bundles
- remove performance GitHub workflow per review feedback

## Testing
- `bash scripts/check_budgets.sh`
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68b2aae16984832a871bdb37c6787add