### PR TITLE
docs: track Python runtime and schedule upgrade reminders

### DIFF
--- a/.github/workflows/python-runtime-reminder.yml
+++ b/.github/workflows/python-runtime-reminder.yml
@@ -1,0 +1,31 @@
+name: Python runtime upgrade reminder
+
+on:
+  schedule:
+    - cron: '0 9 1 * *'
+  workflow_dispatch:
+
+jobs:
+  open-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create or reopen reminder issue
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueTitle = 'Review Python runtime upgrade plan';
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+            });
+            const exists = issues.find(issue => issue.title === issueTitle);
+            if (!exists) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: issueTitle,
+                body: 'Python 3.8 EOL is October 2024. Revisit the plan to upgrade to Python 3.12.',
+              });
+            }

--- a/docs/ops/python-runtime.md
+++ b/docs/ops/python-runtime.md
@@ -1,0 +1,25 @@
+# Python Runtime Strategy
+
+## Current Version
+- Production runtime: **Python 3.8**
+- Official end-of-life: **October 2024** (per [PEP 569](https://peps.python.org/pep-0569/))
+
+## Rationale for Deferral
+- Key dependencies have not yet released Python 3.12–compatible versions.
+- Upgrade would require coordinated testing across multiple services.
+- Available engineering time is prioritized for feature delivery until EOL nears.
+
+## Recurring Review
+A scheduled GitHub Action creates an issue on the first of each month reminding the team to revisit the upgrade plan. The reminder continues until Python 3.8 reaches end-of-life.
+
+## Path to Python 3.12
+1. **Dependency Audit** – catalog all runtime and build dependencies and confirm 3.12 support.
+2. **Staging Validation** – deploy the upgraded stack to staging with representative data and traffic.
+3. **Rollback Preparedness** – document and test procedures to revert to 3.8 if critical regressions surface.
+
+## Next Steps
+- Monitor dependency roadmaps and unblock upgrades as 3.12 compatibility lands.
+- Follow reminders to reassess readiness at least monthly.
+- Target production rollout ahead of the October 2024 EOL to retain support coverage.
+
+- Capture lessons learned after the upgrade to inform future runtime transitions.


### PR DESCRIPTION
## Summary
- document current Python 3.8 runtime, EOL in Oct 2024, and prerequisites for moving to 3.12
- add monthly GitHub Action that opens an issue reminding the team to revisit the upgrade plan

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b2bb213254832ab96adf6e45d5edc4