### PR TITLE
Add related content block to posts and backfill script

### DIFF
--- a/coresite/management/commands/backfill_related_content.py
+++ b/coresite/management/commands/backfill_related_content.py
@@ -1,0 +1,17 @@
+from django.core.management.base import BaseCommand
+from coresite.models import BlogPost
+
+PLACEHOLDER = "<!-- related-content -->"
+
+
+class Command(BaseCommand):
+    help = "Append related content placeholder to blog posts missing it"
+
+    def handle(self, *args, **options):
+        updated = 0
+        for post in BlogPost.objects.all():
+            if PLACEHOLDER not in post.content:
+                post.content = (post.content or "") + f"\n\n{PLACEHOLDER}\n"
+                post.save(update_fields=["content"])
+                updated += 1
+        self.stdout.write(self.style.SUCCESS(f"Updated {updated} posts"))

--- a/coresite/templates/coresite/blog_detail.html
+++ b/coresite/templates/coresite/blog_detail.html
@@ -33,6 +33,37 @@
             {% include "coresite/partials/newsletter_block.html" with analytics_meta=primary_goal_meta %}
           {% endif %}
           <p class="post-taxonomy">Filed under <a href="{% url 'blog_category' post.category.slug %}">{{ post.category.title }}</a> · {% for tag in post.tags %}<a href="{% url 'blog_tag' tag.slug %}">#{{ tag.title }}</a>{% if not forloop.last %} {% endif %}{% endfor %}</p>
+          {% if related_content.knowledge or related_content.tools or related_content.case_studies %}
+          <section aria-labelledby="related-heading" class="related-content">
+            <h2 id="related-heading">Related across TF</h2>
+            <div class="related-groups">
+              {% for item in related_content.knowledge %}
+              <div class="related-card">
+                <span class="related-label">From Knowledge</span>
+                <a href="{{ item.url }}"
+                   data-analytics-event="blog_related_click"
+                   data-analytics-meta='{"type":"knowledge","target":"{{ item.url|escapejs }}"}'>{{ item.title }}</a>
+              </div>
+              {% endfor %}
+              {% for item in related_content.tools %}
+              <div class="related-card">
+                <span class="related-label">From Tools</span>
+                <a href="{{ item.url }}"
+                   data-analytics-event="blog_related_click"
+                   data-analytics-meta='{"type":"tool","target":"{{ item.url|escapejs }}"}'>{{ item.title }}</a>
+              </div>
+              {% endfor %}
+              {% for item in related_content.case_studies %}
+              <div class="related-card">
+                <span class="related-label">From Case Studies</span>
+                <a href="{{ item.url }}"
+                   data-analytics-event="blog_related_click"
+                   data-analytics-meta='{"type":"case_study","target":"{{ item.url|escapejs }}"}'>{{ item.title }}</a>
+              </div>
+              {% endfor %}
+            </div>
+          </section>
+          {% endif %}
         </div>
         {% include "coresite/partials/_related_discussions.html" %}
       </div>

--- a/coresite/tests/test_blog_post_related_content.py
+++ b/coresite/tests/test_blog_post_related_content.py
@@ -1,0 +1,53 @@
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from django.core.management import call_command
+
+from coresite.models import BlogPost, StatusChoices, PrimaryGoalChoices
+
+
+@pytest.mark.django_db
+def test_blog_post_renders_related_content(client):
+    post = BlogPost.objects.create(
+        title="Tag Post",
+        slug="tag-post",
+        status=StatusChoices.PUBLISHED,
+        excerpt="excerpt",
+        content="content",
+        published_at=timezone.now(),
+        category_slug="general",
+        category_title="General",
+        tags=[{"slug": "deployment", "title": "Deployment"}],
+        meta_title="Tag Post",
+        meta_description="Desc",
+        og_image_url="https://example.com/og.png",
+        twitter_image_url="https://example.com/tw.png",
+        primary_goal=PrimaryGoalChoices.NEWSLETTER,
+    )
+    res = client.get(reverse("blog_post", args=[post.slug]))
+    content = res.content.decode()
+    assert "Related across TF" in content
+    assert "From Knowledge" in content
+
+
+@pytest.mark.django_db
+def test_backfill_related_content_command():
+    post = BlogPost.objects.create(
+        title="Old Post",
+        slug="old-post",
+        status=StatusChoices.PUBLISHED,
+        excerpt="excerpt",
+        content="hello",
+        published_at=timezone.now(),
+        category_slug="general",
+        category_title="General",
+        tags=[{"slug": "deployment", "title": "Deployment"}],
+        meta_title="Old Post",
+        meta_description="Desc",
+        og_image_url="https://example.com/og.png",
+        twitter_image_url="https://example.com/tw.png",
+        primary_goal=PrimaryGoalChoices.NEWSLETTER,
+    )
+    call_command("backfill_related_content")
+    post.refresh_from_db()
+    assert "<!-- related-content -->" in post.content

--- a/coresite/views.py
+++ b/coresite/views.py
@@ -1016,6 +1016,11 @@ def blog_post(request, post_slug: str):
     primary_goal_meta = None
     if post.primary_goal == PrimaryGoalChoices.NEWSLETTER:
         primary_goal_meta = json.dumps({"form": "newsletter", "post": post.slug})
+
+    related = {}
+    for key, items in RELATED_CONTENT_ITEMS.items():
+        filtered = [i for i in items if set(tags) & set(i["tags"])]
+        related[key] = filtered[:2] if key == "knowledge" else filtered[:1]
     context = {
         "footer": footer,
         "page_id": "post",
@@ -1023,6 +1028,7 @@ def blog_post(request, post_slug: str):
         "post": post,
         "canonical_url": post.canonical_url,
         "related_discussions": _related_threads(tags),
+        "related_content": related,
         "breadcrumbs": breadcrumbs,
         "blog_label": blog_link["label"] if blog_link else "Blog",
         "primary_goal_meta": primary_goal_meta,


### PR DESCRIPTION
## Summary
- show cross-site related content on blog posts
- script to append related content placeholders to existing posts
- tests for new block and backfill command

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b3252b7380832a8a14b964459c0c45