### PR TITLE
Add reusable blog JSON-LD template and tests

### DIFF
--- a/coresite/templates/coresite/blog_detail.html
+++ b/coresite/templates/coresite/blog_detail.html
@@ -12,48 +12,7 @@
 {% block structured_data %}
   {{ block.super }}
   {% canonical_url canonical_url as resolved_canonical %}
-  {% jsonld %}
-{
-  "@context": "https://schema.org",
-  "@graph": [
-    {
-      "@type": "BlogPosting",
-      "@id": "{{ resolved_canonical }}#article",
-      "mainEntityOfPage": {
-        "@type": "WebPage",
-        "@id": "{{ resolved_canonical }}#webpage"
-      },
-      "headline": "{{ post.title|escapejs }}",
-      "url": "{{ resolved_canonical }}",
-      "datePublished": "{{ post.date|date:'c' }}",
-      "dateModified": "{{ post.updated|default:post.date|date:'c' }}",
-      "author": {
-        "@type": "Organization",
-        "@id": "https://technofatty.com/#organization",
-        "name": "Technofatty",
-        "url": "https://technofatty.com/"
-      },
-      "publisher": {
-        "@type": "Organization",
-        "@id": "https://technofatty.com/#organization",
-        "name": "Technofatty",
-        "url": "https://technofatty.com/"
-      },
-      "description": "{{ post.excerpt|default:'A blog post on Technofatty.'|escapejs }}",
-      "inLanguage": "en"
-    },
-    {
-      "@type": "BreadcrumbList",
-      "@id": "{{ resolved_canonical }}#breadcrumb",
-      "itemListElement": [
-        {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://technofatty.com/"},
-        {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://technofatty.com/blog/"},
-        {"@type": "ListItem", "position": 3, "name": "{{ post.title|escapejs }}", "item": "{{ resolved_canonical }}"}
-      ]
-    }
-  ]
-}
-  {% endjsonld %}
+  {% include "coresite/partials/seo/blog_post_jsonld.html" with post=post canonical_url=resolved_canonical %}
 {% endblock %}
 
 {% block content %}

--- a/coresite/templates/coresite/partials/seo/blog_post_jsonld.html
+++ b/coresite/templates/coresite/partials/seo/blog_post_jsonld.html
@@ -1,0 +1,43 @@
+{% load jsonld %}
+{% jsonld %}
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "BlogPosting",
+      "@id": "{{ canonical_url }}#article",
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "{{ canonical_url }}#webpage"
+      },
+      "headline": "{{ post.title|escapejs }}",
+      "url": "{{ canonical_url }}",
+      "datePublished": "{{ post.date|date:'c' }}",
+      "dateModified": "{{ post.updated|default:post.date|date:'c' }}",
+      "author": {
+        "@type": "Organization",
+        "@id": "https://technofatty.com/#organization",
+        "name": "Technofatty",
+        "url": "https://technofatty.com/"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "@id": "https://technofatty.com/#organization",
+        "name": "Technofatty",
+        "url": "https://technofatty.com/"
+      },
+      "description": "{{ post.excerpt|default:'A blog post on Technofatty.'|escapejs }}",
+      "inLanguage": "en"
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "{{ canonical_url }}#breadcrumb",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://technofatty.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://technofatty.com/blog/"},
+        {"@type": "ListItem", "position": 3, "name": "{{ post.title|escapejs }}", "item": "{{ canonical_url }}"}
+      ]
+    }
+  ]
+}
+{% endjsonld %}

--- a/docs/structured-data.md
+++ b/docs/structured-data.md
@@ -182,6 +182,11 @@ This document lists required and optional context dictionary keys for each templ
 - Required: canonical_url
 - Optional: page_title, meta_description, og_type, og_image_url
 
+<a id="seo-blog_post_jsonld"></a>
+### seo/blog_post_jsonld.html
+- Required: post, canonical_url
+- Optional: None
+
 <a id="seo-structured_data"></a>
 ### seo/structured_data.html
 - Required: None

--- a/tests/fixtures/blog_post.html
+++ b/tests/fixtures/blog_post.html
@@ -5,15 +5,41 @@
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
-  "@type": "BlogPosting",
-  "url": "https://example.com/blog/my-post",
-  "datePublished": "2024-05-01T10:00:00+00:00",
-  "dateModified": "2024-05-02T12:00:00+00:00",
-  "author": {
-    "@type": "Person",
-    "name": "Alice",
-    "url": "https://example.com/authors/alice"
-  }
+  "@graph": [
+    {
+      "@type": "BlogPosting",
+      "@id": "https://example.com/blog/my-post#article",
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "https://example.com/blog/my-post#webpage"
+      },
+      "headline": "Blog Post",
+      "url": "https://example.com/blog/my-post",
+      "datePublished": "2024-05-01T10:00:00+00:00",
+      "dateModified": "2024-05-02T12:00:00+00:00",
+      "author": {
+        "@type": "Organization",
+        "name": "Example",
+        "url": "https://example.com/"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "Example",
+        "url": "https://example.com/"
+      },
+      "description": "Sample post excerpt",
+      "inLanguage": "en"
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://example.com/blog/my-post#breadcrumb",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://example.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://example.com/blog/"},
+        {"@type": "ListItem", "position": 3, "name": "Blog Post", "item": "https://example.com/blog/my-post"}
+      ]
+    }
+  ]
 }
 </script>
 </head>

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -124,3 +124,17 @@ def test_case_study_detail_schema(case_study_json):
     assert case_study_json["@type"] == "Article"
     assert case_study_json["url"] == "https://example.com/case-studies/acme"
     assert case_study_json["publisher"]["@type"] == "Organization"
+
+
+@pytest.fixture
+def blog_post_json():
+    html = (FIXTURES_DIR / "blog_post.html").read_text()
+    return _extract_json(html)
+
+
+def test_blog_post_schema(blog_post_json):
+    graph = {item["@type"]: item for item in blog_post_json["@graph"]}
+    post = graph["BlogPosting"]
+    breadcrumb = graph["BreadcrumbList"]
+    assert post["url"] == "https://example.com/blog/my-post"
+    assert breadcrumb["itemListElement"][2]["item"] == "https://example.com/blog/my-post"


### PR DESCRIPTION
## Summary
- refactor blog detail to use a reusable JSON-LD partial with breadcrumbs
- document required context for the new partial
- add tests validating BlogPosting schema and breadcrumbs

## Testing
- `pytest tests/test_jsonld.py tests/validate_schema.py tests/test_jsonld_tag_urls.py -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b2d914d2e8832a917dbfb28f7a7dfa