### PR TITLE
Add SEO meta fields to BlogPost

### DIFF
--- a/coresite/migrations/0013_blogpost_meta_fields.py
+++ b/coresite/migrations/0013_blogpost_meta_fields.py
@@ -1,0 +1,40 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("coresite", "0012_alpha_beta_case_studies"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="blogpost",
+            name="slug",
+            field=models.SlugField(blank=True, unique=True),
+        ),
+        migrations.AddField(
+            model_name="blogpost",
+            name="meta_title",
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AddField(
+            model_name="blogpost",
+            name="meta_description",
+            field=models.TextField(blank=True),
+        ),
+        migrations.AddField(
+            model_name="blogpost",
+            name="canonical_url",
+            field=models.URLField(blank=True),
+        ),
+        migrations.AddField(
+            model_name="blogpost",
+            name="og_image_url",
+            field=models.URLField(blank=True),
+        ),
+        migrations.AddField(
+            model_name="blogpost",
+            name="twitter_image_url",
+            field=models.URLField(blank=True),
+        ),
+    ]

--- a/coresite/templates/coresite/blog_detail.html
+++ b/coresite/templates/coresite/blog_detail.html
@@ -2,7 +2,7 @@
 {% load jsonld seo_tags %}
 
 {% block meta %}
-  {% with meta_description=post.excerpt|default:'A blog post on Technofatty.' og_type='article' %}
+  {% with meta_title=post.meta_title meta_description=post.meta_description|default:post.excerpt|default:'A blog post on Technofatty.' og_type='article' og_image_url=post.og_image_url %}
     {% include "coresite/partials/seo/meta_head.html" %}
   {% endwith %}
   {% if post.date %}<meta property="article:published_time" content="{{ post.date|date:'c' }}">{% endif %}

--- a/coresite/templates/coresite/partials/seo/blog_post_jsonld.html
+++ b/coresite/templates/coresite/partials/seo/blog_post_jsonld.html
@@ -10,7 +10,7 @@
         "@type": "WebPage",
         "@id": "{{ canonical_url }}#webpage"
       },
-      "headline": "{{ post.title|escapejs }}",
+      "headline": "{{ post.meta_title|default:post.title|escapejs }}",
       "url": "{{ canonical_url }}",
       "datePublished": "{{ post.date|date:'c' }}",
       "dateModified": "{{ post.updated|default:post.date|date:'c' }}",
@@ -26,7 +26,7 @@
         "name": "Technofatty",
         "url": "https://technofatty.com/"
       },
-      "description": "{{ post.excerpt|default:'A blog post on Technofatty.'|escapejs }}",
+      "description": "{{ post.meta_description|default:post.excerpt|default:'A blog post on Technofatty.'|escapejs }}",
       "inLanguage": "en"
     },
     {

--- a/coresite/tests/test_blog_tag_page.py
+++ b/coresite/tests/test_blog_tag_page.py
@@ -23,6 +23,10 @@ def test_blog_tag_page_renders_description_cta_and_related(client, settings):
                 "description": "About deployment",
             }
         ],
+        meta_title="Tag Post",
+        meta_description="Desc",
+        og_image_url="https://example.com/og.png",
+        twitter_image_url="https://example.com/tw.png",
     )
 
     response = client.get(reverse("blog_tag", args=["deployment"]))

--- a/coresite/tests/test_blogpost_model.py
+++ b/coresite/tests/test_blogpost_model.py
@@ -1,6 +1,8 @@
 import pytest
+from django.core.exceptions import ValidationError
+from django.utils import timezone
 
-from coresite.models import BlogPost
+from coresite.models import BlogPost, StatusChoices
 
 
 @pytest.mark.django_db
@@ -17,3 +19,18 @@ def test_blogpost_manual_slug_normalised_and_uniquified():
     p2 = BlogPost.objects.create(title="Second", slug="Custom Slug")
     assert p1.slug == "custom-slug"
     assert p2.slug == "custom-slug-1"
+
+
+@pytest.mark.django_db
+def test_published_blogpost_requires_meta_fields():
+    post = BlogPost(
+        title="Needs Meta",
+        status=StatusChoices.PUBLISHED,
+        published_at=timezone.now(),
+    )
+    with pytest.raises(ValidationError) as excinfo:
+        post.full_clean()
+    assert "meta_title" in excinfo.value.message_dict
+    assert "meta_description" in excinfo.value.message_dict
+    assert "og_image_url" in excinfo.value.message_dict
+    assert "twitter_image_url" in excinfo.value.message_dict

--- a/coresite/tests/test_feeds.py
+++ b/coresite/tests/test_feeds.py
@@ -17,6 +17,10 @@ def test_blog_rss_feed(client):
         slug="test-post",
         status=StatusChoices.PUBLISHED,
         published_at=timezone.now(),
+        meta_title="Test Post",
+        meta_description="Desc",
+        og_image_url="https://example.com/og.png",
+        twitter_image_url="https://example.com/tw.png",
     )
     response = client.get(reverse("blog_rss"))
     assert response.status_code == 200
@@ -31,6 +35,10 @@ def test_blog_atom_feed(client):
         slug="atom-post",
         status=StatusChoices.PUBLISHED,
         published_at=timezone.now(),
+        meta_title="Atom Post",
+        meta_description="Desc",
+        og_image_url="https://example.com/og.png",
+        twitter_image_url="https://example.com/tw.png",
     )
     response = client.get(reverse("blog_atom"))
     assert response.status_code == 200
@@ -44,6 +52,10 @@ def test_blog_json_feed(client):
         slug="json-post",
         status=StatusChoices.PUBLISHED,
         published_at=timezone.now(),
+        meta_title="JSON Post",
+        meta_description="Desc",
+        og_image_url="https://example.com/og.png",
+        twitter_image_url="https://example.com/tw.png",
     )
     response = client.get(reverse("blog_json"))
     assert response.status_code == 200

--- a/coresite/tests/test_related_discussions.py
+++ b/coresite/tests/test_related_discussions.py
@@ -55,6 +55,10 @@ def test_related_discussions_on_blog_post(client):
         category_slug="general",
         category_title="General",
         tags=[{"slug": "deployment", "title": "Deployment"}],
+        meta_title="Tag Post",
+        meta_description="Desc",
+        og_image_url="https://example.com/og.png",
+        twitter_image_url="https://example.com/tw.png",
     )
     res = client.get(reverse("blog_post", args=[post.slug]))
     assert "Related discussions" in res.content.decode()

--- a/coresite/tests/test_schema_ids.py
+++ b/coresite/tests/test_schema_ids.py
@@ -18,6 +18,10 @@ def test_blog_post_schema_ids(client, db):
         slug="test-post",
         status=StatusChoices.PUBLISHED,
         published_at=timezone.now(),
+        meta_title="Test Post",
+        meta_description="Desc",
+        og_image_url="https://example.com/og.png",
+        twitter_image_url="https://example.com/tw.png",
     )
     resp = client.get("/blog/test-post/")
     assert resp.status_code == 200

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -963,7 +963,7 @@ def blog_post(request, post_slug: str):
         "page_id": "post",
         "page_title": post["title"],
         "post": post,
-        "canonical_url": f"/blog/{post_slug}/",
+        "canonical_url": post.canonical_url,
         "related_discussions": _related_threads(tags),
     }
     return render(request, "coresite/blog_detail.html", context)


### PR DESCRIPTION
## Summary
- add meta title, description, canonical URL, and OG/Twitter image URLs to `BlogPost`
- validate SEO fields on published posts and generate canonical URLs
- surface metadata in blog templates and structured data

## Testing
- `python manage.py makemigrations coresite` *(fails: No module named 'django')*
- `pytest` *(fails: No module named 'django')*
- `python -m py_compile coresite/models.py coresite/views.py coresite/tests/test_feeds.py coresite/tests/test_related_discussions.py coresite/tests/test_blog_tag_page.py coresite/tests/test_schema_ids.py coresite/tests/test_blogpost_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2dd73d834832abbeedcdaf26b64b1