### PR TITLE
feat: add blog analytics tracking hooks

### DIFF
--- a/coresite/templates/coresite/blog_detail.html
+++ b/coresite/templates/coresite/blog_detail.html
@@ -33,5 +33,91 @@
         </div>
         {% include "coresite/partials/_related_discussions.html" %}
       </div>
-    </section>
+  </section>
   {% endblock %}
+
+{% block body_scripts %}
+  {{ block.super }}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var slug = '{{ post.slug|escapejs }}';
+      var viewSent = false;
+      function sendView() {
+        if (window.tfSend && !viewSent) {
+          viewSent = true;
+          window.tfSend('blog_post_view', { post: slug });
+        }
+      }
+      sendView();
+      document.addEventListener('tf:consent-updated', sendView);
+
+      var article = document.querySelector('.post-body');
+      if (article) {
+        function isOnSite(pathPrefix, href) {
+          try {
+            var u = new URL(href, window.location.origin);
+            return u.origin === window.location.origin && u.pathname.startsWith(pathPrefix);
+          } catch (e) {
+            return false;
+          }
+        }
+        article.querySelectorAll('a').forEach(function (link) {
+          var href = link.getAttribute('href') || '';
+          if (link.dataset.analyticsEvent) return;
+          if (link.dataset.blogCta !== undefined) {
+            link.dataset.analyticsEvent = 'blog_cta_click';
+            link.dataset.analyticsMeta = JSON.stringify({ post: slug, target: href, utm: location.search.slice(1) });
+          } else if (isOnSite('/tools/', href)) {
+            link.dataset.analyticsEvent = 'blog_click_tool';
+            link.dataset.analyticsMeta = JSON.stringify({ post: slug, target: href });
+          } else if (isOnSite('/knowledge/', href)) {
+            link.dataset.analyticsEvent = 'blog_click_article';
+            link.dataset.analyticsMeta = JSON.stringify({ post: slug, target: href });
+          }
+        });
+      }
+
+      var fired = { start: false, mid: false, end: false };
+      function tick() {
+        if (!article || !window.tfSend) return;
+        var total = article.scrollHeight || article.offsetHeight || 0;
+        if (!total) return;
+        var top = article.getBoundingClientRect().top + window.scrollY;
+        var seen = Math.max(0, (window.scrollY + window.innerHeight - top));
+        var progress = seen / total;
+
+        if (progress > 0 && !fired.start) {
+          fired.start = true;
+          window.tfSend('blog_read_start', { post: slug });
+        }
+        if (progress >= 0.5 && !fired.mid) {
+          fired.mid = true;
+          window.tfSend('blog_read_50', { post: slug });
+        }
+        if (progress >= 0.95 && !fired.end) {
+          fired.end = true;
+          window.tfSend('blog_read_95', { post: slug });
+          off();
+        }
+      }
+      var scheduled = false;
+      function onScroll() {
+        if (!scheduled) {
+          scheduled = true;
+          requestAnimationFrame(function () {
+            scheduled = false;
+            tick();
+          });
+        }
+      }
+      function on() {
+        document.addEventListener('scroll', onScroll, { passive: true });
+      }
+      function off() {
+        document.removeEventListener('scroll', onScroll);
+      }
+      on();
+      tick();
+    });
+  </script>
+{% endblock %}

--- a/coresite/templates/coresite/blog_tag.html
+++ b/coresite/templates/coresite/blog_tag.html
@@ -74,19 +74,25 @@
             {% for item in related_content.knowledge %}
             <div class="related-card">
               <span class="related-label">From Knowledge</span>
-              <a href="{{ item.url }}">{{ item.title }}</a>
+              <a href="{{ item.url }}"
+                 data-analytics-event="blog_related_click"
+                 data-analytics-meta='{"type":"knowledge","target":"{{ item.url|escapejs }}"}'>{{ item.title }}</a>
             </div>
             {% endfor %}
             {% for item in related_content.tools %}
             <div class="related-card">
               <span class="related-label">From Tools</span>
-              <a href="{{ item.url }}">{{ item.title }}</a>
+              <a href="{{ item.url }}"
+                 data-analytics-event="blog_related_click"
+                 data-analytics-meta='{"type":"tool","target":"{{ item.url|escapejs }}"}'>{{ item.title }}</a>
             </div>
             {% endfor %}
             {% for item in related_content.case_studies %}
             <div class="related-card">
               <span class="related-label">From Case Studies</span>
-              <a href="{{ item.url }}">{{ item.title }}</a>
+              <a href="{{ item.url }}"
+                 data-analytics-event="blog_related_click"
+                 data-analytics-meta='{"type":"case_study","target":"{{ item.url|escapejs }}"}'>{{ item.title }}</a>
             </div>
             {% endfor %}
           </div>

--- a/coresite/templates/coresite/partials/_related_discussions.html
+++ b/coresite/templates/coresite/partials/_related_discussions.html
@@ -4,7 +4,9 @@
     <h2 id="related-discussions-heading">Related discussions</h2>
     <ul class="discussion-list">
       {% for thread in related_discussions %}
-      <li><a href="/community/t/{{ thread.slug }}/">{{ thread.title }}</a></li>
+      <li><a href="/community/t/{{ thread.slug }}/"
+             data-analytics-event="blog_related_click"
+             data-analytics-meta='{"type":"discussion","target":"{{ thread.slug|escapejs }}"}'>{{ thread.title }}</a></li>
       {% endfor %}
     </ul>
   </div>

--- a/coresite/tests/test_blog_tracking.py
+++ b/coresite/tests/test_blog_tracking.py
@@ -1,0 +1,61 @@
+import json
+import re
+import shutil
+import subprocess
+import textwrap
+from types import SimpleNamespace
+
+import pytest
+from django.template.loader import render_to_string
+from django.utils import timezone
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_blog_post_view_event():
+    post = SimpleNamespace(
+        title="Test Post",
+        slug="test-post",
+        date=timezone.now(),
+        updated=timezone.now(),
+        category_title="General",
+        category_slug="general",
+        category=SimpleNamespace(slug="general", title="General"),
+        tags=[SimpleNamespace(slug="tag", title="Tag")],
+        meta_title="Test Post",
+        meta_description="Desc",
+        excerpt="Excerpt",
+        canonical_url="/blog/test-post/",
+        og_image_url="https://example.com/og.png",
+        twitter_image_url="https://example.com/tw.png",
+    )
+    html = render_to_string(
+        "coresite/blog_detail.html",
+        {
+            "post": post,
+            "page_id": "post",
+            "page_title": post.title,
+            "breadcrumbs": [],
+            "blog_label": "Blog",
+            "related_discussions": [],
+            "canonical_url": post.canonical_url,
+        },
+    )
+    script = next(
+        m.group(1)
+        for m in re.finditer(r"<script>(.*?)</script>", html, re.S)
+        if "blog_post_view" in m.group(1)
+    )
+    node_script = textwrap.dedent(
+        f"""
+        var calls=[];
+        var window={{tfSend:function(n,m){{calls.push([n,m]);}}}};
+        var document={{events:{{}},addEventListener:function(n,f){{this.events[n]=f;if(n==='DOMContentLoaded')f();}},querySelector:function(){{return null;}}}};
+        var location={{search:''}};
+        {script}
+        console.log(JSON.stringify(calls));
+        """
+    )
+    result = subprocess.run(["node", "-e", node_script], capture_output=True, text=True, check=True)
+    calls = json.loads(result.stdout.strip())
+    assert calls[0][0] == "blog_post_view"
+    assert calls[0][1]["post"] == post.slug


### PR DESCRIPTION
## Summary
- track blog post views and reading progress milestones
- annotate blog content links for CTA, tool, and article tracking
- add analytics metadata to related content links

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68b30e9c29d8832a9a5acf8879b3e3b8