### PR TITLE
Ensure blog post slugs are normalized and unique

### DIFF
--- a/coresite/tests/test_blogpost_model.py
+++ b/coresite/tests/test_blogpost_model.py
@@ -1,0 +1,19 @@
+import pytest
+
+from coresite.models import BlogPost
+
+
+@pytest.mark.django_db
+def test_blogpost_slug_autogenerates_and_uniquifies():
+    p1 = BlogPost.objects.create(title="My Post")
+    p2 = BlogPost.objects.create(title="My Post")
+    assert p1.slug == "my-post"
+    assert p2.slug == "my-post-1"
+
+
+@pytest.mark.django_db
+def test_blogpost_manual_slug_normalised_and_uniquified():
+    p1 = BlogPost.objects.create(title="First", slug="Custom Slug")
+    p2 = BlogPost.objects.create(title="Second", slug="Custom Slug")
+    assert p1.slug == "custom-slug"
+    assert p2.slug == "custom-slug-1"


### PR DESCRIPTION
## Summary
- normalize and uniquify blog post slugs on save
- add tests covering automatic slug generation and collisions

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest coresite/tests/test_blogpost_model.py -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b2d0bfd4c8832a9910d8ea26aa619b