### PR TITLE
Add breadcrumbs to blog posts

### DIFF
--- a/coresite/templates/coresite/blog_detail.html
+++ b/coresite/templates/coresite/blog_detail.html
@@ -12,7 +12,7 @@
 {% block structured_data %}
   {{ block.super }}
   {% canonical_url canonical_url as resolved_canonical %}
-  {% include "coresite/partials/seo/blog_post_jsonld.html" with post=post canonical_url=resolved_canonical %}
+  {% include "coresite/partials/seo/blog_post_jsonld.html" with post=post canonical_url=resolved_canonical blog_label=blog_label %}
 {% endblock %}
 
 {% block content %}
@@ -20,7 +20,7 @@
     <div class="wrap">
         <div class="scaffold__body">
           {% include "coresite/partials/global/status_placeholder.html" %}
-          <p class="back-link">← Back to Blog</p>
+          {% include "coresite/partials/global/breadcrumbs.html" with crumbs=breadcrumbs %}
           <h1 id="{{ page_id }}-heading">{{ page_title }}</h1>
           <p class="post-meta">
             <time datetime="{{ post.date|date:'Y-m-d' }}">{{ post.date|date:'d M Y' }}</time> ·

--- a/coresite/templates/coresite/partials/global/breadcrumbs.html
+++ b/coresite/templates/coresite/partials/global/breadcrumbs.html
@@ -1,0 +1,12 @@
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <ol>
+    {% for crumb in crumbs %}
+      {% if forloop.last %}
+        <li aria-current="page">{{ crumb.title }}</li>
+      {% else %}
+        <li><a href="{{ crumb.url }}">{{ crumb.title }}</a></li>
+      {% endif %}
+    {% endfor %}
+  </ol>
+</nav>
+

--- a/coresite/templates/coresite/partials/seo/blog_post_jsonld.html
+++ b/coresite/templates/coresite/partials/seo/blog_post_jsonld.html
@@ -34,8 +34,9 @@
       "@id": "{{ canonical_url }}#breadcrumb",
       "itemListElement": [
         {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://technofatty.com/"},
-        {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://technofatty.com/blog/"},
-        {"@type": "ListItem", "position": 3, "name": "{{ post.title|escapejs }}", "item": "{{ canonical_url }}"}
+        {"@type": "ListItem", "position": 2, "name": "{{ blog_label|escapejs }}", "item": "https://technofatty.com/blog/"},
+        {"@type": "ListItem", "position": 3, "name": "{{ post.category_title|escapejs }}", "item": "https://technofatty.com/blog/category/{{ post.category_slug }}/"},
+        {"@type": "ListItem", "position": 4, "name": "{{ post.title|escapejs }}", "item": "{{ canonical_url }}"}
       ]
     }
   ]

--- a/coresite/tests/test_blog_breadcrumbs.py
+++ b/coresite/tests/test_blog_breadcrumbs.py
@@ -1,0 +1,46 @@
+import json
+import re
+
+import pytest
+from django.utils import timezone
+
+from coresite.context_processors import NAV_LINKS
+from coresite.models import BlogPost, StatusChoices
+
+
+def _extract_jsonld(html: str):
+    match = re.search(r'<script type="application/ld\+json">(.*?)</script>', html, re.DOTALL)
+    assert match, "No JSON-LD script found"
+    return json.loads(match.group(1))
+
+
+@pytest.mark.django_db
+def test_blog_post_breadcrumbs(client):
+    post = BlogPost.objects.create(
+        title="Test Bread",
+        slug="test-bread",
+        status=StatusChoices.PUBLISHED,
+        published_at=timezone.now(),
+        category_slug="test-cat",
+        category_title="Test Cat",
+        meta_title="Test Bread",
+        meta_description="Desc",
+        canonical_url="https://technofatty.com/blog/test-bread/",
+        og_image_url="https://example.com/og.png",
+        twitter_image_url="https://example.com/tw.png",
+    )
+    resp = client.get("/blog/test-bread/")
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    assert '<nav class="breadcrumbs"' in html
+    blog_label = next(l["label"] for l in NAV_LINKS if l["url"] == "blog")
+    assert f">{blog_label}</a>" in html
+    assert "<li aria-current=\"page\">Test Bread</li>" in html
+
+    data = _extract_jsonld(html)
+    breadcrumb = next(item for item in data["@graph"] if item.get("@type") == "BreadcrumbList")
+    items = breadcrumb["itemListElement"]
+    assert items[1]["name"] == blog_label
+    assert items[2]["name"] == "Test Cat"
+    assert items[3]["name"] == "Test Bread"
+


### PR DESCRIPTION
## Summary
- render breadcrumb links for blog posts using site navigation structure
- include breadcrumb schema with category in BlogPosting structured data
- cover post breadcrumbs with a dedicated test

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68b300284a40832a81333c5ffaae3403