### PR TITLE
docs: log missing links

### DIFF
--- a/docs/content-production-workflow.md
+++ b/docs/content-production-workflow.md
@@ -17,6 +17,7 @@
   - Stakeholder or manager approval
 - **Artifacts & activities**
   - Editorial checklist (grammar, style guide adherence, inclusive language, links)
+  - Record any absent Knowledge or Tool links in a backlog (spreadsheet or issue tracker) for future content creation
   - Track changes/comments or pull requests for revision history
   - Formal approval record (signed-off checklist or workflow ticket)
   - Version bump (v0.2, v0.3) after edits and approvals


### PR DESCRIPTION
## Summary
- note absent Knowledge or Tool links in a backlog for later content creation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b32a5ec638832a92a4940b8f5a9c43