### PR TITLE
Add standard content template for contributors

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Knowledge (content system) → `knowledge.md`
 Blog (editorial tie-ins) → `blog.md`  
 Telemetry & data layer → `telemetry.md`  
 PR & release hygiene → `pr-playbook.md`
+Content template → `content-template.md`
 
 ## How to use this folder
 Capture ideas as they surface. Link them across docs rather than duplicating. Prefer small, frequent commits that keep rationale next to decisions.

--- a/docs/content-template.md
+++ b/docs/content-template.md
@@ -1,0 +1,34 @@
+# Standard Content Template
+
+Use this template for all contributor content. Copy the headings and fill in each field before submitting a draft.
+
+---
+
+## Headline
+- Max 60 characters.
+- Outcome-focused and written in plain language.
+
+## Excerpt
+- 1–2 sentence summary (≤155 characters).
+- Appears in listings, social cards, and meta description.
+
+## Featured Image Alt Text
+- Describes the key visual for screen readers (≤125 characters).
+- Avoid "image of…"; explain the meaning or action.
+
+## Citations
+1. [Source name](URL) – brief note.
+2. ...
+
+## Calls to Action (CTAs)
+- Primary: `[Text](URL)`
+- Secondary: `[Text](URL)` *(optional)*
+
+## Meta Fields
+- **Meta title** – defaults to headline if ≤60 chars.
+- **Meta description** – extended excerpt (≤155 chars).
+- **Meta tags** – comma-separated keywords.
+
+---
+
+Save completed drafts in the repository as `YYYY-MM-DD-slug.md` in the appropriate folder.


### PR DESCRIPTION
## Summary
- add shared content template covering headline, excerpt, alt text, citations, CTAs, and meta fields
- document template location in docs README

## Testing
- `pytest` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cd81b74c832ab2f641eb29aab4a0