### PR TITLE
docs: add content production workflow

### DIFF
--- a/docs/content-production-workflow.md
+++ b/docs/content-production-workflow.md
@@ -1,0 +1,57 @@
+# Content Production Workflow
+
+## 1. Draft
+- **Responsible roles**
+  - Author or copywriter
+  - Subject matter expert (for technical content)
+- **Artifacts & activities**
+  - Content brief, outline, or creative brief
+  - Drafting checklist (research sources, tone/voice, length, fact accuracy)
+  - Versioning: create an initial version (v0.1) in a shared doc or version-control system (e.g., Git, CMS draft)
+  - Informal approvals from SMEs before formal review
+
+## 2. Review
+- **Responsible roles**
+  - Editor (copy/editing, style)
+  - Legal/compliance reviewer (if required)
+  - Stakeholder or manager approval
+- **Artifacts & activities**
+  - Editorial checklist (grammar, style guide adherence, inclusive language, links)
+  - Track changes/comments or pull requests for revision history
+  - Formal approval record (signed-off checklist or workflow ticket)
+  - Version bump (v0.2, v0.3) after edits and approvals
+
+## 3. SEO Optimization
+- **Responsible roles**
+  - SEO specialist or digital marketer
+  - Author/editor collaboration for revisions
+- **Artifacts & activities**
+  - Keyword research document and target keyword list
+  - On-page SEO checklist (meta title/description, headers, alt text, internal/external links)
+  - SEO approval in workflow tool
+  - Version update reflecting SEO changes (v0.4)
+
+## 4. Publish
+- **Responsible roles**
+  - Content manager or CMS administrator
+  - Editor for final proof
+  - Product/brand owner for go-live authorization
+- **Artifacts & activities**
+  - Final content version (v1.0)
+  - Pre-publish checklist (formatting, cross-browser check, mobile readiness, accessibility)
+  - Approval log or release ticket
+  - Publication notes: URL slug, publish date/time, tags/categories
+
+## 5. Analytics & Post-Publish
+- **Responsible roles**
+  - Marketing analyst or growth manager
+  - Content manager for iterative updates
+- **Artifacts & activities**
+  - Analytics dashboard setup (traffic, engagement, conversions)
+  - KPI checklist (page views, time on page, bounce rate, conversions)
+  - Versioning for post-publish revisions (v1.1, v1.2) with change logs
+  - Performance reports and insights for future content planning
+
+---
+
+This workflow moves from creation to review, optimization, publication, and performance tracking. Each phase assigns clear roles, requires specific artifacts (checklists, approvals, version numbers), and maintains traceable history. This approach ensures quality, alignment with strategy, SEO effectiveness, and continuous improvement after release.


### PR DESCRIPTION
## Summary
- document content production workflow from drafting to analytics

## Testing
- `pytest coresite/tests/test_account_workflow.py -q` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68b2c6f1ce98832aa87b0accdb936a35