### PR TITLE
Add primary goal to blog posts and track CTA conversions

### DIFF
--- a/coresite/migrations/0014_blogpost_primary_goal.py
+++ b/coresite/migrations/0014_blogpost_primary_goal.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("coresite", "0013_blogpost_meta_fields"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="blogpost",
+            name="primary_goal",
+            field=models.CharField(
+                choices=[("newsletter", "Newsletter sign-up"), ("none", "None")],
+                default="newsletter",
+                max_length=50,
+            ),
+        ),
+    ]

--- a/coresite/models.py
+++ b/coresite/models.py
@@ -23,6 +23,11 @@ class SubtypeChoices(models.TextChoices):
     QUICK_WIN = "quick_win", "Quick Win"
 
 
+class PrimaryGoalChoices(models.TextChoices):
+    NEWSLETTER = "newsletter", "Newsletter sign-up"
+    NONE = "none", "None"
+
+
 class PublishedManager(models.Manager):
     """Manager that returns only published items."""
 
@@ -223,6 +228,11 @@ class BlogPost(TimestampedModel):
     canonical_url = models.URLField(blank=True)
     og_image_url = models.URLField(blank=True)
     twitter_image_url = models.URLField(blank=True)
+    primary_goal = models.CharField(
+        max_length=50,
+        choices=PrimaryGoalChoices.choices,
+        default=PrimaryGoalChoices.NEWSLETTER,
+    )
 
     objects = models.Manager()
     published = PublishedManager()

--- a/coresite/templates/coresite/blog_detail.html
+++ b/coresite/templates/coresite/blog_detail.html
@@ -29,6 +29,9 @@
           </p>
           <nav class="post-outline" aria-label="In this post"></nav>
           <article class="post-body"></article>
+          {% if post.primary_goal == 'newsletter' %}
+            {% include "coresite/partials/newsletter_block.html" with analytics_meta=primary_goal_meta %}
+          {% endif %}
           <p class="post-taxonomy">Filed under <a href="{% url 'blog_category' post.category.slug %}">{{ post.category.title }}</a> · {% for tag in post.tags %}<a href="{% url 'blog_tag' tag.slug %}">#{{ tag.title }}</a>{% if not forloop.last %} {% endif %}{% endfor %}</p>
         </div>
         {% include "coresite/partials/_related_discussions.html" %}

--- a/coresite/templates/coresite/partials/newsletter_block.html
+++ b/coresite/templates/coresite/partials/newsletter_block.html
@@ -12,7 +12,7 @@
     {% if messages %}
       {% for m in messages %}
         {% if forloop.first %}
-          <form id="newsletter_form" method="post" action="{% url 'newsletter_subscribe' %}" class="is-{{ m.tags }}" aria-busy="false" data-analytics-event="form.newsletter.submit" data-analytics-meta='{"form":"newsletter"}'>
+          <form id="newsletter_form" method="post" action="{% url 'newsletter_subscribe' %}" class="is-{{ m.tags }}" aria-busy="false" data-analytics-event="form.newsletter.submit" data-analytics-meta="{{ analytics_meta|default:'{\"form\":\"newsletter\"}'|safe }}">
             {% csrf_token %}
             <fieldset>
               <legend class="visually-hidden">Newsletter</legend>
@@ -28,14 +28,14 @@
                       aria-label="Subscribe to the newsletter"
                       class="btn btn--cta radius-md"
                       data-analytics-event="cta.newsletter.subscribe"
-                      data-analytics-meta='{"form":"newsletter"}'>{{ APPROVED_CTA|default:'Subscribe' }}</button>
+                      data-analytics-meta="{{ analytics_meta|default:'{\"form\":\"newsletter\"}'|safe }}">{{ APPROVED_CTA|default:'Subscribe' }}</button>
               <div id="newsletter-status" role="status" aria-live="polite" aria-atomic="true" class="form-message is-{{ m.tags }}">{{ m }}</div>
             </fieldset>
           </form>
         {% endif %}
       {% endfor %}
     {% else %}
-      <form id="newsletter_form" method="post" action="{% url 'newsletter_subscribe' %}" aria-busy="false" data-analytics-event="form.newsletter.submit" data-analytics-meta='{"form":"newsletter"}'>
+      <form id="newsletter_form" method="post" action="{% url 'newsletter_subscribe' %}" aria-busy="false" data-analytics-event="form.newsletter.submit" data-analytics-meta="{{ analytics_meta|default:'{\"form\":\"newsletter\"}'|safe }}">
         {% csrf_token %}
         <fieldset>
           <legend class="visually-hidden">Newsletter</legend>
@@ -51,7 +51,7 @@
                   aria-label="Subscribe to the newsletter"
                   class="btn btn--cta radius-md"
                   data-analytics-event="cta.newsletter.subscribe"
-                  data-analytics-meta='{"form":"newsletter"}'>{{ APPROVED_CTA|default:'Subscribe' }}</button>
+                  data-analytics-meta="{{ analytics_meta|default:'{\"form\":\"newsletter\"}'|safe }}">{{ APPROVED_CTA|default:'Subscribe' }}</button>
           <div id="newsletter-status" role="status" aria-live="polite" aria-atomic="true" class="form-message"></div>
         </fieldset>
       </form>

--- a/coresite/tests/test_blog_breadcrumbs.py
+++ b/coresite/tests/test_blog_breadcrumbs.py
@@ -5,7 +5,7 @@ import pytest
 from django.utils import timezone
 
 from coresite.context_processors import NAV_LINKS
-from coresite.models import BlogPost, StatusChoices
+from coresite.models import BlogPost, StatusChoices, PrimaryGoalChoices
 
 
 def _extract_jsonld(html: str):
@@ -28,6 +28,7 @@ def test_blog_post_breadcrumbs(client):
         canonical_url="https://technofatty.com/blog/test-bread/",
         og_image_url="https://example.com/og.png",
         twitter_image_url="https://example.com/tw.png",
+        primary_goal=PrimaryGoalChoices.NEWSLETTER,
     )
     resp = client.get("/blog/test-bread/")
     assert resp.status_code == 200

--- a/coresite/tests/test_blog_filters.py
+++ b/coresite/tests/test_blog_filters.py
@@ -2,7 +2,7 @@ import pytest
 from django.urls import reverse
 from django.utils import timezone
 
-from coresite.models import BlogPost, StatusChoices
+from coresite.models import BlogPost, StatusChoices, PrimaryGoalChoices
 
 
 @pytest.mark.django_db
@@ -25,6 +25,7 @@ def test_blog_filters_by_category_tag_time(client, settings):
         meta_description="Desc",
         og_image_url="https://example.com/og.png",
         twitter_image_url="https://example.com/tw.png",
+        primary_goal=PrimaryGoalChoices.NEWSLETTER,
     )
 
     BlogPost.objects.create(
@@ -41,6 +42,7 @@ def test_blog_filters_by_category_tag_time(client, settings):
         meta_description="Desc",
         og_image_url="https://example.com/og.png",
         twitter_image_url="https://example.com/tw.png",
+        primary_goal=PrimaryGoalChoices.NEWSLETTER,
     )
 
     res = client.get(reverse("blog"), {"category": "tech"})

--- a/coresite/tests/test_blog_tag_page.py
+++ b/coresite/tests/test_blog_tag_page.py
@@ -1,7 +1,7 @@
 import pytest
 from django.urls import reverse
 from django.utils import timezone
-from coresite.models import BlogPost, StatusChoices
+from coresite.models import BlogPost, StatusChoices, PrimaryGoalChoices
 
 
 @pytest.mark.django_db
@@ -24,9 +24,10 @@ def test_blog_tag_page_renders_description_cta_and_related(client, settings):
             }
         ],
         meta_title="Tag Post",
-        meta_description="Desc",
-        og_image_url="https://example.com/og.png",
-        twitter_image_url="https://example.com/tw.png",
+       meta_description="Desc",
+       og_image_url="https://example.com/og.png",
+       twitter_image_url="https://example.com/tw.png",
+        primary_goal=PrimaryGoalChoices.NEWSLETTER,
     )
 
     response = client.get(reverse("blog_tag", args=["deployment"]))

--- a/coresite/tests/test_blogpost_model.py
+++ b/coresite/tests/test_blogpost_model.py
@@ -2,21 +2,21 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 
-from coresite.models import BlogPost, StatusChoices
+from coresite.models import BlogPost, StatusChoices, PrimaryGoalChoices
 
 
 @pytest.mark.django_db
 def test_blogpost_slug_autogenerates_and_uniquifies():
-    p1 = BlogPost.objects.create(title="My Post")
-    p2 = BlogPost.objects.create(title="My Post")
+    p1 = BlogPost.objects.create(title="My Post", primary_goal=PrimaryGoalChoices.NEWSLETTER)
+    p2 = BlogPost.objects.create(title="My Post", primary_goal=PrimaryGoalChoices.NEWSLETTER)
     assert p1.slug == "my-post"
     assert p2.slug == "my-post-1"
 
 
 @pytest.mark.django_db
 def test_blogpost_manual_slug_normalised_and_uniquified():
-    p1 = BlogPost.objects.create(title="First", slug="Custom Slug")
-    p2 = BlogPost.objects.create(title="Second", slug="Custom Slug")
+    p1 = BlogPost.objects.create(title="First", slug="Custom Slug", primary_goal=PrimaryGoalChoices.NEWSLETTER)
+    p2 = BlogPost.objects.create(title="Second", slug="Custom Slug", primary_goal=PrimaryGoalChoices.NEWSLETTER)
     assert p1.slug == "custom-slug"
     assert p2.slug == "custom-slug-1"
 
@@ -27,6 +27,7 @@ def test_published_blogpost_requires_meta_fields():
         title="Needs Meta",
         status=StatusChoices.PUBLISHED,
         published_at=timezone.now(),
+        primary_goal=PrimaryGoalChoices.NEWSLETTER,
     )
     with pytest.raises(ValidationError) as excinfo:
         post.full_clean()
@@ -34,3 +35,11 @@ def test_published_blogpost_requires_meta_fields():
     assert "meta_description" in excinfo.value.message_dict
     assert "og_image_url" in excinfo.value.message_dict
     assert "twitter_image_url" in excinfo.value.message_dict
+
+
+@pytest.mark.django_db
+def test_blogpost_requires_primary_goal():
+    post = BlogPost(title="No Goal")
+    post.primary_goal = ""
+    with pytest.raises(ValidationError):
+        post.full_clean()

--- a/coresite/tests/test_feeds.py
+++ b/coresite/tests/test_feeds.py
@@ -7,6 +7,7 @@ from coresite.models import (
     KnowledgeArticle,
     KnowledgeCategory,
     StatusChoices,
+    PrimaryGoalChoices,
 )
 
 
@@ -21,6 +22,7 @@ def test_blog_rss_feed(client):
         meta_description="Desc",
         og_image_url="https://example.com/og.png",
         twitter_image_url="https://example.com/tw.png",
+        primary_goal=PrimaryGoalChoices.NEWSLETTER,
     )
     response = client.get(reverse("blog_rss"))
     assert response.status_code == 200
@@ -39,6 +41,7 @@ def test_blog_atom_feed(client):
         meta_description="Desc",
         og_image_url="https://example.com/og.png",
         twitter_image_url="https://example.com/tw.png",
+        primary_goal=PrimaryGoalChoices.NEWSLETTER,
     )
     response = client.get(reverse("blog_atom"))
     assert response.status_code == 200
@@ -56,6 +59,7 @@ def test_blog_json_feed(client):
         meta_description="Desc",
         og_image_url="https://example.com/og.png",
         twitter_image_url="https://example.com/tw.png",
+        primary_goal=PrimaryGoalChoices.NEWSLETTER,
     )
     response = client.get(reverse("blog_json"))
     assert response.status_code == 200

--- a/coresite/tests/test_related_discussions.py
+++ b/coresite/tests/test_related_discussions.py
@@ -9,6 +9,7 @@ from coresite.models import (
     CaseStudy,
     BlogPost,
     StatusChoices,
+    PrimaryGoalChoices,
 )
 
 
@@ -59,6 +60,9 @@ def test_related_discussions_on_blog_post(client):
         meta_description="Desc",
         og_image_url="https://example.com/og.png",
         twitter_image_url="https://example.com/tw.png",
+        primary_goal=PrimaryGoalChoices.NEWSLETTER,
     )
     res = client.get(reverse("blog_post", args=[post.slug]))
-    assert "Related discussions" in res.content.decode()
+    content = res.content.decode()
+    assert "Related discussions" in content
+    assert "Subscribe for short, useful tech & music tips" in content

--- a/coresite/tests/test_schema_ids.py
+++ b/coresite/tests/test_schema_ids.py
@@ -3,7 +3,7 @@ import re
 import pytest
 from django.utils import timezone
 
-from coresite.models import BlogPost, StatusChoices
+from coresite.models import BlogPost, StatusChoices, PrimaryGoalChoices
 
 
 def _extract_jsonld(html: str):
@@ -22,6 +22,7 @@ def test_blog_post_schema_ids(client, db):
         meta_description="Desc",
         og_image_url="https://example.com/og.png",
         twitter_image_url="https://example.com/tw.png",
+        primary_goal=PrimaryGoalChoices.NEWSLETTER,
     )
     resp = client.get("/blog/test-post/")
     assert resp.status_code == 200

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -17,11 +17,13 @@ from .models import (
     Tool,
     CaseStudy,
     SITEMAP_CACHE_KEY,
+    PrimaryGoalChoices,
 )
 from .forms import ContactForm
 from .notifiers import ContactNotifier
 from datetime import datetime
 import hashlib
+import json
 from .signals import get_signals_content
 from .support import get_support_content
 from .community import get_community_content
@@ -1011,6 +1013,9 @@ def blog_post(request, post_slug: str):
         }
     )
     breadcrumbs.append({"title": post["title"], "url": post.canonical_url})
+    primary_goal_meta = None
+    if post.primary_goal == PrimaryGoalChoices.NEWSLETTER:
+        primary_goal_meta = json.dumps({"form": "newsletter", "post": post.slug})
     context = {
         "footer": footer,
         "page_id": "post",
@@ -1020,6 +1025,7 @@ def blog_post(request, post_slug: str):
         "related_discussions": _related_threads(tags),
         "breadcrumbs": breadcrumbs,
         "blog_label": blog_link["label"] if blog_link else "Blog",
+        "primary_goal_meta": primary_goal_meta,
     }
     return render(request, "coresite/blog_detail.html", context)
 


### PR DESCRIPTION
## Summary
- Require a `primary_goal` on `BlogPost` entries with default `newsletter`
- Render newsletter CTA on posts when goal is newsletter and pass analytics metadata
- Allow newsletter block to accept custom analytics metadata for conversion tracking

## Testing
- `pip install -r requirements.txt` *(failed: Could not connect to proxy)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b312c1e394832ab2ac25160de31fdc